### PR TITLE
(1/?) Implement scenario logic

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,14 +2,15 @@
  * Preview.js is loaded in the Canvas tab, the “preview” iframe that renders your components in isolation. Use preview.js
  * for global code (such as CSS imports or JavaScript mocks) that applies to all stories.
  */
-import '../styles/globals.scss';
+import '../styles/globals.scss'
 import { initReactI18next } from 'react-i18next'
-import i18n from './i18n';
+import i18n from './i18n'
 
 import enCommon from '../public/locales/en/common.json'
+import enClaimStatus from '../public/locales/en/claim-status.json'
 
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
+  actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
     matchers: {
       color: /(background|color)$/i,
@@ -19,21 +20,37 @@ export const parameters = {
   options: {
     storySort: {
       method: 'alphabetical',
-      order: ['Claim Tracker', 'Component', ['Page Section', ['Work In Progress', 'Header', 'Main', 'Claim Section', 'Claim Status', 'Next Steps', 'Claim Details', 'Footer']], 'Atoms'],
-    }
-  }
+      order: [
+        'Claim Tracker',
+        'Component',
+        [
+          'Page Section',
+          [
+            'Work In Progress',
+            'Header',
+            'Main',
+            'Claim Section',
+            'Claim Status',
+            'Next Steps',
+            'Claim Details',
+            'Footer',
+          ],
+        ],
+        'Atoms',
+      ],
+    },
+  },
 }
 
 export const decorators = [
   (Story, Context) => {
     i18n.use(initReactI18next).init({
-
       lng: 'en',
       fallbackLng: 'en',
-      ns: ['common'],
+      ns: ['common', 'claim-status'],
       defaultNS: 'common',
       resources: {
-        en: { common: enCommon },
+        en: { common: enCommon, 'claim-status': enClaimStatus },
       },
     })
 

--- a/components/ClaimDetails.tsx
+++ b/components/ClaimDetails.tsx
@@ -1,16 +1,10 @@
 import { useTranslation } from 'next-i18next'
 import { InfoField } from './InfoField'
+import { ClaimDetailsContent } from '../types/common'
 
-export interface ClaimDetailsProps {
+export interface ClaimDetailsProps extends ClaimDetailsContent {
   loading: boolean
   title: string
-  programType: string
-  benefitYear: string
-  claimBalance: string
-  weeklyBenefitAmount: string
-  lastPaymentIssued: string
-  extentionType: string
-  extensionEndDate: string
 }
 
 export const ClaimDetails: React.FC<ClaimDetailsProps> = ({

--- a/components/ClaimDetails.tsx
+++ b/components/ClaimDetails.tsx
@@ -8,13 +8,13 @@ export interface ClaimDetailsProps extends ClaimDetailsContent {
 
 export const ClaimDetails: React.FC<ClaimDetailsProps> = ({
   loading = false,
-  programType = 'Unemployment Insurance (UI)',
-  benefitYear = '3/21/2020 - 3/20/2021',
-  claimBalance = '$508.00',
-  weeklyBenefitAmount = '$120.00',
-  lastPaymentIssued = '4/29/2021',
-  extentionType = 'Tier 2 Extension',
-  extensionEndDate = '5/22/2021',
+  programType,
+  benefitYear,
+  claimBalance,
+  weeklyBenefitAmount,
+  lastPaymentIssued,
+  extensionType,
+  extensionEndDate,
 }) => {
   const { t } = useTranslation('common')
 

--- a/components/ClaimDetails.tsx
+++ b/components/ClaimDetails.tsx
@@ -37,7 +37,7 @@ export const ClaimDetails: React.FC<ClaimDetailsProps> = ({
           </div>
           <div className="col-6">
             <div />
-            <InfoField loading={loading} label={t('claim-details.extension-type')} text={extentionType} />
+            <InfoField loading={loading} label={t('claim-details.extension-type')} text={extensionType} />
 
             <InfoField loading={loading} label={t('claim-details.extension-end-date')} text={extensionEndDate} />
           </div>

--- a/components/ClaimDetails.tsx
+++ b/components/ClaimDetails.tsx
@@ -14,7 +14,6 @@ export const ClaimDetails: React.FC<ClaimDetailsProps> = ({
   weeklyBenefitAmount,
   lastPaymentIssued,
   extensionType,
-  extensionEndDate,
 }) => {
   const { t } = useTranslation('common')
 
@@ -38,8 +37,6 @@ export const ClaimDetails: React.FC<ClaimDetailsProps> = ({
           <div className="col-6">
             <div />
             <InfoField loading={loading} label={t('claim-details.extension-type')} text={extensionType} />
-
-            <InfoField loading={loading} label={t('claim-details.extension-end-date')} text={extensionEndDate} />
           </div>
         </div>
       </div>

--- a/components/ClaimDetails.tsx
+++ b/components/ClaimDetails.tsx
@@ -4,12 +4,10 @@ import { ClaimDetailsContent } from '../types/common'
 
 export interface ClaimDetailsProps extends ClaimDetailsContent {
   loading: boolean
-  title: string
 }
 
 export const ClaimDetails: React.FC<ClaimDetailsProps> = ({
   loading = false,
-  title = 'Claim Details',
   programType = 'Unemployment Insurance (UI)',
   benefitYear = '3/21/2020 - 3/20/2021',
   claimBalance = '$508.00',
@@ -22,7 +20,7 @@ export const ClaimDetails: React.FC<ClaimDetailsProps> = ({
 
   return (
     <div className="claim-details container">
-      <h2>{title}</h2>
+      <h2>{t('claim-details.title')}</h2>
 
       <div className="claim-details-box">
         <div className="row">

--- a/components/ClaimSection.tsx
+++ b/components/ClaimSection.tsx
@@ -18,7 +18,6 @@ export const ClaimSection: React.FC<ClaimSectionProps> = ({ loading = false }) =
       />
       <ClaimDetails
         loading={loading}
-        title="Claim Details"
         programType="Unemployment Insurance (UI)"
         benefitYear="3/21/2020 - 3/20/2021"
         claimBalance="$0.00"

--- a/components/ClaimSection.tsx
+++ b/components/ClaimSection.tsx
@@ -1,5 +1,6 @@
 import { ClaimDetails } from './ClaimDetails'
 import { ClaimStatus } from './ClaimStatus'
+import { ScenarioType } from '../utils/getScenario'
 
 export interface ClaimSectionProps {
   loading: boolean
@@ -10,6 +11,7 @@ export const ClaimSection: React.FC<ClaimSectionProps> = ({ loading = false }) =
     <div className="claim-section">
       <ClaimStatus
         loading={loading}
+        scenarioType={ScenarioType.GenericPending}
         nextSteps={[
           'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
           'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',

--- a/components/ClaimSection.tsx
+++ b/components/ClaimSection.tsx
@@ -22,7 +22,6 @@ export const ClaimSection: React.FC<ClaimSectionProps> = ({ loading = false, sta
         weeklyBenefitAmount={detailsContent.weeklyBenefitAmount}
         lastPaymentIssued={detailsContent.lastPaymentIssued}
         extensionType={detailsContent.extensionType}
-        extensionEndDate={detailsContent.extensionEndDate}
       />
     </div>
   )

--- a/components/ClaimSection.tsx
+++ b/components/ClaimSection.tsx
@@ -10,7 +10,7 @@ export const ClaimSection: React.FC<ClaimSectionProps> = ({ loading = false }) =
     <div className="claim-section">
       <ClaimStatus
         loading={loading}
-        statusDescriptionKey="claim-status.generic-pending"
+        statusDescription="claim-status.generic-pending"
         nextSteps={[
           'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
           'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',

--- a/components/ClaimSection.tsx
+++ b/components/ClaimSection.tsx
@@ -6,7 +6,7 @@ export interface ClaimSectionProps extends ScenarioContent {
   loading: boolean
 }
 
-export const ClaimSection: React.FC<ClaimSectionProps> = ({ statusContent, detailsContent, loading = false }) => {
+export const ClaimSection: React.FC<ClaimSectionProps> = ({ loading = false, statusContent, detailsContent }) => {
   return (
     <div className="claim-section">
       <ClaimStatus

--- a/components/ClaimSection.tsx
+++ b/components/ClaimSection.tsx
@@ -1,30 +1,28 @@
 import { ClaimDetails } from './ClaimDetails'
 import { ClaimStatus } from './ClaimStatus'
+import { ScenarioContent } from '../types/common'
 
-export interface ClaimSectionProps {
+export interface ClaimSectionProps extends ScenarioContent {
   loading: boolean
 }
 
-export const ClaimSection: React.FC<ClaimSectionProps> = ({ loading = false }) => {
+export const ClaimSection: React.FC<ClaimSectionProps> = ({ statusContent, detailsContent, loading = false }) => {
   return (
     <div className="claim-section">
       <ClaimStatus
         loading={loading}
-        statusDescription="claim-status.generic-pending"
-        nextSteps={[
-          'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
-          'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-        ]}
+        statusDescription={statusContent.statusDescription}
+        nextSteps={statusContent.nextSteps}
       />
       <ClaimDetails
         loading={loading}
-        programType="Unemployment Insurance (UI)"
-        benefitYear="3/21/2020 - 3/20/2021"
-        claimBalance="$0.00"
-        weeklyBenefitAmount="$111.00"
-        lastPaymentIssued="4/29/2021"
-        extentionType="Tier 2 Extension"
-        extensionEndDate="5/22/2021"
+        programType={detailsContent.programType}
+        benefitYear={detailsContent.benefitYear}
+        claimBalance={detailsContent.claimBalance}
+        weeklyBenefitAmount={detailsContent.weeklyBenefitAmount}
+        lastPaymentIssued={detailsContent.lastPaymentIssued}
+        extensionType={detailsContent.extensionType}
+        extensionEndDate={detailsContent.extensionEndDate}
       />
     </div>
   )

--- a/components/ClaimSection.tsx
+++ b/components/ClaimSection.tsx
@@ -1,6 +1,5 @@
 import { ClaimDetails } from './ClaimDetails'
 import { ClaimStatus } from './ClaimStatus'
-import { ScenarioType } from '../utils/getScenario'
 
 export interface ClaimSectionProps {
   loading: boolean
@@ -11,7 +10,7 @@ export const ClaimSection: React.FC<ClaimSectionProps> = ({ loading = false }) =
     <div className="claim-section">
       <ClaimStatus
         loading={loading}
-        scenarioType={ScenarioType.GenericPending}
+        statusDescriptionKey="claim-status.generic-pending"
         nextSteps={[
           'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
           'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',

--- a/components/ClaimStatus.tsx
+++ b/components/ClaimStatus.tsx
@@ -8,11 +8,7 @@ export interface ClaimStatusProps extends ClaimStatusContent {
   loading: boolean
 }
 
-export const ClaimStatus: React.FC<ClaimStatusProps> = ({
-  loading,
-  statusDescription = 'claim-status.generic-pending',
-  nextSteps = ['step one', 'step two'],
-}) => {
+export const ClaimStatus: React.FC<ClaimStatusProps> = ({ loading = false, statusDescription, nextSteps }) => {
   const { t } = useTranslation('common')
 
   return (

--- a/components/ClaimStatus.tsx
+++ b/components/ClaimStatus.tsx
@@ -2,35 +2,25 @@ import { useTranslation } from 'next-i18next'
 
 import { NextSteps } from './NextSteps'
 import { TextLine } from './TextLine'
-import { ScenarioType } from '../utils/getScenario'
 
 export interface ClaimStatusProps {
   loading: boolean
-  scenarioType: ScenarioType
+  statusDescriptionKey: string
   nextSteps?: string[]
 }
 
 export const ClaimStatus: React.FC<ClaimStatusProps> = ({
   loading,
-  scenarioType = ScenarioType.PendingDetermination,
+  statusDescriptionKey = 'claim-status.generic-pending',
   nextSteps = ['step one', 'step two'],
 }) => {
   const { t } = useTranslation('common')
-
-  let status = ''
-  if (scenarioType === ScenarioType.PendingDetermination) {
-    status = t('claim-status.pending-determination')
-  } else if (scenarioType === ScenarioType.GenericPending) {
-    status = t('claim-status.generic-pending')
-  } else {
-    status = t('claim-status.generic-all-clear')
-  }
 
   return (
     <div className="claim-status">
       <h2>{t('claim-status.title')}</h2>
       <div className="pending-status">
-        <TextLine loading={loading} text={status} />
+        <TextLine loading={loading} text={t(statusDescriptionKey)} />
       </div>
       <div className="status-box">
         <div className="topbar">

--- a/components/ClaimStatus.tsx
+++ b/components/ClaimStatus.tsx
@@ -9,7 +9,7 @@ export interface ClaimStatusProps extends ClaimStatusContent {
 }
 
 export const ClaimStatus: React.FC<ClaimStatusProps> = ({ loading = false, statusDescription, nextSteps }) => {
-  const { t } = useTranslation('common')
+  const { t } = useTranslation(['common', 'claim-status'])
 
   return (
     <div className="claim-status">

--- a/components/ClaimStatus.tsx
+++ b/components/ClaimStatus.tsx
@@ -2,20 +2,35 @@ import { useTranslation } from 'next-i18next'
 
 import { NextSteps } from './NextSteps'
 import { TextLine } from './TextLine'
+import { ScenarioType } from '../utils/getScenario'
 
 export interface ClaimStatusProps {
   loading: boolean
+  scenarioType: ScenarioType
   nextSteps?: string[]
 }
 
-export const ClaimStatus: React.FC<ClaimStatusProps> = ({ loading, nextSteps = ['step one', 'step two'] }) => {
+export const ClaimStatus: React.FC<ClaimStatusProps> = ({
+  loading,
+  scenarioType = ScenarioType.PendingDetermination,
+  nextSteps = ['step one', 'step two'],
+}) => {
   const { t } = useTranslation('common')
+
+  let status = ''
+  if (scenarioType === ScenarioType.PendingDetermination) {
+    status = t('claim-status.pending-determination')
+  } else if (scenarioType === ScenarioType.GenericPending) {
+    status = t('claim-status.generic-pending')
+  } else {
+    status = t('claim-status.generic-all-clear')
+  }
 
   return (
     <div className="claim-status">
       <h2>{t('claim-status.title')}</h2>
       <div className="pending-status">
-        <TextLine loading={loading} text={t('claim-status.pending')} />
+        <TextLine loading={loading} text={status} />
       </div>
       <div className="status-box">
         <div className="topbar">

--- a/components/ClaimStatus.tsx
+++ b/components/ClaimStatus.tsx
@@ -2,16 +2,15 @@ import { useTranslation } from 'next-i18next'
 
 import { NextSteps } from './NextSteps'
 import { TextLine } from './TextLine'
+import { ClaimStatusContent } from '../types/common'
 
-export interface ClaimStatusProps {
+export interface ClaimStatusProps extends ClaimStatusContent {
   loading: boolean
-  statusDescriptionKey: string
-  nextSteps?: string[]
 }
 
 export const ClaimStatus: React.FC<ClaimStatusProps> = ({
   loading,
-  statusDescriptionKey = 'claim-status.generic-pending',
+  statusDescription = 'claim-status.generic-pending',
   nextSteps = ['step one', 'step two'],
 }) => {
   const { t } = useTranslation('common')
@@ -20,7 +19,7 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({
     <div className="claim-status">
       <h2>{t('claim-status.title')}</h2>
       <div className="pending-status">
-        <TextLine loading={loading} text={t(statusDescriptionKey)} />
+        <TextLine loading={loading} text={t(statusDescription)} />
       </div>
       <div className="status-box">
         <div className="topbar">

--- a/components/Main.tsx
+++ b/components/Main.tsx
@@ -4,6 +4,7 @@ import { Title } from './Title'
 import { LanguageSwitcher } from './LanguageSwitcher'
 import { ClaimSection } from './ClaimSection'
 import { TimeoutModal } from './TimeoutModal'
+import { ClaimDetailsContent, ClaimStatusContent } from '../types/common'
 
 export interface MainProps {
   timedOut?: boolean
@@ -11,12 +12,30 @@ export interface MainProps {
 }
 
 export const Main: React.FC<MainProps> = ({ timedOut = false, loading = false }) => {
+  const statusContent: ClaimStatusContent = {
+    statusDescription: 'claim-status.generic-all-clear',
+    nextSteps: [
+      'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+      'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
+    ],
+  }
+
+  const detailsContent: ClaimDetailsContent = {
+    programType: 'Unemployment Insurance (UI)',
+    benefitYear: '3/21/2020 - 3/20/2021',
+    claimBalance: '$0.00',
+    weeklyBenefitAmount: '$111.00',
+    lastPaymentIssued: '4/29/2021',
+    extensionType: 'Tier 2 Extension',
+    extensionEndDate: '5/22/2021',
+  }
+
   return (
     <main className="main">
       <Container className="main-content">
         <Title />
         <LanguageSwitcher />
-        <ClaimSection loading={loading} />
+        <ClaimSection loading={loading} statusContent={statusContent} detailsContent={detailsContent} />
       </Container>
       <TimeoutModal action="startOrUpdate" timedOut={timedOut} />
     </main>

--- a/components/Main.tsx
+++ b/components/Main.tsx
@@ -4,32 +4,14 @@ import { Title } from './Title'
 import { LanguageSwitcher } from './LanguageSwitcher'
 import { ClaimSection } from './ClaimSection'
 import { TimeoutModal } from './TimeoutModal'
-import { ClaimDetailsContent, ClaimStatusContent } from '../types/common'
+import { ScenarioContent } from '../types/common'
 
-export interface MainProps {
+export interface MainProps extends ScenarioContent {
   timedOut?: boolean
   loading: boolean
 }
 
-export const Main: React.FC<MainProps> = ({ timedOut = false, loading = false }) => {
-  const statusContent: ClaimStatusContent = {
-    statusDescription: 'claim-status.generic-all-clear',
-    nextSteps: [
-      'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
-      'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-    ],
-  }
-
-  const detailsContent: ClaimDetailsContent = {
-    programType: 'Unemployment Insurance (UI)',
-    benefitYear: '3/21/2020 - 3/20/2021',
-    claimBalance: '$0.00',
-    weeklyBenefitAmount: '$111.00',
-    lastPaymentIssued: '4/29/2021',
-    extensionType: 'Tier 2 Extension',
-    extensionEndDate: '5/22/2021',
-  }
-
+export const Main: React.FC<MainProps> = ({ timedOut = false, loading = false, statusContent, detailsContent }) => {
   return (
     <main className="main">
       <Container className="main-content">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,9 +12,11 @@ import { Footer } from '../components/Footer'
 import { WorkInProgress } from '../components/WorkInProgress'
 
 import queryApiGateway, { Claim } from '../utils/queryApiGateway'
+import getScenario, { ScenarioType } from '../utils/getScenario'
 
 export interface HomeProps {
   claimData?: Claim[]
+  scenarioType?: ScenarioType
   loading: boolean
 }
 
@@ -42,13 +44,17 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale }) =>
   const logger = isProd ? pino({}) : pino({ prettyPrint: true })
   logger.info(req)
 
-  // Step 1: Make the API request and return the data.
-  const data: Claim = await queryApiGateway(req)
+  // Make the API request and return the data.
+  const claimData: Claim = await queryApiGateway(req)
 
-  // Step 2: Return Props
+  // Run business logic to determine the current scenario.
+  const scenarioType: ScenarioType = getScenario(claimData)
+
+  // Return Props.
   return {
     props: {
-      claimData: [data],
+      claimData: [claimData],
+      scenarioType: scenarioType,
       loading: false,
       ...(await serverSideTranslations(locale || 'en', ['common', 'header', 'footer'])),
     },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,11 +12,10 @@ import { Footer } from '../components/Footer'
 import { WorkInProgress } from '../components/WorkInProgress'
 
 import queryApiGateway, { Claim } from '../utils/queryApiGateway'
-import getScenario, { ScenarioType } from '../utils/getScenario'
+import getScenarioContent from '../utils/getScenarioContent'
 
 export interface HomeProps {
   claimData?: Claim[]
-  scenarioType?: ScenarioType
   loading: boolean
 }
 
@@ -48,13 +47,12 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale }) =>
   const claimData: Claim = await queryApiGateway(req)
 
   // Run business logic to determine the current scenario.
-  const scenarioType: ScenarioType = getScenario(claimData)
+  const scenarioContent = getScenarioContent(claimData)
 
   // Return Props.
   return {
     props: {
       claimData: [claimData],
-      scenarioType: scenarioType,
       loading: false,
       ...(await serverSideTranslations(locale || 'en', ['common', 'header', 'footer'])),
     },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,15 +13,33 @@ import { WorkInProgress } from '../components/WorkInProgress'
 
 import queryApiGateway from '../utils/queryApiGateway'
 import getScenarioContent from '../utils/getScenarioContent'
-import { Claim } from '../types/common'
+import { ClaimDetailsContent, ClaimStatusContent, ScenarioContent } from '../types/common'
 
 export interface HomeProps {
-  claimData?: Claim[]
+  scenarioContent: ScenarioContent
   loading: boolean
 }
 
-export default function Home({ claimData, loading }: HomeProps): ReactElement {
+export default function Home({ scenarioContent, loading }: HomeProps): ReactElement {
   const { t } = useTranslation('common')
+
+  const statusContent: ClaimStatusContent = {
+    statusDescription: 'claim-status.generic-all-clear',
+    nextSteps: [
+      'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+      'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
+    ],
+  }
+
+  const detailsContent: ClaimDetailsContent = {
+    programType: 'Unemployment Insurance (UI)',
+    benefitYear: '3/21/2020 - 3/20/2021',
+    claimBalance: '$0.00',
+    weeklyBenefitAmount: '$111.00',
+    lastPaymentIssued: '4/29/2021',
+    extensionType: 'Tier 2 Extension',
+    extensionEndDate: '5/22/2021',
+  }
 
   return (
     <Container fluid className="index">
@@ -32,9 +50,9 @@ export default function Home({ claimData, loading }: HomeProps): ReactElement {
       </Head>
       <WorkInProgress />
       <Header />
-      <Main loading={loading} />
+      <Main loading={loading} statusContent={statusContent} detailsContent={detailsContent} />
       <Footer />
-      {console.dir({ claimData })} {/* @TODO: Remove. For development purposes only. */}
+      {console.dir({ scenarioContent })} {/* @TODO: Remove. For development purposes only. */}
     </Container>
   )
 }
@@ -45,7 +63,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale }) =>
   logger.info(req)
 
   // Make the API request and return the data.
-  const claimData: Claim = await queryApiGateway(req)
+  const claimData = await queryApiGateway(req)
 
   // Run business logic to determine the current scenario.
   const scenarioContent = getScenarioContent(claimData)
@@ -53,7 +71,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale }) =>
   // Return Props.
   return {
     props: {
-      claimData: [claimData],
+      scenarioContent: scenarioContent,
       loading: false,
       ...(await serverSideTranslations(locale || 'en', ['common', 'header', 'footer'])),
     },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -59,7 +59,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale }) =>
     props: {
       scenarioContent: scenarioContent,
       loading: false,
-      ...(await serverSideTranslations(locale || 'en', ['common', 'header', 'footer'])),
+      ...(await serverSideTranslations(locale || 'en', ['common', 'claim-status'])),
     },
   }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,7 +13,7 @@ import { WorkInProgress } from '../components/WorkInProgress'
 
 import queryApiGateway from '../utils/queryApiGateway'
 import getScenarioContent from '../utils/getScenarioContent'
-import { ClaimDetailsContent, ClaimStatusContent, ScenarioContent } from '../types/common'
+import { ScenarioContent } from '../types/common'
 
 export interface HomeProps {
   scenarioContent: ScenarioContent
@@ -22,24 +22,6 @@ export interface HomeProps {
 
 export default function Home({ scenarioContent, loading }: HomeProps): ReactElement {
   const { t } = useTranslation('common')
-
-  const statusContent: ClaimStatusContent = {
-    statusDescription: 'claim-status.generic-all-clear',
-    nextSteps: [
-      'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
-      'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-    ],
-  }
-
-  const detailsContent: ClaimDetailsContent = {
-    programType: 'Unemployment Insurance (UI)',
-    benefitYear: '3/21/2020 - 3/20/2021',
-    claimBalance: '$0.00',
-    weeklyBenefitAmount: '$111.00',
-    lastPaymentIssued: '4/29/2021',
-    extensionType: 'Tier 2 Extension',
-    extensionEndDate: '5/22/2021',
-  }
 
   return (
     <Container fluid className="index">
@@ -50,7 +32,11 @@ export default function Home({ scenarioContent, loading }: HomeProps): ReactElem
       </Head>
       <WorkInProgress />
       <Header />
-      <Main loading={loading} statusContent={statusContent} detailsContent={detailsContent} />
+      <Main
+        loading={loading}
+        statusContent={scenarioContent.statusContent}
+        detailsContent={scenarioContent.detailsContent}
+      />
       <Footer />
       {console.dir({ scenarioContent })} {/* @TODO: Remove. For development purposes only. */}
     </Container>
@@ -65,7 +51,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale }) =>
   // Make the API request and return the data.
   const claimData = await queryApiGateway(req)
 
-  // Run business logic to determine the current scenario.
+  // Run business logic to get content for the current scenario.
   const scenarioContent = getScenarioContent(claimData)
 
   // Return Props.

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,8 +11,9 @@ import { Main } from '../components/Main'
 import { Footer } from '../components/Footer'
 import { WorkInProgress } from '../components/WorkInProgress'
 
-import queryApiGateway, { Claim } from '../utils/queryApiGateway'
+import queryApiGateway from '../utils/queryApiGateway'
 import getScenarioContent from '../utils/getScenarioContent'
+import { Claim } from '../types/common'
 
 export interface HomeProps {
   claimData?: Claim[]

--- a/public/locales/en/claim-status.json
+++ b/public/locales/en/claim-status.json
@@ -1,0 +1,11 @@
+{
+  "pending-determination": {
+    "description": "We need to confirm your eligibility for benefits."
+  },
+  "base-pending": {
+    "description": "Your payments are pending further review."
+  },
+  "base-no-pending": {
+    "description": "There are no pending issues at this time."
+  }
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -13,9 +13,6 @@
   "change-locale": "En español",
   "claim-status": {
     "title": "Claim Status",
-    "pending-determination": "We need to confirm your eligibility for benefits.",
-    "generic-pending": "Your payments are pending further review.",
-    "generic-all-clear": "There are no pending issues at this time.",
     "next-steps": "Next Steps"
   },
   "claim-details": {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -13,7 +13,9 @@
   "change-locale": "En español",
   "claim-status": {
     "title": "Claim Status",
-    "pending": "Your payments are pending further review.",
+    "pending-determination": "We need to confirm your eligibility for benefits.",
+    "generic-pending": "Your payments are pending further review.",
+    "generic-all-clear": "There are no pending issues at this time.",
     "next-steps": "Next Steps"
   },
   "claim-details": {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -19,6 +19,7 @@
     "next-steps": "Next Steps"
   },
   "claim-details": {
+    "title": "Claim Details",
     "benefit-year": "Benefit Year",
     "program-type": "Program Type",
     "claim-balance": "Claim Balance",

--- a/public/locales/es/claim-status.json
+++ b/public/locales/es/claim-status.json
@@ -1,0 +1,11 @@
+{
+  "pending-determination": {
+    "description": "Necesitamos confirmar su elegibilidad para los beneficios."
+  },
+  "base-pending": {
+    "description": "Sus pagos están pendientes de revisión adicional."
+  },
+  "base-no-pending": {
+    "description": "No hay asuntos pendientes en este momento."
+  }
+}

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -13,9 +13,6 @@
   "change-locale": "In English",
   "claim-status": {
     "title": "Claim Status",
-    "pending-determination": "Necesitamos confirmar su elegibilidad para los beneficios.",
-    "generic-pending": "Sus pagos están pendientes de revisión adicional.",
-    "generic-all-clear": "No hay asuntos pendientes en este momento.",
     "next-steps": "Próximos Pasos"
   },
   "claim-details": {

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -13,7 +13,9 @@
   "change-locale": "In English",
   "claim-status": {
     "title": "Claim Status",
-    "pending": "Sus pagos están pendientes de revisión adicional.",
+    "pending-determination": "Necesitamos confirmar su elegibilidad para los beneficios.",
+    "generic-pending": "Sus pagos están pendientes de revisión adicional.",
+    "generic-all-clear": "No hay asuntos pendientes en este momento.",
     "next-steps": "Próximos Pasos"
   },
   "claim-details": {

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -19,6 +19,7 @@
     "next-steps": "Próximos Pasos"
   },
   "claim-details": {
+    "title": "Claim Details",
     "benefit-year": "Año de beneficio",
     "program-type": "Tipo de Programa",
     "claim-balance": "Balance de Reclamación",

--- a/setupTests.tsx
+++ b/setupTests.tsx
@@ -4,6 +4,7 @@ import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
 import enCommon from './public/locales/en/common.json'
+import enClaimStatus from './public/locales/en/claim-status.json'
 
 /* eslint-disable @typescript-eslint/no-floating-promises */
 // Disabling this rule due to hitting a half hour of debugging,
@@ -13,10 +14,10 @@ import enCommon from './public/locales/en/common.json'
 i18n.use(initReactI18next).init({
   lng: 'en',
   fallbackLng: 'en',
-  ns: ['common'],
+  ns: ['common', 'claim-status'],
   defaultNS: 'common',
   resources: {
-    en: { common: enCommon },
+    en: { common: enCommon, 'claim-status': enClaimStatus },
   },
 })
 /* eslint-enable @typescript-eslint/no-floating-promises */

--- a/stories/ClaimDetails.stories.tsx
+++ b/stories/ClaimDetails.stories.tsx
@@ -12,4 +12,12 @@ export default {
 const Template: Story<ClaimDetailsProps> = (args) => <ClaimDetailsComponent {...args} />
 
 export const ClaimDetails = Template.bind({})
-ClaimDetails.args = {}
+ClaimDetails.args = {
+  programType: 'Unemployment Insurance (UI)',
+  benefitYear: '3/21/2020 - 3/20/2021',
+  claimBalance: '$508.00',
+  weeklyBenefitAmount: '$120.00',
+  lastPaymentIssued: '4/29/2021',
+  extensionType: 'Tier 2 Extension',
+  extensionEndDate: '5/22/2021',
+}

--- a/stories/ClaimDetails.stories.tsx
+++ b/stories/ClaimDetails.stories.tsx
@@ -19,5 +19,4 @@ ClaimDetails.args = {
   weeklyBenefitAmount: '$120.00',
   lastPaymentIssued: '4/29/2021',
   extensionType: 'Tier 2 Extension',
-  extensionEndDate: '5/22/2021',
 }

--- a/stories/ClaimSection.stories.tsx
+++ b/stories/ClaimSection.stories.tsx
@@ -3,6 +3,7 @@ import { Story, Meta } from '@storybook/react'
 import { ClaimSection as ClaimSectionComponent, ClaimSectionProps } from '../components/ClaimSection'
 import * as ClaimDetailsStories from './ClaimDetails.stories'
 import * as ClaimStatusStories from './ClaimStatus.stories'
+import { ClaimDetailsContent, ClaimStatusContent } from '../types/common'
 
 export default {
   title: 'Component/Page Section/Claim Section',
@@ -13,6 +14,6 @@ const Template: Story<ClaimSectionProps> = (args) => <ClaimSectionComponent {...
 
 export const ClaimSection = Template.bind({})
 ClaimSection.args = {
-  ...ClaimDetailsStories.ClaimDetails.args,
-  ...ClaimStatusStories.ClaimStatus.args,
+  detailsContent: ClaimDetailsStories.ClaimDetails.args as ClaimDetailsContent,
+  statusContent: ClaimStatusStories.ClaimStatus.args as ClaimStatusContent,
 }

--- a/stories/ClaimStatus.stories.tsx
+++ b/stories/ClaimStatus.stories.tsx
@@ -10,4 +10,7 @@ export default {
 const Template: Story<ClaimStatusProps> = (args) => <ClaimStatusComponent {...args} />
 
 export const ClaimStatus = Template.bind({})
-ClaimStatus.args = {}
+ClaimStatus.args = {
+  statusDescription: 'claim-status.generic-pending',
+  nextSteps: ['step one', 'step two'],
+}

--- a/stories/ClaimStatus.stories.tsx
+++ b/stories/ClaimStatus.stories.tsx
@@ -11,6 +11,6 @@ const Template: Story<ClaimStatusProps> = (args) => <ClaimStatusComponent {...ar
 
 export const ClaimStatus = Template.bind({})
 ClaimStatus.args = {
-  statusDescription: 'claim-status.generic-pending',
+  statusDescription: 'claim-status:base-pending.description',
   nextSteps: ['step one', 'step two'],
 }

--- a/stories/Main.stories.tsx
+++ b/stories/Main.stories.tsx
@@ -2,6 +2,9 @@ import { Story, Meta } from '@storybook/react'
 import { withNextRouter } from 'storybook-addon-next-router'
 
 import { Main as MainComponent, MainProps } from '../components/Main'
+import * as ClaimDetailsStories from './ClaimDetails.stories'
+import * as ClaimStatusStories from './ClaimStatus.stories'
+import { ClaimDetailsContent, ClaimStatusContent } from '../types/common'
 
 export default {
   title: 'Component/Page Section/Main',
@@ -12,10 +15,13 @@ export default {
 const Template: Story<MainProps> = (args) => <MainComponent {...args} />
 
 export const Main = Template.bind({})
-Main.args = {}
+Main.args = {
+  detailsContent: ClaimDetailsStories.ClaimDetails.args as ClaimDetailsContent,
+  statusContent: ClaimStatusStories.ClaimStatus.args as ClaimStatusContent,
+}
 
 export const TimedOut = Template.bind({})
-TimedOut.args = { timedOut: true }
+TimedOut.args = { timedOut: true, ...Main.args }
 
 export const Loading = Template.bind({})
-Loading.args = { loading: true }
+Loading.args = { loading: true, ...Main.args }

--- a/stories/Page.stories.tsx
+++ b/stories/Page.stories.tsx
@@ -2,6 +2,8 @@ import { Story, Meta } from '@storybook/react'
 import { withNextRouter } from 'storybook-addon-next-router'
 
 import Home, { HomeProps } from '../pages/index'
+import * as MainStories from './Main.stories'
+import { ScenarioContent } from '../types/common'
 
 export default {
   title: 'Claim Tracker/Page',
@@ -12,4 +14,6 @@ export default {
 const Template: Story<HomeProps> = (args) => <Home {...args} />
 
 export const Page = Template.bind({})
-Page.args = {}
+Page.args = {
+  scenarioContent: MainStories.Main.args as ScenarioContent,
+}

--- a/tests/components/main.test.tsx
+++ b/tests/components/main.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { Main } from '../../components/Main'
+import getScenarioContent from '../../utils/getScenarioContent'
+import { ScenarioContent } from '../../types/common'
 
 import { useRouter } from 'next/router'
 
@@ -8,6 +10,13 @@ jest.mock('next/router', () => ({
   useRouter: jest.fn(),
 }))
 
+let scenarioContent: ScenarioContent
+
+beforeAll(() => {
+  const pendingDeterminationScenario = { pendingDetermination: ['temporary text'] }
+  scenarioContent = getScenarioContent(pendingDeterminationScenario)
+})
+
 describe('Main component shows the page', () => {
   it('has our title, details, and body', () => {
     const mockRouter = {
@@ -15,7 +24,13 @@ describe('Main component shows the page', () => {
     }
     ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
 
-    render(<Main loading={false} />)
+    render(
+      <Main
+        loading={false}
+        statusContent={scenarioContent.statusContent}
+        detailsContent={scenarioContent.detailsContent}
+      />,
+    )
     expect(screen.queryByText('Claim Tracker')).toBeInTheDocument()
     expect(screen.queryByText('Claim Status')).toBeInTheDocument()
     expect(screen.queryByText('Next Steps')).toBeInTheDocument()
@@ -31,7 +46,9 @@ describe('Main component shows loading', () => {
     }
     ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
 
-    render(<Main loading />)
+    render(
+      <Main loading statusContent={scenarioContent.statusContent} detailsContent={scenarioContent.detailsContent} />,
+    )
     expect(screen.queryByText('Claim Tracker')).toBeInTheDocument()
     expect(screen.queryByText('Claim Status')).toBeInTheDocument()
     expect(screen.queryByText('Next Steps')).toBeInTheDocument()
@@ -48,7 +65,14 @@ describe('Main component shows the timeout', () => {
     }
     ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
 
-    render(<Main timedOut loading={false} />)
+    render(
+      <Main
+        timedOut
+        loading={false}
+        statusContent={scenarioContent.statusContent}
+        detailsContent={scenarioContent.detailsContent}
+      />,
+    )
     expect(screen.queryByText('Your Session Will End Soon')).toBeInTheDocument()
   })
 })

--- a/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/tests/pages/__snapshots__/index.test.tsx.snap
@@ -227,7 +227,7 @@ exports[`Exemplar react-test-renderer Snapshot test renders homepage unchanged 1
             <span
               className="text-line"
             >
-              Your payments are pending further review.
+              We need to confirm your eligibility for benefits.
             </span>
           </div>
           <div
@@ -366,20 +366,6 @@ exports[`Exemplar react-test-renderer Snapshot test renders homepage unchanged 1
                     className="info-entry"
                   >
                     Tier 2 Extension
-                  </div>
-                </div>
-                <div
-                  className="info"
-                >
-                  <div
-                    className="info-label"
-                  >
-                    Extension End Date
-                  </div>
-                  <div
-                    className="info-entry"
-                  >
-                    5/22/2021
                   </div>
                 </div>
               </div>

--- a/tests/pages/index.test.tsx
+++ b/tests/pages/index.test.tsx
@@ -1,6 +1,8 @@
 import renderer from 'react-test-renderer'
 import { render, screen } from '@testing-library/react'
 import Index from '../../pages/index'
+import getScenarioContent from '../../utils/getScenarioContent'
+import { ScenarioContent } from '../../types/common'
 
 import { useRouter } from 'next/router'
 
@@ -9,6 +11,13 @@ jest.mock('next/router', () => ({
   useRouter: jest.fn(),
 }))
 
+let scenarioContent: ScenarioContent
+
+beforeAll(() => {
+  const pendingDeterminationScenario = { pendingDetermination: ['temporary text'] }
+  scenarioContent = getScenarioContent(pendingDeterminationScenario)
+})
+
 describe('Exemplar react-test-renderer Snapshot test', () => {
   it('renders homepage unchanged', () => {
     const mockRouter = {
@@ -16,14 +25,14 @@ describe('Exemplar react-test-renderer Snapshot test', () => {
     }
     ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
 
-    const tree = renderer.create(<Index loading={false} />).toJSON()
+    const tree = renderer.create(<Index loading={false} scenarioContent={scenarioContent} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 })
 
 describe('Example react testing-library Test', () => {
   it('has our placeholder app', () => {
-    render(<Index loading={false} />)
+    render(<Index loading={false} scenarioContent={scenarioContent} />)
     expect(screen.queryByText('Claim Tracker')).toBeInTheDocument()
   })
 })

--- a/tests/utils/getScenario.test.tsx
+++ b/tests/utils/getScenario.test.tsx
@@ -1,0 +1,64 @@
+import getScenario, { ScenarioType } from '../../utils/getScenario'
+
+/**
+ * Begin tests
+ */
+describe('Identifying the scenario', () => {
+  it('returns the pending determination scenario if there is a pendingDetermination object', () => {
+    const pendingDeterminationScenario = { pendingDetermination: ['temporary text'] }
+    const scenarioType: ScenarioType = getScenario(pendingDeterminationScenario)
+    expect(scenarioType).toBe(ScenarioType.PendingDetermination)
+  })
+
+  it('returns the pending determination scenario if there is a pendingDetermination object regardless of other criteria', () => {
+    const pendingDeterminationScenarioWith = {
+      pendingDetermination: ['temporary text'],
+      hasPendingWeeks: true,
+    }
+    const scenarioTypeWith: ScenarioType = getScenario(pendingDeterminationScenarioWith)
+    expect(scenarioTypeWith).toBe(ScenarioType.PendingDetermination)
+
+    const pendingDeterminationScenarioWithout = {
+      pendingDetermination: ['temporary text'],
+      hasPendingWeeks: false,
+    }
+    const scenarioTypeWithout: ScenarioType = getScenario(pendingDeterminationScenarioWithout)
+    expect(scenarioTypeWithout).toBe(ScenarioType.PendingDetermination)
+  })
+
+  it('returns generic pending scenario if there are pending weeks', () => {
+    const genericPendingScenario = { hasPendingWeeks: true }
+    const scenarioType: ScenarioType = getScenario(genericPendingScenario)
+    expect(scenarioType).toBe(ScenarioType.GenericPending)
+  })
+
+  it('returns generic pending scenario if there are pending weeks and pendingDetermination is null', () => {
+    const genericPendingScenarioNull = { hasPendingWeeks: true, pendingDetermination: null }
+    const scenarioType: ScenarioType = getScenario(genericPendingScenarioNull)
+    expect(scenarioType).toBe(ScenarioType.GenericPending)
+  })
+
+  it('returns generic pending scenario if there are pending weeks and pendingDetermination is an empty array', () => {
+    const genericPendingScenarioEmpty = { hasPendingWeeks: true, pendingDetermination: [] }
+    const scenarioType: ScenarioType = getScenario(genericPendingScenarioEmpty)
+    expect(scenarioType).toBe(ScenarioType.GenericPending)
+  })
+
+  it('returns generic all clear scenario if there are no pending weeks', () => {
+    const genericAllClearScenario = { hasPendingWeeks: false }
+    const scenarioType: ScenarioType = getScenario(genericAllClearScenario)
+    expect(scenarioType).toBe(ScenarioType.GenericAllClear)
+  })
+
+  it('returns generic all clear scenario if there are no pending weeks and pendingDetermination is null', () => {
+    const genericAllClearScenarioNull = { hasPendingWeeks: false, pendingDetermination: null }
+    const scenarioType: ScenarioType = getScenario(genericAllClearScenarioNull)
+    expect(scenarioType).toBe(ScenarioType.GenericAllClear)
+  })
+
+  it('returns generic all clear scenario if there are no pending weeks and pendingDetermination is an empty array', () => {
+    const genericAllClearScenarioEmpty = { hasPendingWeeks: false, pendingDetermination: [] }
+    const scenarioType: ScenarioType = getScenario(genericAllClearScenarioEmpty)
+    expect(scenarioType).toBe(ScenarioType.GenericAllClear)
+  })
+})

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -1,9 +1,9 @@
 import getScenarioContent, { getScenario, ScenarioContent, ScenarioType } from '../../utils/getScenarioContent'
-import { useTranslation } from 'next-i18next'
 
 // Shared test constants
 const pendingDeterminationScenario = { pendingDetermination: ['temporary text'] }
-const { t } = useTranslation('common')
+const genericPendingScenario = { hasPendingWeeks: true }
+const genericAllClearScenario = { hasPendingWeeks: false }
 
 /**
  * Begin tests
@@ -12,8 +12,14 @@ const { t } = useTranslation('common')
 // Test getScenarioContent()
 describe('Retrieving the scenario content', () => {
   it('returns the correct status description for the scenario', () => {
-    const content: ScenarioContent = getScenarioContent(pendingDeterminationScenario)
-    expect(content).toBe(t('claim-status.pending-determination'))
+    const pendingDetermination: ScenarioContent = getScenarioContent(pendingDeterminationScenario)
+    expect(pendingDetermination.statusDescription).toBe('claim-status.pending-determination')
+
+    const genericPending: ScenarioContent = getScenarioContent(genericPendingScenario)
+    expect(genericPending.statusDescription).toBe('claim-status.generic-pending')
+
+    const genericAllClear: ScenarioContent = getScenarioContent(genericAllClearScenario)
+    expect(genericAllClear.statusDescription).toBe('claim-status.generic-all-clear')
   })
 })
 
@@ -41,7 +47,6 @@ describe('Identifying the scenario', () => {
   })
 
   it('returns generic pending scenario if there are pending weeks', () => {
-    const genericPendingScenario = { hasPendingWeeks: true }
     const scenarioType: ScenarioType = getScenario(genericPendingScenario)
     expect(scenarioType).toBe(ScenarioType.GenericPending)
   })
@@ -59,7 +64,6 @@ describe('Identifying the scenario', () => {
   })
 
   it('returns generic all clear scenario if there are no pending weeks', () => {
-    const genericAllClearScenario = { hasPendingWeeks: false }
     const scenarioType: ScenarioType = getScenario(genericAllClearScenario)
     expect(scenarioType).toBe(ScenarioType.GenericAllClear)
   })

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -1,11 +1,25 @@
-import getScenario, { ScenarioType } from '../../utils/getScenario'
+import getScenarioContent, { getScenario, ScenarioContent, ScenarioType } from '../../utils/getScenarioContent'
+import { useTranslation } from 'next-i18next'
+
+// Shared test constants
+const pendingDeterminationScenario = { pendingDetermination: ['temporary text'] }
+const { t } = useTranslation('common')
 
 /**
  * Begin tests
  */
+
+// Test getScenarioContent()
+describe('Retrieving the scenario content', () => {
+  it('returns the correct status description for the scenario', () => {
+    const content: ScenarioContent = getScenarioContent(pendingDeterminationScenario)
+    expect(content).toBe(t('claim-status.pending-determination'))
+  })
+})
+
+// Test getScenario()
 describe('Identifying the scenario', () => {
   it('returns the pending determination scenario if there is a pendingDetermination object', () => {
-    const pendingDeterminationScenario = { pendingDetermination: ['temporary text'] }
     const scenarioType: ScenarioType = getScenario(pendingDeterminationScenario)
     expect(scenarioType).toBe(ScenarioType.PendingDetermination)
   })

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -1,7 +1,7 @@
 import getScenarioContent, { getScenario, ScenarioType } from '../../utils/getScenarioContent'
 import { ScenarioContent } from '../../types/common'
 
-// Shared test constants
+// Shared test constants for mock API gateway responses
 const pendingDeterminationScenario = { pendingDetermination: ['temporary text'] }
 const basePendingScenario = { hasPendingWeeks: true }
 const baseNoPendingScenario = { hasPendingWeeks: false }
@@ -24,14 +24,14 @@ describe('Retrieving the scenario content', () => {
   })
 })
 
-// Test getScenario()
-describe('Identifying the scenario', () => {
-  it('returns the pending determination scenario if there is a pendingDetermination object', () => {
+// Test getScenario(): pending determination scenario
+describe('The pending determination scenario', () => {
+  it('is returned when there is a pendingDetermination object', () => {
     const scenarioType: ScenarioType = getScenario(pendingDeterminationScenario)
     expect(scenarioType).toBe(ScenarioType.PendingDetermination)
   })
 
-  it('returns the pending determination scenario if there is a pendingDetermination object regardless of other criteria', () => {
+  it('is returned when there is a pendingDetermination object regardless of other criteria', () => {
     const pendingDeterminationScenarioWith = {
       pendingDetermination: ['temporary text'],
       hasPendingWeeks: true,
@@ -46,36 +46,42 @@ describe('Identifying the scenario', () => {
     const scenarioTypeWithout: ScenarioType = getScenario(pendingDeterminationScenarioWithout)
     expect(scenarioTypeWithout).toBe(ScenarioType.PendingDetermination)
   })
+})
 
-  it('returns the base state (with pending weeks) if there are pending weeks', () => {
+// Test getScenario(): base state with pending weeks scenario
+describe('The base state (with pending weeks) scenario', () => {
+  it('is returned when there are pending weeks', () => {
     const scenarioType: ScenarioType = getScenario(basePendingScenario)
     expect(scenarioType).toBe(ScenarioType.BasePending)
   })
 
-  it('returns the base state (with pending weeks) if there are pending weeks and pendingDetermination is null', () => {
+  it('is returned when there are pending weeks and pendingDetermination is null', () => {
     const basePendingScenarioNull = { hasPendingWeeks: true, pendingDetermination: null }
     const scenarioType: ScenarioType = getScenario(basePendingScenarioNull)
     expect(scenarioType).toBe(ScenarioType.BasePending)
   })
 
-  it('returns the base state (with pending weeks) if there are pending weeks and pendingDetermination is an empty array', () => {
+  it('is returned when there are pending weeks and pendingDetermination is an empty array', () => {
     const basePendingScenarioEmpty = { hasPendingWeeks: true, pendingDetermination: [] }
     const scenarioType: ScenarioType = getScenario(basePendingScenarioEmpty)
     expect(scenarioType).toBe(ScenarioType.BasePending)
   })
+})
 
-  it('returns base state (with no pending weeks) if there are no pending weeks', () => {
+// Test getScenario(): base state with no pending weeks scenario
+describe('The base state (with no pending weeks) scenario', () => {
+  it('is returned when there are no pending weeks', () => {
     const scenarioType: ScenarioType = getScenario(baseNoPendingScenario)
     expect(scenarioType).toBe(ScenarioType.BaseNoPending)
   })
 
-  it('returns base state (with no pending weeks) if there are no pending weeks and pendingDetermination is null', () => {
+  it('is returned when there are no pending weeks and pendingDetermination is null', () => {
     const baseNoPendingScenarioNull = { hasPendingWeeks: false, pendingDetermination: null }
     const scenarioType: ScenarioType = getScenario(baseNoPendingScenarioNull)
     expect(scenarioType).toBe(ScenarioType.BaseNoPending)
   })
 
-  it('returns base state (with no pending weeks) if there are no pending weeks and pendingDetermination is an empty array', () => {
+  it('is returned when there are no pending weeks and pendingDetermination is an empty array', () => {
     const baseNoPendingScenarioEmpty = { hasPendingWeeks: false, pendingDetermination: [] }
     const scenarioType: ScenarioType = getScenario(baseNoPendingScenarioEmpty)
     expect(scenarioType).toBe(ScenarioType.BaseNoPending)

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -3,8 +3,8 @@ import { ScenarioContent } from '../../types/common'
 
 // Shared test constants
 const pendingDeterminationScenario = { pendingDetermination: ['temporary text'] }
-const genericPendingScenario = { hasPendingWeeks: true }
-const genericAllClearScenario = { hasPendingWeeks: false }
+const basePendingScenario = { hasPendingWeeks: true }
+const baseNoPendingScenario = { hasPendingWeeks: false }
 
 /**
  * Begin tests
@@ -14,13 +14,13 @@ const genericAllClearScenario = { hasPendingWeeks: false }
 describe('Retrieving the scenario content', () => {
   it('returns the correct status description for the scenario', () => {
     const pendingDetermination: ScenarioContent = getScenarioContent(pendingDeterminationScenario)
-    expect(pendingDetermination.statusContent.statusDescription).toBe('claim-status.pending-determination')
+    expect(pendingDetermination.statusContent.statusDescription).toBe('pending-determination.description')
 
-    const genericPending: ScenarioContent = getScenarioContent(genericPendingScenario)
-    expect(genericPending.statusContent.statusDescription).toBe('claim-status.generic-pending')
+    const basePending: ScenarioContent = getScenarioContent(basePendingScenario)
+    expect(basePending.statusContent.statusDescription).toBe('base-pending.description')
 
-    const genericAllClear: ScenarioContent = getScenarioContent(genericAllClearScenario)
-    expect(genericAllClear.statusContent.statusDescription).toBe('claim-status.generic-all-clear')
+    const baseNoPending: ScenarioContent = getScenarioContent(baseNoPendingScenario)
+    expect(baseNoPending.statusContent.statusDescription).toBe('base-no-pending.description')
   })
 })
 
@@ -47,37 +47,37 @@ describe('Identifying the scenario', () => {
     expect(scenarioTypeWithout).toBe(ScenarioType.PendingDetermination)
   })
 
-  it('returns generic pending scenario if there are pending weeks', () => {
-    const scenarioType: ScenarioType = getScenario(genericPendingScenario)
-    expect(scenarioType).toBe(ScenarioType.GenericPending)
+  it('returns the base state (with pending weeks) if there are pending weeks', () => {
+    const scenarioType: ScenarioType = getScenario(basePendingScenario)
+    expect(scenarioType).toBe(ScenarioType.BasePending)
   })
 
-  it('returns generic pending scenario if there are pending weeks and pendingDetermination is null', () => {
-    const genericPendingScenarioNull = { hasPendingWeeks: true, pendingDetermination: null }
-    const scenarioType: ScenarioType = getScenario(genericPendingScenarioNull)
-    expect(scenarioType).toBe(ScenarioType.GenericPending)
+  it('returns the base state (with pending weeks) if there are pending weeks and pendingDetermination is null', () => {
+    const basePendingScenarioNull = { hasPendingWeeks: true, pendingDetermination: null }
+    const scenarioType: ScenarioType = getScenario(basePendingScenarioNull)
+    expect(scenarioType).toBe(ScenarioType.BasePending)
   })
 
-  it('returns generic pending scenario if there are pending weeks and pendingDetermination is an empty array', () => {
-    const genericPendingScenarioEmpty = { hasPendingWeeks: true, pendingDetermination: [] }
-    const scenarioType: ScenarioType = getScenario(genericPendingScenarioEmpty)
-    expect(scenarioType).toBe(ScenarioType.GenericPending)
+  it('returns the base state (with pending weeks) if there are pending weeks and pendingDetermination is an empty array', () => {
+    const basePendingScenarioEmpty = { hasPendingWeeks: true, pendingDetermination: [] }
+    const scenarioType: ScenarioType = getScenario(basePendingScenarioEmpty)
+    expect(scenarioType).toBe(ScenarioType.BasePending)
   })
 
-  it('returns generic all clear scenario if there are no pending weeks', () => {
-    const scenarioType: ScenarioType = getScenario(genericAllClearScenario)
-    expect(scenarioType).toBe(ScenarioType.GenericAllClear)
+  it('returns base state (with no pending weeks) if there are no pending weeks', () => {
+    const scenarioType: ScenarioType = getScenario(baseNoPendingScenario)
+    expect(scenarioType).toBe(ScenarioType.BaseNoPending)
   })
 
-  it('returns generic all clear scenario if there are no pending weeks and pendingDetermination is null', () => {
-    const genericAllClearScenarioNull = { hasPendingWeeks: false, pendingDetermination: null }
-    const scenarioType: ScenarioType = getScenario(genericAllClearScenarioNull)
-    expect(scenarioType).toBe(ScenarioType.GenericAllClear)
+  it('returns base state (with no pending weeks) if there are no pending weeks and pendingDetermination is null', () => {
+    const baseNoPendingScenarioNull = { hasPendingWeeks: false, pendingDetermination: null }
+    const scenarioType: ScenarioType = getScenario(baseNoPendingScenarioNull)
+    expect(scenarioType).toBe(ScenarioType.BaseNoPending)
   })
 
-  it('returns generic all clear scenario if there are no pending weeks and pendingDetermination is an empty array', () => {
-    const genericAllClearScenarioEmpty = { hasPendingWeeks: false, pendingDetermination: [] }
-    const scenarioType: ScenarioType = getScenario(genericAllClearScenarioEmpty)
-    expect(scenarioType).toBe(ScenarioType.GenericAllClear)
+  it('returns base state (with no pending weeks) if there are no pending weeks and pendingDetermination is an empty array', () => {
+    const baseNoPendingScenarioEmpty = { hasPendingWeeks: false, pendingDetermination: [] }
+    const scenarioType: ScenarioType = getScenario(baseNoPendingScenarioEmpty)
+    expect(scenarioType).toBe(ScenarioType.BaseNoPending)
   })
 })

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -87,3 +87,12 @@ describe('The base state (with no pending weeks) scenario', () => {
     expect(scenarioType).toBe(ScenarioType.BaseNoPending)
   })
 })
+
+// Test getScenario(): error
+describe('Getting the scenario', () => {
+  it.skip('errors when given an unknown scenario', () => {
+    expect(() => {
+      getScenario({})
+    }).toThrowError('Unknown Scenario')
+  })
+})

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -14,13 +14,13 @@ const baseNoPendingScenario = { hasPendingWeeks: false }
 describe('Retrieving the scenario content', () => {
   it('returns the correct status description for the scenario', () => {
     const pendingDetermination: ScenarioContent = getScenarioContent(pendingDeterminationScenario)
-    expect(pendingDetermination.statusContent.statusDescription).toBe('pending-determination.description')
+    expect(pendingDetermination.statusContent.statusDescription).toBe('claim-status:pending-determination.description')
 
     const basePending: ScenarioContent = getScenarioContent(basePendingScenario)
-    expect(basePending.statusContent.statusDescription).toBe('base-pending.description')
+    expect(basePending.statusContent.statusDescription).toBe('claim-status:base-pending.description')
 
     const baseNoPending: ScenarioContent = getScenarioContent(baseNoPendingScenario)
-    expect(baseNoPending.statusContent.statusDescription).toBe('base-no-pending.description')
+    expect(baseNoPending.statusContent.statusDescription).toBe('claim-status:base-no-pending.description')
   })
 })
 

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -1,4 +1,5 @@
-import getScenarioContent, { getScenario, ScenarioContent, ScenarioType } from '../../utils/getScenarioContent'
+import getScenarioContent, { getScenario, ScenarioType } from '../../utils/getScenarioContent'
+import { ScenarioContent } from '../../types/common'
 
 // Shared test constants
 const pendingDeterminationScenario = { pendingDetermination: ['temporary text'] }
@@ -13,13 +14,13 @@ const genericAllClearScenario = { hasPendingWeeks: false }
 describe('Retrieving the scenario content', () => {
   it('returns the correct status description for the scenario', () => {
     const pendingDetermination: ScenarioContent = getScenarioContent(pendingDeterminationScenario)
-    expect(pendingDetermination.statusDescription).toBe('claim-status.pending-determination')
+    expect(pendingDetermination.statusContent.statusDescription).toBe('claim-status.pending-determination')
 
     const genericPending: ScenarioContent = getScenarioContent(genericPendingScenario)
-    expect(genericPending.statusDescription).toBe('claim-status.generic-pending')
+    expect(genericPending.statusContent.statusDescription).toBe('claim-status.generic-pending')
 
     const genericAllClear: ScenarioContent = getScenarioContent(genericAllClearScenario)
-    expect(genericAllClear.statusDescription).toBe('claim-status.generic-all-clear')
+    expect(genericAllClear.statusContent.statusDescription).toBe('claim-status.generic-all-clear')
   })
 })
 

--- a/tests/utils/queryApiGateway.test.tsx
+++ b/tests/utils/queryApiGateway.test.tsx
@@ -1,4 +1,5 @@
-import queryApiGateway, { buildApiUrl, extractJSON, Claim, QueryParams } from '../../utils/queryApiGateway'
+import { Claim } from '../../types/common'
+import queryApiGateway, { buildApiUrl, extractJSON, QueryParams } from '../../utils/queryApiGateway'
 import mockEnv from 'mocked-env'
 import fs from 'fs'
 import fetch from 'node-fetch'

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -1,0 +1,9 @@
+export interface PendingDetermination {
+  determinationStatus?: null | undefined | string
+}
+
+export interface Claim {
+  ClaimType?: null | undefined | string
+  hasPendingWeeks?: null | undefined | boolean
+  pendingDetermination?: null | [PendingDetermination]
+}

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -7,3 +7,23 @@ export interface Claim {
   hasPendingWeeks?: null | undefined | boolean
   pendingDetermination?: null | [PendingDetermination]
 }
+
+export interface ClaimStatusContent {
+  statusDescription: string
+  nextSteps?: string[]
+}
+
+export interface ClaimDetailsContent {
+  programType: string
+  benefitYear: string
+  claimBalance: string
+  weeklyBenefitAmount: string
+  lastPaymentIssued: string
+  extentionType: string
+  extensionEndDate: string
+}
+
+export interface ScenarioContent {
+  statusContent: ClaimStatusContent
+  detailsContent: ClaimDetailsContent
+}

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -23,7 +23,7 @@ export interface Claim {
 
 // Type interfaces for Claim Status and Claim Details
 export interface ClaimStatusContent {
-  statusDescription: string
+  statusDescription: string // This is an i18n string
   nextSteps?: string[]
 }
 

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -19,7 +19,7 @@ export interface ClaimDetailsContent {
   claimBalance: string
   weeklyBenefitAmount: string
   lastPaymentIssued: string
-  extentionType: string
+  extensionType: string
   extensionEndDate: string
 }
 

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -32,7 +32,6 @@ export interface ClaimDetailsContent {
   weeklyBenefitAmount: string
   lastPaymentIssued: string
   extensionType: string
-  extensionEndDate: string
 }
 
 export interface ScenarioContent {

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -1,3 +1,4 @@
+// Type interfaces for API gateway result
 export interface PendingDetermination {
   determinationStatus?: null | undefined | string
 }
@@ -20,6 +21,7 @@ export interface Claim {
   claimDetails?: ClaimDetailsResult
 }
 
+// Type interfaces for Claim Status and Claim Details
 export interface ClaimStatusContent {
   statusDescription: string
   nextSteps?: string[]

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -2,10 +2,22 @@ export interface PendingDetermination {
   determinationStatus?: null | undefined | string
 }
 
+export interface ClaimDetailsResult {
+  programType: string
+  benefitYearStartDate: string
+  benefitYearEndDate: string
+  claimBalance: string
+  weeklyBenefitAmount: string
+  lastPaymentIssued: string
+  lastPaymentAmount: string
+  monetaryStatus: string
+}
+
 export interface Claim {
   ClaimType?: null | undefined | string
   hasPendingWeeks?: null | undefined | boolean
   pendingDetermination?: null | [PendingDetermination]
+  claimDetails?: ClaimDetailsResult
 }
 
 export interface ClaimStatusContent {

--- a/utils/getScenario.tsx
+++ b/utils/getScenario.tsx
@@ -1,0 +1,32 @@
+import { Claim } from './queryApiGateway'
+
+export enum ScenarioType {
+  PendingDetermination,
+  GenericPending,
+  GenericAllClear,
+}
+
+/**
+ * Return the correct scenario to display.
+ *
+ * @param {Qbject} claim
+ * @returns {Object}
+ */
+export default function getScenario(claimData: Claim): ScenarioType {
+  // The pending determination scenario: if claimData contains any pendingDetermination
+  // objects
+  // @TODO: refactor with more detailed pending determination scenarios #252
+  if (claimData.pendingDetermination && claimData.pendingDetermination.length > 0) {
+    return ScenarioType.PendingDetermination
+  }
+  // The generic pending scenario: if there are no pendingDetermination objects
+  // AND hasPendingWeeks is true
+  else if (claimData.hasPendingWeeks === true) {
+    return ScenarioType.GenericPending
+  }
+  // The generic "all clear"/base state scenario: if there are no pendingDetermination objects
+  // and hasPendingWeeks is false
+  else {
+    return ScenarioType.GenericAllClear
+  }
+}

--- a/utils/getScenario.tsx
+++ b/utils/getScenario.tsx
@@ -1,9 +1,9 @@
 import { Claim } from './queryApiGateway'
 
 export enum ScenarioType {
-  PendingDetermination,
-  GenericPending,
-  GenericAllClear,
+  PendingDetermination = 'Pending Determination Scenario',
+  GenericPending = 'Generic Pending Scenario',
+  GenericAllClear = 'Generic All Clear Scenario',
 }
 
 /**
@@ -26,7 +26,12 @@ export default function getScenario(claimData: Claim): ScenarioType {
   }
   // The generic "all clear"/base state scenario: if there are no pendingDetermination objects
   // and hasPendingWeeks is false
-  else {
+  else if (claimData.hasPendingWeeks === false) {
     return ScenarioType.GenericAllClear
+  }
+  // This is unexpected
+  // @TODO: Log the scenario and display 500
+  else {
+    throw new Error('Unexpected scenario')
   }
 }

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -1,4 +1,5 @@
 import { Claim } from './queryApiGateway'
+import { useTranslation } from 'next-i18next'
 
 export enum ScenarioType {
   PendingDetermination = 'Pending Determination Scenario',
@@ -6,13 +7,17 @@ export enum ScenarioType {
   GenericAllClear = 'Generic All Clear Scenario',
 }
 
+export interface ScenarioContent {
+  statusDescription: string
+}
+
 /**
- * Return the correct scenario to display.
+ * Identify the correct scenario to display.
  *
  * @param {Qbject} claim
  * @returns {Object}
  */
-export default function getScenario(claimData: Claim): ScenarioType {
+export function getScenario(claimData: Claim): ScenarioType {
   // The pending determination scenario: if claimData contains any pendingDetermination
   // objects
   // @TODO: refactor with more detailed pending determination scenarios #252
@@ -32,6 +37,31 @@ export default function getScenario(claimData: Claim): ScenarioType {
   // This is unexpected
   // @TODO: Log the scenario and display 500
   else {
-    throw new Error('Unexpected scenario')
+    // throw new Error('Unexpected scenario')
+    return ScenarioType.GenericAllClear
   }
+}
+
+/**
+ * Return scenario content.
+ *
+ * @param {Object} claim
+ * @param {enum} scenarioType
+ * @returns {Object}
+ */
+export default function getScenarioContent(claimData: Claim): ScenarioContent {
+  const content = {} as ScenarioContent
+
+  // Get the scenario type.
+  const scenarioType = getScenario(claimData)
+
+  if (scenarioType === ScenarioType.PendingDetermination) {
+    content.statusDescription = 'claim-status.pending-determination'
+  } else if (scenarioType === ScenarioType.GenericPending) {
+    content.statusDescription = 'claim-status.generic-pending'
+  } else {
+    content.statusDescription = 'claim-status.generic-all-clear'
+  }
+
+  return content
 }

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -1,13 +1,9 @@
-import { Claim } from '../types/common'
+import { Claim, ClaimDetailsContent, ClaimStatusContent, ScenarioContent } from '../types/common'
 
 export enum ScenarioType {
   PendingDetermination = 'Pending Determination Scenario',
   GenericPending = 'Generic Pending Scenario',
   GenericAllClear = 'Generic All Clear Scenario',
-}
-
-export interface ScenarioContent {
-  statusDescription: string
 }
 
 /**
@@ -49,17 +45,55 @@ export function getScenario(claimData: Claim): ScenarioType {
  * @returns {Object}
  */
 export default function getScenarioContent(claimData: Claim): ScenarioContent {
-  const content = {} as ScenarioContent
-
   // Get the scenario type.
   const scenarioType = getScenario(claimData)
 
+  // Construct claim status content.
+  let statusDescription = ''
   if (scenarioType === ScenarioType.PendingDetermination) {
-    content.statusDescription = 'claim-status.pending-determination'
+    statusDescription = 'claim-status.pending-determination'
   } else if (scenarioType === ScenarioType.GenericPending) {
-    content.statusDescription = 'claim-status.generic-pending'
+    statusDescription = 'claim-status.generic-pending'
   } else {
-    content.statusDescription = 'claim-status.generic-all-clear'
+    statusDescription = 'claim-status.generic-all-clear'
+  }
+
+  const nextSteps = [
+    'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+    'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
+  ]
+
+  const statusContent: ClaimStatusContent = {
+    statusDescription: statusDescription,
+    nextSteps: nextSteps,
+  }
+
+  // Construct claim details content.
+  // @TODO: Remove placeholder default content
+  const detailsContent: ClaimDetailsContent = {
+    programType: 'Unemployment Insurance (UI)',
+    benefitYear: '3/21/2020 - 3/20/2021',
+    claimBalance: '$0.00',
+    weeklyBenefitAmount: '$111.00',
+    lastPaymentIssued: '4/29/2021',
+    extensionType: 'Tier 2 Extension',
+    extensionEndDate: '5/22/2021',
+  }
+
+  if (claimData.claimDetails) {
+    detailsContent.programType = claimData.claimDetails.programType
+    detailsContent.benefitYear = `${claimData.claimDetails.benefitYearStartDate} - ${claimData.claimDetails.benefitYearEndDate}`
+    detailsContent.claimBalance = claimData.claimDetails.claimBalance
+    detailsContent.weeklyBenefitAmount = claimData.claimDetails.weeklyBenefitAmount
+    detailsContent.lastPaymentIssued = claimData.claimDetails.lastPaymentIssued
+    // @TODO
+    // detailsContent.extensionType = ''
+    // detailsContent.extensionEndDate = ''
+  }
+
+  const content: ScenarioContent = {
+    statusContent: statusContent,
+    detailsContent: detailsContent,
   }
 
   return content

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -1,4 +1,4 @@
-import { Claim } from './queryApiGateway'
+import { Claim } from '../types/common'
 
 export enum ScenarioType {
   PendingDetermination = 'Pending Determination Scenario',

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -49,6 +49,7 @@ export default function getScenarioContent(claimData: Claim): ScenarioContent {
   const scenarioType = getScenario(claimData)
 
   // Construct claim status content.
+  // This sets an i18n string.
   let statusDescription = ''
   if (scenarioType === ScenarioType.PendingDetermination) {
     statusDescription = 'claim-status:pending-determination.description'

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -77,7 +77,6 @@ export default function getScenarioContent(claimData: Claim): ScenarioContent {
     weeklyBenefitAmount: '$111.00',
     lastPaymentIssued: '4/29/2021',
     extensionType: 'Tier 2 Extension',
-    extensionEndDate: '5/22/2021',
   }
 
   if (claimData.claimDetails) {
@@ -88,7 +87,6 @@ export default function getScenarioContent(claimData: Claim): ScenarioContent {
     detailsContent.lastPaymentIssued = claimData.claimDetails.lastPaymentIssued
     // @TODO
     // detailsContent.extensionType = ''
-    // detailsContent.extensionEndDate = ''
   }
 
   const content: ScenarioContent = {

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -1,9 +1,9 @@
 import { Claim, ClaimDetailsContent, ClaimStatusContent, ScenarioContent } from '../types/common'
 
 export enum ScenarioType {
-  PendingDetermination = 'Pending Determination Scenario',
-  GenericPending = 'Generic Pending Scenario',
-  GenericAllClear = 'Generic All Clear Scenario',
+  PendingDetermination = 'Pending determination scenario',
+  BasePending = 'Base state with pending weeks',
+  BaseNoPending = 'Base state with no pending weeks',
 }
 
 /**
@@ -22,18 +22,18 @@ export function getScenario(claimData: Claim): ScenarioType {
   // The generic pending scenario: if there are no pendingDetermination objects
   // AND hasPendingWeeks is true
   else if (claimData.hasPendingWeeks === true) {
-    return ScenarioType.GenericPending
+    return ScenarioType.BasePending
   }
   // The generic "all clear"/base state scenario: if there are no pendingDetermination objects
   // and hasPendingWeeks is false
   else if (claimData.hasPendingWeeks === false) {
-    return ScenarioType.GenericAllClear
+    return ScenarioType.BaseNoPending
   }
   // This is unexpected
   // @TODO: Log the scenario and display 500
   else {
     // throw new Error('Unexpected scenario')
-    return ScenarioType.GenericAllClear
+    return ScenarioType.BaseNoPending
   }
 }
 
@@ -51,11 +51,11 @@ export default function getScenarioContent(claimData: Claim): ScenarioContent {
   // Construct claim status content.
   let statusDescription = ''
   if (scenarioType === ScenarioType.PendingDetermination) {
-    statusDescription = 'claim-status.pending-determination'
-  } else if (scenarioType === ScenarioType.GenericPending) {
-    statusDescription = 'claim-status.generic-pending'
+    statusDescription = 'claim-status:pending-determination.description'
+  } else if (scenarioType === ScenarioType.BasePending) {
+    statusDescription = 'claim-status:base-pending.description'
   } else {
-    statusDescription = 'claim-status.generic-all-clear'
+    statusDescription = 'claim-status:base-no-pending.description'
   }
 
   const nextSteps = [

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -1,5 +1,4 @@
 import { Claim } from './queryApiGateway'
-import { useTranslation } from 'next-i18next'
 
 export enum ScenarioType {
   PendingDetermination = 'Pending Determination Scenario',

--- a/utils/queryApiGateway.tsx
+++ b/utils/queryApiGateway.tsx
@@ -2,17 +2,8 @@ import path from 'path'
 import fs from 'fs'
 import https from 'https'
 import fetch, { Response } from 'node-fetch'
-import type { IncomingMessage } from 'http'
-
-export interface PendingDetermination {
-  determinationStatus?: null | undefined | string
-}
-
-export interface Claim {
-  ClaimType?: null | undefined | string
-  hasPendingWeeks?: null | undefined | boolean
-  pendingDetermination?: null | [PendingDetermination]
-}
+import { IncomingMessage } from 'http'
+import { Claim } from '../types/common'
 
 export interface QueryParams {
   user_key: string

--- a/utils/queryApiGateway.tsx
+++ b/utils/queryApiGateway.tsx
@@ -4,8 +4,14 @@ import https from 'https'
 import fetch, { Response } from 'node-fetch'
 import type { IncomingMessage } from 'http'
 
+export interface PendingDetermination {
+  determinationStatus?: null | undefined | string
+}
+
 export interface Claim {
-  ClaimType: string | null | undefined
+  ClaimType?: null | undefined | string
+  hasPendingWeeks?: null | undefined | boolean
+  pendingDetermination?: null | [PendingDetermination]
 }
 
 export interface QueryParams {


### PR DESCRIPTION
## Ticket

#242 

## Changes

- Started adding business logic to identify the correct scenario
- Started adding logic to control content for Claim Status
- Started adding logic to handle passing through Claim Details content
- Created a separate `claim-status.json` namespace for strings related to the Claim Status section
- Created `types/common.tsx` for shared Typescript types
- Added `claim-details.title` to `common.json` for translation consistency
- Removed `extensionEndDate` per conversation with Diana and @nicoleslaw 
- Moved default/placeholder values out of components
- Added test values for components into stories and tests

## Context

This PR begins to the work for #242. There's still quite a bit to do (such as the logic for extracting the Extension Type out of the Program Type, the logic for providing the content for Next Steps, etc), but this PR was already getting too large, so I decided to split the work into multiple PRs.

The work in this PR can be organized into the following broad categories:
- Business logic (see `getScenarioContent.tsx`)
- Adding props to get the content from the business logic into the components
- Breaking out a separate language namespace for the various scenarios that will be displayed in the Claim Status component

## Testing Instructions

- `yarn test`
- `yarn storybook`