### PR TITLE
Unblock timed out Azure builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,14 +37,3 @@ steps:
 
   - task: PublishBuildArtifacts@1
     displayName: "Publish artifacts: drop"
-  
-  - task: Veracode@3
-    inputs:
-      ConnectionDetailsSelection: 'Endpoint'
-      AnalysisService: 'veracode'
-      veracodeAppProfile: '$(system.teamProject)'
-      version: '$(build.buildNumber)'
-      filepath: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
-      createProfile: true
-      failTheBuildIfVeracodeScanDidNotInitiate: true
-      maximumWaitTime: '360'


### PR DESCRIPTION
This reverts commit f7c3cb2a843fde03657ef611eb474a7b52fadc4d.

Azure builds are timing out on this new command - reverting for now as we have time sensitive fixes to get out on Testing for EDD to validate

![image](https://user-images.githubusercontent.com/6129479/118158570-f854f000-b3e9-11eb-89e6-dabfbe25a5cd.png)


fyi @sureshtekyentra 