### PR TITLE
Add source sans pro to storybook

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<link href="https://fonts.googleapis.com/css?family=Source Sans Pro" rel="stylesheet" />


### PR DESCRIPTION
## Changes

- Adds `.storybook/preview-head.html`

## Context

We added Source Sans Pro in #233, but it turns out that Storybook doesn't know about the nextjs `<Head>` component. To fix the fonts in Storybook, we need to also [add the font to `<head>`](https://storybook.js.org/docs/ember/configure/story-rendering#adding-to-head) in Storybook.

## Testing Instructions

1. Pull this branch
2. Run `yarn storybook`
3. Verify that Source Sans Pro is being loaded in the Console > Network tab
4. Verify that the text in the iframe is rendered as Source Sans Pro