### PR TITLE
Cleans up SP7 component spacing

### DIFF
--- a/components/ClaimDetails.tsx
+++ b/components/ClaimDetails.tsx
@@ -19,7 +19,8 @@ export const ClaimDetails: React.FC<ClaimDetailsProps> = ({
 
   return (
     <div className="claim-details container">
-      <h2 className="claim-details-title">{title}</h2>
+      <h2 className="claim-details-title">{t('claim-details.title')}</h2>
+
       <div className="claim-details-box">
         <div className="row">
           <div className="col-6">

--- a/components/ClaimDetails.tsx
+++ b/components/ClaimDetails.tsx
@@ -28,7 +28,7 @@ export const ClaimDetails: React.FC<ClaimDetailsProps> = ({
 
   return (
     <div className="claim-details container">
-      <h2>{title}</h2>
+      <h2 className="claim-details-title">{title}</h2>
 
       <div className="claim-details-box">
         <div className="row">

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -98,8 +98,12 @@ body {
   .claim-details {
     padding: 3rem 0 1rem 0;
 
+    .claim-details-title {
+      margin-bottom: 1rem;
+    }
+
     .claim-details-box {
-      padding: 1rem;
+      padding: 0.5rem 1.5rem 1.5rem 1.5rem;
       border: 3px solid #f0f0f0;
     }
 

--- a/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/tests/pages/__snapshots__/index.test.tsx.snap
@@ -267,7 +267,9 @@ exports[`Exemplar react-test-renderer Snapshot test renders homepage unchanged 1
         <div
           className="claim-details container"
         >
-          <h2>
+          <h2
+            className="claim-details-title"
+          >
             Claim Details
           </h2>
           <div


### PR DESCRIPTION
Small tweaks to the component spacing from conversation with @nguyen-tina 

  - Adjusts spacing from Claim Details title to its box
  - Fixes the box spacing to be equal all-around
  
Related to #197 

Before | After
--|--
![image](https://user-images.githubusercontent.com/6129479/123669736-66267100-d80a-11eb-9956-be7284a02515.png) |  ![image](https://user-images.githubusercontent.com/6129479/123669695-59a21880-d80a-11eb-8fea-18b439d8846f.png)
