### PR TITLE
Adds the NextJs i18next library

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'es'],
+  },
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,7 @@
+const { i18n } = require('./next-i18next.config')
+
 module.exports = {
+  i18n,
   webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
     config.node = {
       fs: 'empty'

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "husky": "4",
     "jest": "^26.6.3",
     "lint-staged": "^10.5.4",
+    "next-i18next": "^8.1.2",
     "prettier": "^2.2.1",
     "react-test-renderer": "^17.0.1",
     "typescript": "^4.2.3"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       "<rootDir>/node_modules/"
     ],
     "setupFilesAfterEnv": [
-      "<rootDir>/setupTests.js"
+      "<rootDir>/setupTests.tsx"
     ]
   },
   "devDependencies": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,9 +1,10 @@
 import '../styles/globals.css'
 import { AppProps } from 'next/app'
 import { ReactElement } from 'react'
+import { appWithTranslation } from 'next-i18next'
 
 function MyApp({ Component, pageProps }: AppProps): ReactElement {
   return <Component {...pageProps} />
 }
 
-export default MyApp
+export default appWithTranslation(MyApp)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,17 +1,25 @@
 import Head from 'next/head'
 import { ReactElement } from 'react'
 import styles from '../styles/Home.module.css'
+import { useTranslation } from 'next-i18next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useRouter } from 'next/router'
+import Link from 'next/link'
+import { GetServerSideProps } from 'next'
 
 export default function Home(): ReactElement {
+  const { t } = useTranslation('common')
+  const router = useRouter()
+
   return (
     <div className={styles.container}>
       <Head>
-        <title>Placeholder Claim Tracker App</title>
+        <title>{t('title')}</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
       <main className={styles.main}>
-        <h1 className={styles.title}>Welcome to the Placeholder Claim Tracker App!</h1>
+        <h1 className={styles.title}>{t('welcome')}</h1>
 
         <div>
           <iframe
@@ -24,13 +32,23 @@ export default function Home(): ReactElement {
             allowFullScreen
           />
         </div>
+
+        <Link href="/" locale={router.locale === 'en' ? 'es' : 'en'}>
+          <button>{t('change-locale')}</button>
+        </Link>
       </main>
 
       <footer className={styles.footer}>
         <a href="https://www.navapbc.com/" target="_blank" rel="noopener noreferrer">
-          Powered by Nava PBC
+          {t('footer')}
         </a>
       </footer>
     </div>
   )
 }
+
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(locale || 'en', ['common'])),
+  },
+})

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,5 @@
+{
+  "title": "Placeholder Claim Tracker App",
+  "welcome": "Welcome to the Placeholder Claim Tracker App!",
+  "footer": "Powered by Nava PBC"
+}

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1,0 +1,5 @@
+{
+  "title": "Aplicación temporal de Claim Tracker",
+  "welcome": "Bienvenido a la aplicación temporal Claim Tracker!",
+  "footer": "Desarrollado por Nava PBC"
+}

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,1 +1,0 @@
-import '@testing-library/jest-dom/extend-expect'

--- a/setupTests.tsx
+++ b/setupTests.tsx
@@ -1,0 +1,22 @@
+import '@testing-library/jest-dom/extend-expect'
+
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+import enCommon from './public/locales/en/common.json'
+
+/* eslint-disable @typescript-eslint/no-floating-promises */
+// Disabling this rule due to hitting a half hour of debugging,
+// and considering this is a specialized file used only for tests
+
+// Mock react-i18next for tests
+i18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['common'],
+  defaultNS: 'common',
+  resources: {
+    en: { common: enCommon },
+  },
+})
+/* eslint-enable @typescript-eslint/no-floating-promises */

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Exemplar-react-test renderer Snapshot test renders homepage unchanged 1
 <div>
   <main>
     <h1>
-      welcome
+      Welcome to the Placeholder Claim Tracker App!
     </h1>
     <div>
       <iframe
@@ -30,7 +30,7 @@ exports[`Exemplar-react-test renderer Snapshot test renders homepage unchanged 1
       rel="noopener noreferrer"
       target="_blank"
     >
-      footer
+      Powered by Nava PBC
     </a>
   </footer>
 </div>

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Exemplar-react-test renderer Snapshot test renders homepage unchanged 1
 <div>
   <main>
     <h1>
-      Welcome to the Placeholder Claim Tracker App!
+      welcome
     </h1>
     <div>
       <iframe
@@ -17,6 +17,12 @@ exports[`Exemplar-react-test renderer Snapshot test renders homepage unchanged 1
         width="560"
       />
     </div>
+    <button
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+    >
+      change-locale
+    </button>
   </main>
   <footer>
     <a
@@ -24,7 +30,7 @@ exports[`Exemplar-react-test renderer Snapshot test renders homepage unchanged 1
       rel="noopener noreferrer"
       target="_blank"
     >
-      Powered by Nava PBC
+      footer
     </a>
   </footer>
 </div>

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -2,8 +2,20 @@ import renderer from 'react-test-renderer'
 import { render, screen } from '@testing-library/react'
 import Index from '../pages/index'
 
+import { useRouter } from 'next/router'
+
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: jest.fn(),
+}))
+
 describe('Exemplar-react-test renderer Snapshot test', () => {
   it('renders homepage unchanged', () => {
+    const mockRouter = {
+      locale: 'en',
+    }
+    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+
     const tree = renderer.create(<Index />).toJSON()
     expect(tree).toMatchSnapshot()
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,8 +21,7 @@
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx",
-    "setupTests.js"
+    "**/*.tsx"
   ],
   "exclude": [
     "node_modules"

--- a/yarn.lock
+++ b/yarn.lock
@@ -275,7 +275,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.6", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
@@ -718,6 +718,21 @@
   integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
   dependencies:
     "@types/node" "*"
+
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
+"@types/i18next-fs-backend@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/i18next-fs-backend/-/i18next-fs-backend-1.0.0.tgz#3fb0374f4d376375b7cc1d3729bca663d104fa64"
+  integrity sha512-PotQ0NE17NavxXCsdyq9qIKZQOB7+A5O/2nDdvfbfm6/IgvvC1YUO6hxK3nIHASu+QGjO1QV5J8PJw4OL12LMQ==
+  dependencies:
+    i18next "^19.7.0"
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
@@ -1752,6 +1767,11 @@ core-js-pure@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.9.1.tgz#677b322267172bd490e4464696f790cbc355bec5"
   integrity sha512-laz3Zx0avrw9a4QEIdmIblnVuJz8W51leY9iLThatCsFawWxC3sE4guASC78JbCin+DkwMpCdp1AVAuzL/GN7A==
+
+core-js@^3:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.9.1.tgz#cec8de593db8eb2a85ffb0dbdeb312cb6e5460ae"
+  integrity sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2974,6 +2994,13 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hoist-non-react-statics@^3.2.0, hoist-non-react-statics@^3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 hosted-git-info@^2.1.4:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
@@ -2990,6 +3017,13 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+html-parse-stringify2@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify2/-/html-parse-stringify2-2.0.1.tgz#dc5670b7292ca158b7bc916c9a6735ac8872834a"
+  integrity sha1-3FZwtyksoVi3vJFsmmc1rIhyg0o=
+  dependencies:
+    void-elements "^2.0.1"
 
 http-errors@1.7.3:
   version "1.7.3"
@@ -3036,6 +3070,18 @@ husky@4:
     please-upgrade-node "^3.2.0"
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
+
+i18next-fs-backend@^1.0.7:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/i18next-fs-backend/-/i18next-fs-backend-1.1.1.tgz#1d8028926803f63784ffa0f2b1478fb369f92735"
+  integrity sha512-RFkfy10hNxJqc7MVAp5iAZq0Tum6msBCNebEe3OelOBvrROvzHUPaR8Qe10RQrOGokTm0W4vJGEJzruFkEt+hQ==
+
+i18next@^19.7.0, i18next@^19.8.4:
+  version "19.9.2"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.9.2.tgz#ea5a124416e3c5ab85fddca2c8e3c3669a8da397"
+  integrity sha512-0i6cuo6ER6usEOtKajUUDj92zlG+KArFia0857xxiEHAQcUwh/RtOQocui1LPJwunSYT574Pk64aNva1kwtxZg==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
 
 iconv-lite@0.4.24:
   version "0.4.24"
@@ -4280,6 +4326,19 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+next-i18next@^8.1.2:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/next-i18next/-/next-i18next-8.1.2.tgz#394c1864b78d6da4489a16e5086725e756c47a0f"
+  integrity sha512-v2nolBcjh36G0qEvMzgeplYYVQkudYBD1xcsJ04vwAd9zvGlOC0SyQ6dzpxI+OteIOeCJ82RDO+VrVtEKxiVww==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/i18next-fs-backend" "^1.0.0"
+    core-js "^3"
+    hoist-non-react-statics "^3.2.0"
+    i18next "^19.8.4"
+    i18next-fs-backend "^1.0.7"
+    react-i18next "^11.8.8"
+
 next@10.0.8:
   version "10.0.8"
   resolved "https://registry.yarnpkg.com/next/-/next-10.0.8.tgz#a2232c11ffad974d67f3d572b8db2acaa5ddedd7"
@@ -4999,7 +5058,15 @@ react-dom@17.0.1:
     object-assign "^4.1.1"
     scheduler "^0.20.1"
 
-react-is@16.13.1, react-is@^16.8.1:
+react-i18next@^11.8.8:
+  version "11.8.12"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.8.12.tgz#6a9f57277062fb6a6129cad4db5e6198d5c60b58"
+  integrity sha512-M2PSVP9MzT/7yofXfCOF5gAVotinrM4BXWiguk8uFSznJsfFzTjrp3K9CBWcXitpoCBVZGZJ2AnbaWGSNkJqfw==
+  dependencies:
+    "@babel/runtime" "^7.13.6"
+    html-parse-stringify2 "^2.0.1"
+
+react-is@16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -6251,6 +6318,11 @@ vm-browserify@1.1.2, vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+void-elements@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
+  integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!-- Write a description below of the changes in this pull request. 

Include images/GIFs if relevant for reviewers. Try Firefox (click the three dots to the right of the URL bar) for full-page screenshots and LICEcap (macOS) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items. -->
Adds the framework for internationalization & connects it up for testing.

===

Resolves #44 

  - [x] Confirmed i18next-react is a reasonable choice for our project
    - Yes, but specifically we're using the NextJS extension of it
  - [x] Integrated next-i18next into the project base
  - [x] Document choices in our [Technical Foundations doc](https://docs.google.com/document/d/1i2pj7_3n0VjqqztOepkd2VcG7JA8N9Tg5P76GSI8tzw/edit#heading=h.u20evo1icmuu)