### PR TITLE
Refactor utility code into a separate utility file

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@testing-library/dom": "^7.30.0",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
+    "@types/jest": "^26.0.23",
     "@types/node": "^14.14.33",
     "@types/pem": "^1.9.5",
     "@types/react": "^17.0.3",
@@ -89,6 +90,7 @@
     "storybook": "^6.2.7",
     "storybook-addon-next-router": "^2.0.4",
     "style-loader": "^2.0.0",
+    "ts-jest": "^27.0.3",
     "typescript": "^4.2.3"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "husky": "4",
     "jest": "^26.6.3",
     "lint-staged": "^10.5.4",
+    "mocked-env": "^1.3.4",
     "next-i18next": "^8.1.2",
     "pino-pretty": "^4.8.0",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@testing-library/dom": "^7.30.0",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
-    "@types/jest": "^26.0.23",
     "@types/node": "^14.14.33",
     "@types/pem": "^1.9.5",
     "@types/react": "^17.0.3",
@@ -90,7 +89,6 @@
     "storybook": "^6.2.7",
     "storybook-addon-next-router": "^2.0.4",
     "style-loader": "^2.0.0",
-    "ts-jest": "^27.0.3",
     "typescript": "^4.2.3"
   },
   "husky": {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,3 @@
-import fs from 'fs'
-import path from 'path'
-import https from 'https'
-
 import Head from 'next/head'
 import Container from 'react-bootstrap/Container'
 import pino from 'pino'
@@ -9,11 +5,11 @@ import { ReactElement } from 'react'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { GetServerSideProps } from 'next'
-import fetch, { Response } from 'node-fetch'
 
 import { Header } from '../components/Header'
 import { Main } from '../components/Main'
 import { Footer } from '../components/Footer'
+import queryApiGateway from '../utils/queryApiGateway'
 
 export interface Claim {
   ClaimType: string | 'not working'
@@ -40,95 +36,13 @@ export default function Home({ claimData }: HomeProps): ReactElement {
   )
 }
 
-export interface QueryParams {
-  user_key: string
-  uniqueNumber: string
-}
-
-function buildApiUrl(url: string, queryParams: QueryParams) {
-  const apiUrl = new URL(url)
-
-  for (const key in queryParams) {
-    apiUrl.searchParams.append(key, queryParams[key as 'user_key' | 'uniqueNumber'])
-  }
-
-  return apiUrl.toString()
-}
-
 export const getServerSideProps: GetServerSideProps = async ({ req, locale }) => {
   const isProd = process.env.NODE_ENV === 'production'
   const logger = isProd ? pino({}) : pino({ prettyPrint: true })
   logger.info(req)
 
-  /*
-   * Load environment variables to be used for authentication & API calls.
-   * @TODO: Handle error case where env vars are null or undefined.
-   */
-  // Request fields
-  const ID_HEADER_NAME: string = process.env.ID_HEADER_NAME ?? ''
-
-  // API fields
-  const API_URL: string = process.env.API_URL ?? ''
-  const API_USER_KEY: string = process.env.API_USER_KEY ?? ''
-
-  // TLS Certificate fields
-  const CERT_DIR: string = process.env.CERTIFICATE_DIR ?? ''
-  const P12_FILE: string = process.env.P12_FILE ?? ''
-  const P12_PATH: string = path.join(CERT_DIR, P12_FILE)
-
-  let apiData: JSON | null = null
-
-  // Makes API call, returns all API data.
-  async function makeRequest() {
-    const headers = {
-      Accept: 'application/json',
-    }
-
-    // https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options
-    const options = {
-      pfx: fs.readFileSync(P12_PATH),
-    }
-
-    // Instantiate agent to use with TLS Certificate.
-    // Reference: https://github.com/node-fetch/node-fetch/issues/904#issuecomment-747828286
-    const sslConfiguredAgent: https.Agent = new https.Agent(options)
-
-    const apiUrlParams: QueryParams = {
-      user_key: API_USER_KEY,
-      uniqueNumber: req.headers[ID_HEADER_NAME] as string,
-    }
-
-    const apiUrl: RequestInfo = buildApiUrl(API_URL, apiUrlParams)
-
-    try {
-      const response: Response = await fetch(apiUrl, {
-        headers: headers,
-        agent: sslConfiguredAgent,
-      })
-
-      // TODO: Why does @ts-ignore not work on this line?
-      // TODO: Implement proper typing of responseBody if possible.
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const responseBody: JSON = await response.json()
-
-      apiData = responseBody
-    } catch (error) {
-      console.log(error)
-    }
-
-    // Although we are using an https.Agent with keepAlive false (default behaviour),
-    // we are explicitly destroying it because:
-    // > It is good practice, to destroy() an Agent instance when it is no longer in use,
-    // > because unused sockets consume OS resources.
-    // https://nodejs.org/api/http.html#http_class_http_agent
-    sslConfiguredAgent.destroy()
-
-    return apiData
-  }
-
-  // Use the above code so getServerSideProps returns props.
   // Step 1: Make the API request and return the data.
-  const data = await makeRequest()
+  const data: Promise<string> = await queryApiGateway(req)
 
   // Step 2: Return Props
   return {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -38,7 +38,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale }) =>
   logger.info(req)
 
   // Step 1: Make the API request and return the data.
-  const data: Promise<string> = await queryApiGateway(req)
+  const data: Claim = await queryApiGateway(req)
 
   // Step 2: Return Props
   return {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,11 +9,7 @@ import { GetServerSideProps } from 'next'
 import { Header } from '../components/Header'
 import { Main } from '../components/Main'
 import { Footer } from '../components/Footer'
-import queryApiGateway from '../utils/queryApiGateway'
-
-export interface Claim {
-  ClaimType: string | 'not working'
-}
+import queryApiGateway, { Claim } from '../utils/queryApiGateway'
 
 export interface HomeProps {
   claimData?: Claim[]

--- a/tests/utils/queryApiGateway.test.tsx
+++ b/tests/utils/queryApiGateway.test.tsx
@@ -1,0 +1,150 @@
+import queryApiGateway, { buildApiUrl, extractJSON, Claim, QueryParams } from '../../utils/queryApiGateway'
+import mockEnv from 'mocked-env'
+import fs from 'fs'
+import fetch from 'node-fetch'
+
+// Mock some modules
+jest.mock('fs')
+jest.mock('node-fetch')
+// const { Response } = jest.requireActual('node-fetch')
+
+// Shared test constants
+const goodUrl = 'http://nowhere.com'
+
+/**
+ * Begin tests
+ */
+
+// Test queryApiGateway
+describe('Querying the API Gateway', () => {
+  const goodResponse = { ClaimType: 'PUA' }
+  const goodRequest = {
+    headers: {
+      id: '12345',
+    },
+  }
+
+  beforeEach(() => {
+    // Mock the fetch response
+    // fetch.mockReturnValue(Promise.resolve(new Response(JSON.stringify(goodResponse))))
+    // Mock fs.readFileSync()
+    fs.readFileSync = jest.fn().mockResolvedValue('mock file data')
+  })
+
+  afterEach(() => {
+    // Clear mocks after each test
+    jest.clearAllMocks()
+  })
+
+  // Test mock fetch is working correctly
+  it('has a correctly mocked fetch', async () => {
+    const resp: Response = await fetch()
+    const body: string = await resp.text()
+    const jsonData: Claim = extractJSON(body)
+    expect(jsonData.ClaimType).toBe('PUA')
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  // Test that queryApiGateway works correctly
+  it('returns the expected value', async () => {
+    // Mock process.env
+    const restore = mockEnv({
+      API_URL: goodUrl,
+    })
+
+    const data = await queryApiGateway(goodRequest)
+    expect(data).toStrictEqual(goodResponse)
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    // Restore env vars
+    restore()
+  })
+
+  // Test that queryApiGateway handles Errors
+  it('handles errors thrown by fetch', async () => {
+    // Mock a network error
+    // fetch.mockRejectedValueOnce(new Error('network error'))
+
+    // Mock process.env
+    const restore = mockEnv({
+      API_URL: goodUrl,
+    })
+
+    const data = await queryApiGateway(goodRequest)
+    expect(data).toStrictEqual(null)
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    // Restore env vars
+    restore()
+  })
+
+  // Test that queryApiGateway handles non-200 responses from API gateway
+  it('handles non-200 responses from API gateway', async () => {
+    // Mock a 403 response error
+    // const errorResponse403: Response = new Response('403 Forbidden', {
+    //   status: 403,
+    // })
+    // fetch.mockReturnValue(Promise.resolve(errorResponse403))
+
+    // Mock process.env
+    const restore = mockEnv({
+      API_URL: goodUrl,
+    })
+
+    const data = await queryApiGateway(goodRequest)
+    expect(data).toStrictEqual(null)
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    // Restore env vars
+    restore()
+  })
+
+  // Test that queryApiGateway handles errors from API gateway
+  it('handles errors returned by API gateway', async () => {
+    // Mock a string response from API gateway
+    // This happens when an incorrect query is sent to API gateway,
+    // such as missing the unqiueNumber query string.
+    // fetch.mockReturnValue(Promise.resolve(new Response('not json')))
+
+    // Mock process.env
+    const restore = mockEnv({
+      API_URL: goodUrl,
+    })
+
+    const data = await queryApiGateway(goodRequest)
+    expect(data).toStrictEqual(null)
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    // Restore env vars
+    restore()
+  })
+})
+
+// Test buildApiUrl
+describe('Building the API url', () => {
+  const goodParams: QueryParams = {
+    user_key: 'key',
+    uniqueNumber: 'num',
+  }
+
+  it('returns the correct url given correct options', () => {
+    const apiUrl: string = buildApiUrl(goodUrl, goodParams)
+    expect(apiUrl).toContain(goodUrl)
+    expect(apiUrl).toContain(`user_key=${goodParams.user_key}`)
+    expect(apiUrl).toContain(`uniqueNumber=${goodParams.uniqueNumber}`)
+  })
+
+  it('with a bad url throws an error', () => {
+    const badUrl = 'badurl'
+    expect(() => {
+      buildApiUrl(badUrl, goodParams)
+    }).toThrowError('Invalid URL')
+  })
+})
+
+/*
+ * @TODO: Test
+ * - env vars missing (each) #176
+ * - pfx missing or not read correctly #176
+ * - request missing expected header #217
+ */

--- a/tests/utils/queryApiGateway.test.tsx
+++ b/tests/utils/queryApiGateway.test.tsx
@@ -6,7 +6,7 @@ import fetch from 'node-fetch'
 // Mock some modules
 jest.mock('fs')
 jest.mock('node-fetch')
-// const { Response } = jest.requireActual('node-fetch')
+const { Response } = jest.requireActual('node-fetch')
 
 // Shared test constants
 const goodUrl = 'http://nowhere.com'
@@ -26,7 +26,7 @@ describe('Querying the API Gateway', () => {
 
   beforeEach(() => {
     // Mock the fetch response
-    // fetch.mockReturnValue(Promise.resolve(new Response(JSON.stringify(goodResponse))))
+    fetch.mockReturnValue(Promise.resolve(new Response(JSON.stringify(goodResponse))))
     // Mock fs.readFileSync()
     fs.readFileSync = jest.fn().mockResolvedValue('mock file data')
   })
@@ -63,7 +63,7 @@ describe('Querying the API Gateway', () => {
   // Test that queryApiGateway handles Errors
   it('handles errors thrown by fetch', async () => {
     // Mock a network error
-    // fetch.mockRejectedValueOnce(new Error('network error'))
+    fetch.mockRejectedValueOnce(new Error('network error'))
 
     // Mock process.env
     const restore = mockEnv({
@@ -81,10 +81,10 @@ describe('Querying the API Gateway', () => {
   // Test that queryApiGateway handles non-200 responses from API gateway
   it('handles non-200 responses from API gateway', async () => {
     // Mock a 403 response error
-    // const errorResponse403: Response = new Response('403 Forbidden', {
-    //   status: 403,
-    // })
-    // fetch.mockReturnValue(Promise.resolve(errorResponse403))
+    const errorResponse403: Response = new Response('403 Forbidden', {
+      status: 403,
+    })
+    fetch.mockReturnValue(Promise.resolve(errorResponse403))
 
     // Mock process.env
     const restore = mockEnv({
@@ -104,7 +104,7 @@ describe('Querying the API Gateway', () => {
     // Mock a string response from API gateway
     // This happens when an incorrect query is sent to API gateway,
     // such as missing the unqiueNumber query string.
-    // fetch.mockReturnValue(Promise.resolve(new Response('not json')))
+    fetch.mockReturnValue(Promise.resolve(new Response('not json')))
 
     // Mock process.env
     const restore = mockEnv({

--- a/tests/utils/queryApiGateway.test.tsx
+++ b/tests/utils/queryApiGateway.test.tsx
@@ -6,7 +6,9 @@ import fetch from 'node-fetch'
 // Mock some modules
 jest.mock('fs')
 jest.mock('node-fetch')
+/* eslint-disable  @typescript-eslint/no-unsafe-assignment */
 const { Response } = jest.requireActual('node-fetch')
+/* eslint-enable  @typescript-eslint/no-unsafe-assignment */
 
 // Shared test constants
 const goodUrl = 'http://nowhere.com'
@@ -26,7 +28,9 @@ describe('Querying the API Gateway', () => {
 
   beforeEach(() => {
     // Mock the fetch response
+    /* eslint-disable  @typescript-eslint/no-unsafe-call */
     fetch.mockReturnValue(Promise.resolve(new Response(JSON.stringify(goodResponse))))
+    /* eslint-enable  @typescript-eslint/no-unsafe-call */
     // Mock fs.readFileSync()
     fs.readFileSync = jest.fn().mockResolvedValue('mock file data')
   })
@@ -63,7 +67,9 @@ describe('Querying the API Gateway', () => {
   // Test that queryApiGateway handles Errors
   it('handles errors thrown by fetch', async () => {
     // Mock a network error
+    /* eslint-disable  @typescript-eslint/no-unsafe-call */
     fetch.mockRejectedValueOnce(new Error('network error'))
+    /* eslint-enable  @typescript-eslint/no-unsafe-call */
 
     // Mock process.env
     const restore = mockEnv({
@@ -81,10 +87,14 @@ describe('Querying the API Gateway', () => {
   // Test that queryApiGateway handles non-200 responses from API gateway
   it('handles non-200 responses from API gateway', async () => {
     // Mock a 403 response error
+    /* eslint-disable  @typescript-eslint/no-unsafe-assignment */
+    /* eslint-disable  @typescript-eslint/no-unsafe-call */
     const errorResponse403: Response = new Response('403 Forbidden', {
       status: 403,
     })
+    /* eslint-enable  @typescript-eslint/no-unsafe-assignment */
     fetch.mockReturnValue(Promise.resolve(errorResponse403))
+    /* eslint-enable  @typescript-eslint/no-unsafe-call */
 
     // Mock process.env
     const restore = mockEnv({
@@ -104,7 +114,9 @@ describe('Querying the API Gateway', () => {
     // Mock a string response from API gateway
     // This happens when an incorrect query is sent to API gateway,
     // such as missing the unqiueNumber query string.
+    /* eslint-disable  @typescript-eslint/no-unsafe-call */
     fetch.mockReturnValue(Promise.resolve(new Response('not json')))
+    /* eslint-enable  @typescript-eslint/no-unsafe-call */
 
     // Mock process.env
     const restore = mockEnv({

--- a/tests/utils/queryApiGateway.test.tsx
+++ b/tests/utils/queryApiGateway.test.tsx
@@ -18,7 +18,7 @@ const emptyResponse = { ClaimType: undefined }
  * Begin tests
  */
 
-// Test queryApiGateway
+// Test queryApiGateway()
 describe('Querying the API Gateway', () => {
   const goodResponse = { ClaimType: 'PUA' }
   const goodRequest = {
@@ -41,7 +41,8 @@ describe('Querying the API Gateway', () => {
     jest.clearAllMocks()
   })
 
-  // Test mock fetch is working correctly
+  // Test mocked fetch is working correctly to eliminate testing issues that might be
+  // originating from the way fetch is mocked.
   it('has a correctly mocked fetch', async () => {
     const resp: Response = await fetch()
     const body: string = await resp.text()
@@ -50,7 +51,6 @@ describe('Querying the API Gateway', () => {
     expect(fetch).toHaveBeenCalledTimes(1)
   })
 
-  // Test that queryApiGateway works correctly
   it('returns the expected value', async () => {
     // Mock process.env
     const restore = mockEnv({
@@ -65,9 +65,7 @@ describe('Querying the API Gateway', () => {
     restore()
   })
 
-  // Test that queryApiGateway handles Errors
   it('handles errors thrown by fetch', async () => {
-    // Mock a network error
     /* eslint-disable  @typescript-eslint/no-unsafe-call */
     fetch.mockRejectedValueOnce(new Error('network error'))
     /* eslint-enable  @typescript-eslint/no-unsafe-call */
@@ -85,9 +83,7 @@ describe('Querying the API Gateway', () => {
     restore()
   })
 
-  // Test that queryApiGateway handles non-200 responses from API gateway
   it('handles non-200 responses from API gateway', async () => {
-    // Mock a 403 response error
     /* eslint-disable  @typescript-eslint/no-unsafe-assignment */
     /* eslint-disable  @typescript-eslint/no-unsafe-call */
     const errorResponse403: Response = new Response('403 Forbidden', {
@@ -110,7 +106,6 @@ describe('Querying the API Gateway', () => {
     restore()
   })
 
-  // Test that queryApiGateway handles errors from API gateway
   it('handles errors returned by API gateway', async () => {
     // Mock a string response from API gateway
     // This happens when an incorrect query is sent to API gateway,
@@ -133,7 +128,7 @@ describe('Querying the API Gateway', () => {
   })
 })
 
-// Test buildApiUrl
+// Test buildApiUrl()
 describe('Building the API url', () => {
   const goodParams: QueryParams = {
     user_key: 'key',

--- a/tests/utils/queryApiGateway.test.tsx
+++ b/tests/utils/queryApiGateway.test.tsx
@@ -12,7 +12,7 @@ const { Response } = jest.requireActual('node-fetch')
 
 // Shared test constants
 const goodUrl = 'http://nowhere.com'
-const emptyResponse = { ClaimType: null }
+const emptyResponse = { ClaimType: undefined }
 
 /**
  * Begin tests

--- a/tests/utils/queryApiGateway.test.tsx
+++ b/tests/utils/queryApiGateway.test.tsx
@@ -12,6 +12,7 @@ const { Response } = jest.requireActual('node-fetch')
 
 // Shared test constants
 const goodUrl = 'http://nowhere.com'
+const emptyResponse = { ClaimType: null }
 
 /**
  * Begin tests
@@ -77,7 +78,7 @@ describe('Querying the API Gateway', () => {
     })
 
     const data = await queryApiGateway(goodRequest)
-    expect(data).toStrictEqual(null)
+    expect(data).toStrictEqual(emptyResponse)
     expect(fetch).toHaveBeenCalledTimes(1)
 
     // Restore env vars
@@ -102,7 +103,7 @@ describe('Querying the API Gateway', () => {
     })
 
     const data = await queryApiGateway(goodRequest)
-    expect(data).toStrictEqual(null)
+    expect(data).toStrictEqual(emptyResponse)
     expect(fetch).toHaveBeenCalledTimes(1)
 
     // Restore env vars
@@ -124,7 +125,7 @@ describe('Querying the API Gateway', () => {
     })
 
     const data = await queryApiGateway(goodRequest)
-    expect(data).toStrictEqual(null)
+    expect(data).toStrictEqual(emptyResponse)
     expect(fetch).toHaveBeenCalledTimes(1)
 
     // Restore env vars

--- a/utils/queryApiGateway.tsx
+++ b/utils/queryApiGateway.tsx
@@ -1,0 +1,101 @@
+import path from 'path'
+import fs from 'fs'
+import https from 'https'
+import fetch, { Response } from 'node-fetch'
+import type { NextApiRequest } from 'next'
+
+export interface QueryParams {
+  user_key: string
+  uniqueNumber: string
+}
+
+/**
+ * Returns results from API Gateway
+ *
+ * @param {Qbject} request
+ * @returns {Object}
+ */
+const queryApiGateway = async (req: NextApiRequest): Promise<string> => {
+  /**
+   * Load environment variables to be used for authentication & API calls.
+   * @TODO: Handle error case where env vars are null or undefined.
+   */
+  // Request fields
+  const ID_HEADER_NAME: string = process.env.ID_HEADER_NAME ?? ''
+
+  // API fields
+  const API_URL: string = process.env.API_URL ?? ''
+  const API_USER_KEY: string = process.env.API_USER_KEY ?? ''
+
+  // TLS Certificate fields
+  const CERT_DIR: string = process.env.CERTIFICATE_DIR ?? ''
+  const P12_FILE: string = process.env.P12_FILE ?? ''
+  const P12_PATH: string = path.join(CERT_DIR, P12_FILE)
+
+  let apiData: JSON | null = null
+
+  const headers = {
+    Accept: 'application/json',
+  }
+
+  // https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options
+  const pfxFile: Buffer = fs.readFileSync(P12_PATH)
+  const options = {
+    pfx: pfxFile,
+  }
+
+  // Instantiate agent to use with TLS Certificate.
+  // Reference: https://github.com/node-fetch/node-fetch/issues/904#issuecomment-747828286
+  const sslConfiguredAgent: https.Agent = new https.Agent(options)
+
+  const apiUrlParams: QueryParams = {
+    user_key: API_USER_KEY,
+    uniqueNumber: req.headers[ID_HEADER_NAME] as string,
+  }
+
+  const apiUrl: RequestInfo = buildApiUrl(API_URL, apiUrlParams)
+
+  try {
+    const response: Response = await fetch(apiUrl, {
+      headers: headers,
+      agent: sslConfiguredAgent,
+    })
+
+    // TODO: Why does @ts-ignore not work on this line?
+    // TODO: Implement proper typing of responseBody if possible.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const responseBody: JSON = await response.json()
+
+    apiData = responseBody
+  } catch (error) {
+    console.log(error)
+  }
+
+  // Although we are using an https.Agent with keepAlive false (default behaviour),
+  // we are explicitly destroying it because:
+  // > It is good practice, to destroy() an Agent instance when it is no longer in use,
+  // > because unused sockets consume OS resources.
+  // https://nodejs.org/api/http.html#http_class_http_agent
+  sslConfiguredAgent.destroy()
+
+  return apiData
+}
+
+/**
+ * Construct the url request to the API gateway.
+ *
+ * @param {string} url - base url for the API gateway
+ * @param {QueryParams} queryParams - query params to append to the API gateway url
+ * @returns {string}
+ */
+function buildApiUrl(url: string, queryParams: QueryParams) {
+  const apiUrl = new URL(url)
+
+  for (const key in queryParams) {
+    apiUrl.searchParams.append(key, queryParams[key as 'user_key' | 'uniqueNumber'])
+  }
+
+  return apiUrl.toString()
+}
+
+export default queryApiGateway

--- a/utils/queryApiGateway.tsx
+++ b/utils/queryApiGateway.tsx
@@ -2,10 +2,10 @@ import path from 'path'
 import fs from 'fs'
 import https from 'https'
 import fetch, { Response } from 'node-fetch'
-import type { NextApiRequest } from 'next'
+import type { IncomingMessage } from 'http'
 
 export interface Claim {
-  ClaimType: string | 'not working'
+  ClaimType: string | null
 }
 
 export interface QueryParams {
@@ -26,9 +26,9 @@ export interface ApiEnvVars {
  * @param {Qbject} request
  * @returns {Promise<string>}
  */
-export default async function queryApiGateway(req: NextApiRequest): Promise<string> {
+export default async function queryApiGateway(req: IncomingMessage): Promise<Claim> {
   const apiEnvVars: ApiEnvVars = getApiVars()
-  let apiData: Claim | null = null
+  let apiData: Claim = { ClaimType: null }
 
   const headers = {
     Accept: 'application/json',
@@ -81,7 +81,7 @@ export default async function queryApiGateway(req: NextApiRequest): Promise<stri
  * @TODO: Handle error case where env vars are null or undefined.
  */
 export function getApiVars(): ApiEnvVars {
-  const apiEnvVars: ApiEnvVars = {}
+  const apiEnvVars: ApiEnvVars = { idHeaderName: '', apiUrl: '', apiUserKey: '', pfxPath: '' }
 
   // Request fields
   apiEnvVars.idHeaderName = process.env.ID_HEADER_NAME ?? ''
@@ -120,6 +120,6 @@ export function buildApiUrl(url: string, queryParams: QueryParams): string {
  * See https://github.com/typescript-eslint/typescript-eslint/issues/2118#issuecomment-641464651
  * @TODO: Validate response. See #150
  */
-export function extractJSON(responseBody: JSON): Claim {
+export function extractJSON(responseBody: string): Claim {
   return JSON.parse(responseBody) as Claim
 }

--- a/utils/queryApiGateway.tsx
+++ b/utils/queryApiGateway.tsx
@@ -5,7 +5,7 @@ import fetch, { Response } from 'node-fetch'
 import type { IncomingMessage } from 'http'
 
 export interface Claim {
-  ClaimType: string | null
+  ClaimType: string | null | undefined
 }
 
 export interface QueryParams {
@@ -28,7 +28,7 @@ export interface ApiEnvVars {
  */
 export default async function queryApiGateway(req: IncomingMessage): Promise<Claim> {
   const apiEnvVars: ApiEnvVars = getApiVars()
-  let apiData: Claim = { ClaimType: null }
+  let apiData: Claim = { ClaimType: undefined }
 
   const headers = {
     Accept: 'application/json',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,6 +1672,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^27.0.2":
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.0.2.tgz#e153d6c46bda0f2589f0702b071f9898c7bbd37e"
+  integrity sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
 "@mdx-js/loader@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/loader/-/loader-1.6.22.tgz#d9e8fe7f8185ff13c9c8639c048b123e30d322c4"
@@ -3187,6 +3198,14 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/jest@^26.0.23":
+  version "26.0.23"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.23.tgz#a1b7eab3c503b80451d019efb588ec63522ee4e7"
+  integrity sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
@@ -3445,6 +3464,13 @@
   version "15.0.13"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.13.tgz#34f7fec8b389d7f3c1fd08026a5763e072d3c6dc"
   integrity sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^16.0.0":
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.3.tgz#4b6d35bb8e680510a7dc2308518a80ee1ef27e01"
+  integrity sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -4714,6 +4740,13 @@ browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.3:
     escalade "^3.1.1"
     node-releases "^1.1.70"
 
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -4726,7 +4759,7 @@ buffer-crc32@~0.2.3:
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
-buffer-from@^1.0.0:
+buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -5085,6 +5118,11 @@ ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+ci-info@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
+  integrity sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -6908,7 +6946,7 @@ fast-json-parse@^1.0.3:
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
   integrity sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -8283,6 +8321,13 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
+is-ci@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.0.tgz#c7e7be3c9d8eef7d0fa144390bd1e4b88dc4c994"
+  integrity sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==
+  dependencies:
+    ci-info "^3.1.1"
+
 is-core-module@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
@@ -9042,6 +9087,18 @@ jest-util@^26.6.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
+jest-util@^27.0.0:
+  version "27.0.2"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.0.2.tgz#fc2c7ace3c75ae561cf1e5fdb643bf685a5be7c7"
+  integrity sha512-1d9uH3a00OFGGWSibpNYr+jojZ6AckOMCXV2Z4K3YXDnzpkAaXQyIpY14FOJPiUmil7CD+A6Qs+lnnh6ctRbIA==
+  dependencies:
+    "@jest/types" "^27.0.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^3.0.0"
+    picomatch "^2.2.3"
+
 jest-validate@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-26.6.2.tgz#23d380971587150467342911c3d7b4ac57ab20ec"
@@ -9257,19 +9314,19 @@ json-stringify-safe@5.0.x, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+json5@2.x, json5@^2.1.2, json5@^2.1.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
-
-json5@^2.1.2, json5@^2.1.3:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
 
 jsonfile@^2.1.0:
   version "2.4.0"
@@ -9629,7 +9686,7 @@ lodash.uniq@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@4.x, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -9740,6 +9797,11 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-error@1.x:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -10092,17 +10154,17 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-mkdirp@^1.0.3, mkdirp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocked-env@^1.3.4:
   version "1.3.4"
@@ -10967,6 +11029,11 @@ picomatch@2.2.2, picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+picomatch@^2.2.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
+  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -12514,17 +12581,17 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
+semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 send@0.17.1:
   version "0.17.1"
@@ -13595,6 +13662,22 @@ ts-essentials@^2.0.3:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
 
+ts-jest@^27.0.3:
+  version "27.0.3"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.0.3.tgz#808492f022296cde19390bb6ad627c8126bf93f8"
+  integrity sha512-U5rdMjnYam9Ucw+h0QvtNDbc5+88nxt7tbIvqaZUhFrfG4+SkWhMXjejCLVGcpILTPuV+H3W/GZDZrnZFpPeXw==
+  dependencies:
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^27.0.0"
+    json5 "2.x"
+    lodash "4.x"
+    make-error "1.x"
+    mkdirp "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
+
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -14501,6 +14584,11 @@ yaml@^1.10.0, yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yargs-parser@20.x, yargs-parser@^20.2.2, yargs-parser@^20.2.3:
+  version "20.2.7"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
+  integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
+
 yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
@@ -14508,11 +14596,6 @@ yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
-
-yargs-parser@^20.2.2, yargs-parser@^20.2.3:
-  version "20.2.7"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
-  integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
 
 yargs@16.2.0:
   version "16.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4986,6 +4986,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+check-more-types@2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
+  integrity sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=
+
 chokidar@3.5.1, "chokidar@>=2.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.4.2:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
@@ -9382,6 +9387,11 @@ latest-version@^5.1.0:
   dependencies:
     package-json "^6.3.0"
 
+lazy-ass@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
+  integrity sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
+
 lazy-universal-dotenv@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lazy-universal-dotenv/-/lazy-universal-dotenv-3.0.1.tgz#a6c8938414bca426ab8c9463940da451a911db38"
@@ -10093,6 +10103,16 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+mocked-env@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/mocked-env/-/mocked-env-1.3.4.tgz#271cc15074a9b1db20330133a03766e41e528489"
+  integrity sha512-VGe9c1exy/pt1T+O++ovGsW7aqlRr4e/iBORc28wjvdeRuD7jJObXE9uvNrShbXYVJ8HQ0bWWmZcDrbwTywiiw==
+  dependencies:
+    check-more-types "2.24.0"
+    debug "4.3.1"
+    lazy-ass "1.6.0"
+    ramda "0.27.1"
 
 moment@^2.18.1:
   version "2.29.1"
@@ -11493,6 +11513,11 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
+ramda@0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
+  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
 
 ramda@^0.21.0:
   version "0.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,17 +1672,6 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jest/types@^27.0.2":
-  version "27.0.2"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.0.2.tgz#e153d6c46bda0f2589f0702b071f9898c7bbd37e"
-  integrity sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^16.0.0"
-    chalk "^4.0.0"
-
 "@mdx-js/loader@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/loader/-/loader-1.6.22.tgz#d9e8fe7f8185ff13c9c8639c048b123e30d322c4"
@@ -3198,14 +3187,6 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/jest@^26.0.23":
-  version "26.0.23"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.23.tgz#a1b7eab3c503b80451d019efb588ec63522ee4e7"
-  integrity sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==
-  dependencies:
-    jest-diff "^26.0.0"
-    pretty-format "^26.0.0"
-
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
@@ -3464,13 +3445,6 @@
   version "15.0.13"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.13.tgz#34f7fec8b389d7f3c1fd08026a5763e072d3c6dc"
   integrity sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
-  dependencies:
-    "@types/yargs-parser" "*"
-
-"@types/yargs@^16.0.0":
-  version "16.0.3"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.3.tgz#4b6d35bb8e680510a7dc2308518a80ee1ef27e01"
-  integrity sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -4740,13 +4714,6 @@ browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.3:
     escalade "^3.1.1"
     node-releases "^1.1.70"
 
-bs-logger@0.x:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
-  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
-  dependencies:
-    fast-json-stable-stringify "2.x"
-
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -4759,7 +4726,7 @@ buffer-crc32@~0.2.3:
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
-buffer-from@1.x, buffer-from@^1.0.0:
+buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -5118,11 +5085,6 @@ ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
-
-ci-info@^3.1.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
-  integrity sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -6946,7 +6908,7 @@ fast-json-parse@^1.0.3:
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
   integrity sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -8321,13 +8283,6 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-ci@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.0.tgz#c7e7be3c9d8eef7d0fa144390bd1e4b88dc4c994"
-  integrity sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==
-  dependencies:
-    ci-info "^3.1.1"
-
 is-core-module@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
@@ -9087,18 +9042,6 @@ jest-util@^26.6.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
-jest-util@^27.0.0:
-  version "27.0.2"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.0.2.tgz#fc2c7ace3c75ae561cf1e5fdb643bf685a5be7c7"
-  integrity sha512-1d9uH3a00OFGGWSibpNYr+jojZ6AckOMCXV2Z4K3YXDnzpkAaXQyIpY14FOJPiUmil7CD+A6Qs+lnnh6ctRbIA==
-  dependencies:
-    "@jest/types" "^27.0.2"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    is-ci "^3.0.0"
-    picomatch "^2.2.3"
-
 jest-validate@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-26.6.2.tgz#23d380971587150467342911c3d7b4ac57ab20ec"
@@ -9314,19 +9257,19 @@ json-stringify-safe@5.0.x, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@2.x, json5@^2.1.2, json5@^2.1.3:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
-
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+json5@^2.1.2, json5@^2.1.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
 
 jsonfile@^2.1.0:
   version "2.4.0"
@@ -9686,7 +9629,7 @@ lodash.uniq@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.x, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -9797,11 +9740,6 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
-
-make-error@1.x:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
-  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -10154,17 +10092,17 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
 mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@^1.0.3, mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocked-env@^1.3.4:
   version "1.3.4"
@@ -11029,11 +10967,6 @@ picomatch@2.2.2, picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
-
-picomatch@^2.2.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
-  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -12581,17 +12514,17 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
+semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
-
-semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 send@0.17.1:
   version "0.17.1"
@@ -13662,22 +13595,6 @@ ts-essentials@^2.0.3:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
 
-ts-jest@^27.0.3:
-  version "27.0.3"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.0.3.tgz#808492f022296cde19390bb6ad627c8126bf93f8"
-  integrity sha512-U5rdMjnYam9Ucw+h0QvtNDbc5+88nxt7tbIvqaZUhFrfG4+SkWhMXjejCLVGcpILTPuV+H3W/GZDZrnZFpPeXw==
-  dependencies:
-    bs-logger "0.x"
-    buffer-from "1.x"
-    fast-json-stable-stringify "2.x"
-    jest-util "^27.0.0"
-    json5 "2.x"
-    lodash "4.x"
-    make-error "1.x"
-    mkdirp "1.x"
-    semver "7.x"
-    yargs-parser "20.x"
-
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -14584,11 +14501,6 @@ yaml@^1.10.0, yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yargs-parser@20.x, yargs-parser@^20.2.2, yargs-parser@^20.2.3:
-  version "20.2.7"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
-  integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
-
 yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
@@ -14596,6 +14508,11 @@ yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.2.2, yargs-parser@^20.2.3:
+  version "20.2.7"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
+  integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
 
 yargs@16.2.0:
   version "16.2.0"


### PR DESCRIPTION
## Ticket 

Resolves #221

## Changes

- Adds testing package [mocked-env](https://github.com/bahmutov/mocked-env) to mock environment variables in tests
- Refactors API gateway functions into a separate utility module
- Adds tests for API gateway functions
- Adds conditional to check if API gateway call returns a non-200 response
- Changes the default response of the API gateway call from `null` to `{ ClaimType: undefined }`
  - Allows us to use the `Claim` type and to distinguish between a `{ ClaimType: null }` response from the test API gateway endpoints

## Context

#221 (the ticket this PR resolves) came out of a [comment](https://github.com/cagov/ui-claim-tracker/pull/219#discussion_r647394618) in #219. This PR refactors API gateway functions into a separate utility file and adds tests for API gateway functions.

Note: I ran into linting issues for the jest test mocks. Due to time limitations, we've temporarily used `eslint-disable` for the lines that were failing `yarn lint` in order to move on to higher priority work. I've opened #238, which captures the work of making `queryApiGateway.test.tsx` no longer reliant on `eslint-disable`.

## Testing Instructions

`yarn test`