### PR TITLE
Add reusable wrapper component around <Trans>.

### DIFF
--- a/components/TransLine.tsx
+++ b/components/TransLine.tsx
@@ -1,0 +1,21 @@
+import { Trans } from 'react-i18next'
+import React from 'react'
+
+export interface TransLineProps {
+  i18nString: string // Expects an i18n string
+  links?: string[] | null
+}
+
+export const TransLine: React.FC<TransLineProps> = ({ i18nString, links = null }) => {
+  let linkComponents: JSX.Element[] = []
+  if (links && links.length > 0) {
+    // Disabling some linting rules for this line. The anchor <a> element will
+    // be interporlated by <Trans>.
+    /* eslint-disable jsx-a11y/anchor-has-content */
+    /* eslint-disable react/self-closing-comp */
+    linkComponents = links.map((link, index) => <a href={link} key={index}></a>)
+    /* eslint-enable jsx-a11y/anchor-has-content */
+    /* eslint-enable react/self-closing-comp */
+  }
+  return <Trans i18nKey={i18nString}>{linkComponents}</Trans>
+}

--- a/components/TransLine.tsx
+++ b/components/TransLine.tsx
@@ -13,7 +13,7 @@ export const TransLine: React.FC<TransLineProps> = ({ i18nString, links = null }
     // be interporlated by <Trans>.
     /* eslint-disable jsx-a11y/anchor-has-content */
     /* eslint-disable react/self-closing-comp */
-    linkComponents = links.map((link, index) => <a href={link} key={index}></a>)
+    linkComponents = links.map((link) => <a href={link} key={link}></a>)
     /* eslint-enable jsx-a11y/anchor-has-content */
     /* eslint-enable react/self-closing-comp */
   }

--- a/components/TransLine.tsx
+++ b/components/TransLine.tsx
@@ -2,11 +2,11 @@ import { Trans } from 'react-i18next'
 import React from 'react'
 
 export interface TransLineProps {
-  i18nString: string // Expects an i18n string
+  i18nKey: string // Expects an i18n key
   links?: string[] | null
 }
 
-export const TransLine: React.FC<TransLineProps> = ({ i18nString, links = null }) => {
+export const TransLine: React.FC<TransLineProps> = ({ i18nKey, links = null }) => {
   let linkComponents: JSX.Element[] = []
   if (links && links.length > 0) {
     // Disabling some linting rules for this line. The anchor <a> element will
@@ -17,5 +17,5 @@ export const TransLine: React.FC<TransLineProps> = ({ i18nString, links = null }
     /* eslint-enable jsx-a11y/anchor-has-content */
     /* eslint-enable react/self-closing-comp */
   }
-  return <Trans i18nKey={i18nString}>{linkComponents}</Trans>
+  return <Trans i18nKey={i18nKey}>{linkComponents}</Trans>
 }

--- a/setupTests.tsx
+++ b/setupTests.tsx
@@ -14,10 +14,24 @@ import enClaimStatus from './public/locales/en/claim-status.json'
 i18n.use(initReactI18next).init({
   lng: 'en',
   fallbackLng: 'en',
-  ns: ['common', 'claim-status'],
+  ns: ['common', 'claim-status', 'test'],
   defaultNS: 'common',
   resources: {
-    en: { common: enCommon, 'claim-status': enClaimStatus },
+    en: {
+      common: enCommon,
+      'claim-status': enClaimStatus,
+      test: {
+        transLine: {
+          plainString: 'just text',
+          plainStringOneLink: 'first <0>second</0> third',
+          plainStringLinks: 'first <0>second</0> <1>third</1>',
+          plainStringLinksComplicated: '<1>first</1> <0>second</0> third <0>fourth</0> <1>fifth</1>',
+          styledString: 'first <strong>second</strong> third',
+          styledStringOneLink: 'first <strong>second</strong> <0>third</0>',
+          styledLink: 'first <strong><0>second</0></strong>',
+        },
+      },
+    },
   },
 })
 /* eslint-enable @typescript-eslint/no-floating-promises */

--- a/stories/TransLine.stories.tsx
+++ b/stories/TransLine.stories.tsx
@@ -1,0 +1,15 @@
+import { Story, Meta } from '@storybook/react'
+import { TransLine as TransLineComponent, TransLineProps } from '../components/TransLine'
+
+export default {
+  title: 'Component/Atoms/Trans Line',
+  component: TransLineComponent,
+} as Meta
+
+const Template: Story<TransLineProps> = (args) => <TransLineComponent {...args} />
+
+export const TransLine = Template.bind({})
+TransLine.args = {
+  i18nString: 'work-in-progress.message',
+  links: ['https://navapbc.com', 'https://edd.ca.gov'],
+}

--- a/stories/TransLine.stories.tsx
+++ b/stories/TransLine.stories.tsx
@@ -11,5 +11,7 @@ const Template: Story<TransLineProps> = (args) => <TransLineComponent {...args} 
 export const TransLine = Template.bind({})
 TransLine.args = {
   i18nKey: 'work-in-progress.message',
-  links: ['https://navapbc.com', 'https://edd.ca.gov'],
+  // There are two links in this array because the work-in-progress.message translation
+  // string uses <1> as the link placeholder. <0> is not used and is ignored.
+  links: ['example.com/placeholder', 'https://edd.ca.gov'],
 }

--- a/stories/TransLine.stories.tsx
+++ b/stories/TransLine.stories.tsx
@@ -10,6 +10,6 @@ const Template: Story<TransLineProps> = (args) => <TransLineComponent {...args} 
 
 export const TransLine = Template.bind({})
 TransLine.args = {
-  i18nString: 'work-in-progress.message',
+  i18nKey: 'work-in-progress.message',
   links: ['https://navapbc.com', 'https://edd.ca.gov'],
 }

--- a/tests/components/TransLine.test.tsx
+++ b/tests/components/TransLine.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import { TransLine } from '../../components/TransLine'
+
+describe('TransLine component loads', () => {
+  it('a string with no links or styles', () => {
+    render(<TransLine i18nKey="test:transLine.plainString" />)
+    expect(screen.getByText('just text')).toBeInTheDocument()
+  })
+
+  it('a string with one link and no styles', () => {
+    const links = ['https://example.com']
+    render(<TransLine i18nKey="test:transLine.plainStringOneLink" links={links} />)
+    expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', links[0])
+  })
+
+  it('a string with multiple links and no styles', () => {
+    const links = ['https://example.com/alpha', 'https://example.com/beta']
+    render(<TransLine i18nKey="test:transLine.plainStringLinks" links={links} />)
+    expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', links[0])
+    expect(screen.getByRole('link', { name: 'third' })).toHaveAttribute('href', links[1])
+  })
+
+  it('a string with multiple links reused links and out of order', () => {
+    const links = ['https://example.com/alpha', 'https://example.com/beta']
+    render(<TransLine i18nKey="test:transLine.plainStringLinksComplicated" links={links} />)
+    expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', links[0])
+    expect(screen.getByRole('link', { name: 'fourth' })).toHaveAttribute('href', links[0])
+    expect(screen.getByRole('link', { name: 'first' })).toHaveAttribute('href', links[1])
+    expect(screen.getByRole('link', { name: 'fifth' })).toHaveAttribute('href', links[1])
+  })
+
+  it('a string with no links, but with styles', () => {
+    render(<TransLine i18nKey="test:transLine.styledString" />)
+    expect(screen.getByText('first', { exact: false })).toBeInTheDocument()
+    screen.getByText((content, element) => {
+      return element.tagName.toLowerCase() === 'strong' && content.startsWith('second')
+    })
+    expect(screen.getByText('third', { exact: false })).toBeInTheDocument()
+  })
+
+  it('a string with one link and styles', () => {
+    const links = ['https://example.com/alpha']
+    render(<TransLine i18nKey="test:transLine.styledStringOneLink" links={links} />)
+    expect(screen.getByText('first', { exact: false })).toBeInTheDocument()
+    screen.getByText((content, element) => {
+      return element.tagName.toLowerCase() === 'strong' && content.startsWith('second')
+    })
+    expect(screen.getByRole('link', { name: 'third' })).toHaveAttribute('href', links[0])
+  })
+
+  it('a string with a styled link', () => {
+    const links = ['https://example.com/alpha']
+    render(<TransLine i18nKey="test:transLine.styledLink" links={links} />)
+    expect(screen.getByText('first', { exact: false })).toBeInTheDocument()
+    screen.getByText((content, element) => {
+      return element.tagName.toLowerCase() === 'strong'
+    })
+    expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', links[0])
+  })
+})

--- a/tests/components/header.test.tsx
+++ b/tests/components/header.test.tsx
@@ -1,20 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { Header } from '../../components/Header'
 
-import { useRouter } from 'next/router'
-
-jest.mock('next/router', () => ({
-  __esModule: true,
-  useRouter: jest.fn(),
-}))
-
 describe('Header component loads', () => {
   it('has the desktop UIO Link by default', () => {
-    const mockRouter = {
-      locale: 'en',
-    }
-    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
-
     render(<Header userArrivedFromUioMobile={false} />)
     expect(screen.queryByText('UI Online Home')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'UI Online Home' })).toHaveAttribute(
@@ -24,11 +12,6 @@ describe('Header component loads', () => {
   })
 
   it('has the UIO Mobile Link when the user arrived from UIO Mobile', () => {
-    const mockRouter = {
-      locale: 'en',
-    }
-    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
-
     render(<Header userArrivedFromUioMobile />)
     expect(screen.queryByText('UI Online Home')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'UI Online Home' })).toHaveAttribute(


### PR DESCRIPTION
## Changes

- Added a new component `<TransLine>`
- Removes router mock code in the header test

## Context

The proposed translation strings contain embedded links. To translate them using [next-i18next](https://github.com/isaachinman/next-i18next), we'll use the [react-i18n `<Trans>`](https://react.i18next.com/latest/trans-component) component. 

This PR introduces a reusable component that will build a `<Trans>` component with arbitrary embedded links. As with the react-i18n `<Trans>` component, some care needs to be taken to make sure that the correct replacement tag (e.g. `<0></0>`) is in the translation string that's passed as the `i18nString` argument.

## Testing Instructions

`yarn test`

Use `yarn storybook` to play with the component. It's listed under Atoms > Trans Line. You can edit `common.json` to add additional strings that have multiple links.