### PR TITLE
Relocates Header & Footer strings into Common

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -7,8 +7,6 @@ import { initReactI18next } from 'react-i18next'
 import i18n from './i18n';
 
 import enCommon from '../public/locales/en/common.json'
-import enHeader from '../public/locales/en/header.json'
-import enFooter from '../public/locales/en/footer.json'
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -32,10 +30,10 @@ export const decorators = [
 
       lng: 'en',
       fallbackLng: 'en',
-      ns: ['common', 'header'],
+      ns: ['common'],
       defaultNS: 'common',
       resources: {
-        en: { common: enCommon, header: enHeader, footer: enFooter },
+        en: { common: enCommon },
       },
     })
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -4,36 +4,36 @@ import Navbar from 'react-bootstrap/Navbar'
 import { useTranslation } from 'next-i18next'
 
 export const Footer: React.FC = () => {
-  const { t } = useTranslation('footer')
+  const { t } = useTranslation('common')
 
   return (
     <footer className="footer">
       <Container>
         <Navbar className="justify-content-between" variant="dark">
           <Nav className="flex-column flex-sm-row">
-            <Nav.Link href="#top">{t('toTop')}</Nav.Link>
+            <Nav.Link href="#top">{t('footer.toTop')}</Nav.Link>
             <Nav.Link target="_blank" rel="noopener noreferrer" href="https://edd.ca.gov/about_edd/contact_edd.htm">
-              {t('contact')}
+              {t('footer.contact')}
             </Nav.Link>
             <Nav.Link
               target="_blank"
               rel="noopener noreferrer"
               href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
             >
-              {t('conditionsOfUse')}
+              {t('footer.conditionsOfUse')}
             </Nav.Link>
             <Nav.Link target="_blank" rel="noopener noreferrer" href="https://edd.ca.gov/about_edd/privacy_policy.htm">
-              {t('privacyPolicy')}
+              {t('footer.privacyPolicy')}
             </Nav.Link>
             <Nav.Link target="_blank" rel="noopener noreferrer" href="https://edd.ca.gov/about_edd/accessibility.htm">
-              {t('accessibility')}
+              {t('footer.accessibility')}
             </Nav.Link>
           </Nav>
         </Navbar>
       </Container>
       <div className="secondary-footer">
         <Container>
-          <div className="copyright">{t('copyright')}</div>
+          <div className="copyright">{t('footer.copyright')}</div>
         </Container>
       </div>
     </footer>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,27 +3,32 @@ import Navbar from 'react-bootstrap/Navbar'
 import { useTranslation } from 'next-i18next'
 
 export const Header: React.FC = () => {
-  const { t } = useTranslation('header')
+  const { t } = useTranslation('common')
 
   return (
     <header className="header border-bottom border-secondary">
       <Navbar collapseOnSelect className="justify-content-between" expand="lg" fixed-top="true" variant="dark">
         <Navbar.Brand target="_blank" rel="noopener noreferrer" href="https://ca.gov">
-          <img src="/claimstatus/images/Ca-Gov-Logo-Gold.svg" alt={t('alt-image-cagov')} width="46" height="34" />
+          <img
+            src="/claimstatus/images/Ca-Gov-Logo-Gold.svg"
+            alt={t('header.alt-image-cagov')}
+            width="46"
+            height="34"
+          />
         </Navbar.Brand>
         <Nav>
           <Navbar.Collapse>
             <Nav.Link target="_blank" rel="noopener noreferrer" href="https://edd.ca.gov">
-              <span className="text">{t('edd-home')}</span>
+              <span className="text">{t('header.edd-home')}</span>
             </Nav.Link>
           </Navbar.Collapse>
           {/*  TODO what is the URL here? */}
           <Nav.Link target="_blank" rel="noopener noreferrer" href="https://askedd.edd.ca.gov/">
-            <span className="text">{t('help')}</span>
+            <span className="text">{t('header.help')}</span>
           </Nav.Link>
           {/*  TODO what is the URL here? */}
           <Nav.Link target="_blank" rel="noopener noreferrer" href="https://edd.ca.gov/login.htm">
-            <span className="text">{t('logout')}</span>
+            <span className="text">{t('header.logout')}</span>
           </Nav.Link>
         </Nav>
       </Navbar>
@@ -31,7 +36,7 @@ export const Header: React.FC = () => {
         <Navbar.Brand target="_blank" rel="noopener noreferrer" href="https://edd.ca.gov">
           <img
             src="/claimstatus/images/edd-logo-2-Color.svg"
-            alt={t('alt-image-edd')}
+            alt={t('header.alt-image-edd')}
             height="60"
             width="171"
             className="d-inline-block align-top mr-5"
@@ -41,7 +46,7 @@ export const Header: React.FC = () => {
         <Navbar.Collapse>
           <Nav>
             <Nav.Link target="_blank" rel="noopener noreferrer" href="https://uio.edd.ca.gov">
-              <span className="text">{t('uio-home')}</span>
+              <span className="text">{t('header.uio-home')}</span>
             </Nav.Link>
           </Nav>
         </Navbar.Collapse>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,4 +1,13 @@
 {
+  "header": {
+    "alt-image-cagov": "CA.gov",
+    "alt-image-edd": "EDD Employment Development Department State of California Home",
+    "edd-home": "EDD Home",
+    "help": "Help",
+    "welcome": "Welcome, name",
+    "logout": "Log out",
+    "uio-home": "UI Online Home"
+  },
   "title": "Claim Tracker",
   "welcome": "Claim Tracker",
   "change-locale": "En español",
@@ -23,6 +32,14 @@
   "feedback": {
     "title": "Help us improve this page",
     "message": "This is a new part of UI Online. <1>Your Feedback</1> will help us improve it."
+  },
+  "footer": {
+    "toTop": "Back to Top",
+    "contact": "Contact EDD",
+    "conditionsOfUse": "Conditions of Use",
+    "privacyPolicy": "Privacy Policy",
+    "accessibility": "Accessibility",
+    "copyright": "Copyright © 2021 State of California"
   },
   "timeout-modal": {
     "header": "Your Session Will End Soon",

--- a/public/locales/en/footer.json
+++ b/public/locales/en/footer.json
@@ -1,8 +1,0 @@
-{
-  "toTop": "Back to Top",
-  "contact": "Contact EDD",
-  "conditionsOfUse": "Conditions of Use",
-  "privacyPolicy": "Privacy Policy",
-  "accessibility": "Accessibility",
-  "copyright": "Copyright © 2021 State of California"
-}

--- a/public/locales/en/header.json
+++ b/public/locales/en/header.json
@@ -1,9 +1,0 @@
-{
-  "alt-image-cagov": "CA.gov",
-  "alt-image-edd": "EDD Employment Development Department State of California Home",
-  "edd-home": "EDD Home",
-  "help": "Help",
-  "welcome": "Welcome, name",
-  "logout": "Log out",
-  "uio-home": "UI Online Home"
-}

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1,4 +1,13 @@
 {
+  "header": {
+    "alt-image-cagov": "CA.gov",
+    "alt-image-edd": "Página principal del Departamento de Desarrollo de Empleo del EDD",
+    "edd-home": "EDD Casa",
+    "help": "Ayuda",
+    "welcome": "Bienvenidas, nombre",
+    "logout": "Cerrar sesión",
+    "uio-home": "UI Online Casa"
+  },
   "title": "Claim Tracker",
   "welcome": "Claim Tracker",
   "change-locale": "In English",
@@ -23,6 +32,14 @@
   "feedback": {
     "title": "Ayúdanos a mejorar esta página",
     "message": "Esta es una parte nueva de UI Online. <1>Tus comentarios</1> nos ayudarán a mejorarlo."
+  },
+  "footer": {
+    "toTop": "Volver Arriba",
+    "contact": "Contacta con EDD",
+    "conditionsOfUse": "Condiciones de Uso",
+    "privacyPolicy": "Política de Privacidad",
+    "accessibility": "Accesibilidad",
+    "copyright": "Copyright © 2021 Estado de California"
   },
   "timeout-modal": {
     "header": "Tu sesión terminará pronto",

--- a/public/locales/es/footer.json
+++ b/public/locales/es/footer.json
@@ -1,8 +1,0 @@
-{
-  "toTop": "Volver Arriba",
-  "contact": "Contacta con EDD",
-  "conditionsOfUse": "Condiciones de Uso",
-  "privacyPolicy": "Política de Privacidad",
-  "accessibility": "Accesibilidad",
-  "copyright": "Copyright © 2021 Estado de California"
-}

--- a/public/locales/es/header.json
+++ b/public/locales/es/header.json
@@ -1,9 +1,0 @@
-{
-  "alt-image-cagov": "CA.gov",
-  "alt-image-edd": "Página principal del Departamento de Desarrollo de Empleo del EDD",
-  "edd-home": "EDD Casa",
-  "help": "Ayuda",
-  "welcome": "Bienvenidas, nombre",
-  "logout": "Cerrar sesión",
-  "uio-home": "UI Online Casa"
-}

--- a/setupTests.tsx
+++ b/setupTests.tsx
@@ -4,8 +4,6 @@ import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
 import enCommon from './public/locales/en/common.json'
-import enHeader from './public/locales/en/header.json'
-import enFooter from './public/locales/en/footer.json'
 
 /* eslint-disable @typescript-eslint/no-floating-promises */
 // Disabling this rule due to hitting a half hour of debugging,
@@ -15,10 +13,10 @@ import enFooter from './public/locales/en/footer.json'
 i18n.use(initReactI18next).init({
   lng: 'en',
   fallbackLng: 'en',
-  ns: ['common', 'header'],
+  ns: ['common'],
   defaultNS: 'common',
   resources: {
-    en: { common: enCommon, header: enHeader, footer: enFooter },
+    en: { common: enCommon },
   },
 })
 /* eslint-enable @typescript-eslint/no-floating-promises */


### PR DESCRIPTION
<!-- Write a description below of the changes in this pull request. 

Include images/GIFs if relevant for reviewers. Try Firefox (right-click -> Take Screenshot) for full-page screenshots and LICEcap (macOS) or Peek (ubuntu) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items. -->

Finally found a good reason to pull in header & footer to common - shared semantic links. 

cc: @nicoleslaw 

===

Connects to #235 

- [ ] Changes are tested on Staging post-merge into `main`
