### PR TITLE
Refactor API Gateway call to remove pem package

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "dotenv": "^9.0.2",
     "next": "10.0.8",
     "node-fetch": "^2.6.1",
-    "pem": "^1.14.4",
     "pino": "^6.11.3",
     "react": "17.0.1",
     "react-bootstrap": "^1.5.2",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -90,7 +90,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale }) =>
     }
 
     // Instantiate agent to use with TLS Certificate.
-    // Reference: https://sebtrif.xyz/blog/2019-10-03-client-side-ssl-in-node-js-with-fetch/
+    // Reference: https://github.com/node-fetch/node-fetch/issues/904#issuecomment-747828286
     const sslConfiguredAgent: https.Agent = new https.Agent(options)
 
     const apiUrlParams: QueryParams = {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 import https from 'https'
-import { promisify } from 'util'
 
 import Head from 'next/head'
 import Container from 'react-bootstrap/Container'
@@ -10,7 +9,6 @@ import { ReactElement } from 'react'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { GetServerSideProps } from 'next'
-import pem, { Pkcs12ReadResult } from 'pem'
 import fetch, { Response } from 'node-fetch'
 
 import { Header } from '../components/Header'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4986,11 +4986,6 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-charenc@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
-
 chokidar@3.5.1, "chokidar@>=2.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.4.2:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
@@ -5552,11 +5547,6 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-crypt@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
-  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 crypto-browserify@3.12.0, crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -6342,11 +6332,6 @@ es5-shim@^4.5.13:
   version "4.5.15"
   resolved "https://registry.yarnpkg.com/es5-shim/-/es5-shim-4.5.15.tgz#6a26869b261854a3b045273f5583c52d390217fe"
   integrity sha512-FYpuxEjMeDvU4rulKqFdukQyZSTpzhg4ScQHrAosrlVpR6GFyaw14f74yn2+4BugniIS0Frpg7TvwZocU4ZMTw==
-
-es6-promisify@^6.0.0:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.1.1.tgz#46837651b7b06bf6fff893d03f29393668d01621"
-  integrity sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg==
 
 es6-shim@^0.35.5:
   version "0.35.6"
@@ -8271,7 +8256,7 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.0"
 
-is-buffer@^1.1.5, is-buffer@~1.1.6:
+is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -9807,15 +9792,6 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
-md5@^2.2.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
-  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
-  dependencies:
-    charenc "0.0.2"
-    crypt "0.0.2"
-    is-buffer "~1.1.6"
-
 mdast-squeeze-paragraphs@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-4.0.0.tgz#7c4c114679c3bee27ef10b58e2e015be79f1ef97"
@@ -10644,7 +10620,7 @@ os-browserify@^0.3.0:
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
 
-os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
+os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -10956,16 +10932,6 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-pem@^1.14.4:
-  version "1.14.4"
-  resolved "https://registry.yarnpkg.com/pem/-/pem-1.14.4.tgz#a68c70c6e751ccc5b3b5bcd7af78b0aec1177ff9"
-  integrity sha512-v8lH3NpirgiEmbOqhx0vwQTxwi0ExsiWBGYh0jYNq7K6mQuO4gI6UEFlr6fLAdv9TPXRt6GqiwE37puQdIDS8g==
-  dependencies:
-    es6-promisify "^6.0.0"
-    md5 "^2.2.1"
-    os-tmpdir "^1.0.1"
-    which "^2.0.2"
 
 pend@~1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Ticket

Resolves #182

## Changes

- Removes `pem` package
- Removes `getCertificate()` function and instead passes the PKCS#12 file directly to `https.Agent`
- Removes explicit setting of `rejectUnauthorized` and `keepAlive` and instead uses default values

## Context

To make the mTLS request to the API Gateway, we create a custom `https.Agent` and pass the agent as an option to [node-fetch](https://github.com/node-fetch/node-fetch) (other [options](https://blog.logrocket.com/5-ways-to-make-http-requests-in-node-js/) would also have been fine). 

Documented `https.Agent` options are in the `https.Agent` [new Agent](https://nodejs.org/api/https.html#https_new_agent_options) and [`http.Agent`](https://nodejs.org/api/http.html#http_class_http_agent) docs. However, it [turns out](https://github.com/node-fetch/node-fetch/issues/904#issuecomment-747828286) that `https.Agent` also accepts options for [`tls.connect()`](https://nodejs.org/api/tls.html#tls_tls_connect_port_host_options_callback), which in turn accepts options for [`tls.createSecureContext()`](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options). 

`tls.createSecureContext()` accepts `pfx` as an option, so this PR removes the `pem` package and passes the pfx file directly to the `https.Agent` instead of [reading it](https://dexus.github.io/pem/jsdoc/module-pem.html#.readPkcs12) into separate cert and key files. This simplifies the code and reduces dependencies.

This PR uses the default value (false) for the `http.Agent` option `keepAlive` because we are only making one connection, so it is unnecessary to keep the connection open.

We use the default value (true) for the `tls.connect()` option `rejectUnauthorized` because we only want to accept TLS certs _from_ the API gateway that have been signed by known and trusted CAs.

We also do not use the `tls.connect()` option `checkServerIdentity` because we want to use the built-in `tls.checkServerIdentity()` for verify the server identity. 

## Testing Instructions

To test this is working as expected:

0. [Set up `.env`](https://github.com/cagov/ui-claim-tracker#environment-variables)
1. Fetch remote branches: `git fetch`
2. Checkout this branch: `git checkout rocket/182-mtls`
3. Update your local packages: `yarn install`
4. Run the app locally: `yarn dev`
5. Navigate to the app in your browser: `localhost:3000/claimstatus`
6. Verify in either the browser console or local terminal window where you ran `yarn dev` that the result of the call to the API gateway is `{ claimData: [ { ClaimType: null } ] }` 
