### PR TITLE
Request converts header keys to lowercase

### DIFF
--- a/tests/utils/queryApiGateway.test.tsx
+++ b/tests/utils/queryApiGateway.test.tsx
@@ -1,5 +1,5 @@
 import { Claim } from '../../types/common'
-import queryApiGateway, { buildApiUrl, extractJSON, QueryParams } from '../../utils/queryApiGateway'
+import queryApiGateway, { buildApiUrl, getUniqueNumber, extractJSON, QueryParams } from '../../utils/queryApiGateway'
 import mockEnv from 'mocked-env'
 import fs from 'fs'
 import fetch from 'node-fetch'
@@ -14,6 +14,11 @@ const { Response } = jest.requireActual('node-fetch')
 // Shared test constants
 const goodUrl = 'http://nowhere.com'
 const emptyResponse = { ClaimType: undefined }
+const goodRequest = {
+  headers: {
+    id: '12345',
+  },
+}
 
 /**
  * Begin tests
@@ -22,11 +27,6 @@ const emptyResponse = { ClaimType: undefined }
 // Test queryApiGateway()
 describe('Querying the API Gateway', () => {
   const goodResponse = { ClaimType: 'PUA' }
-  const goodRequest = {
-    headers: {
-      id: '12345',
-    },
-  }
 
   beforeEach(() => {
     // Mock the fetch response
@@ -148,6 +148,43 @@ describe('Building the API url', () => {
     expect(() => {
       buildApiUrl(badUrl, goodParams)
     }).toThrowError('Invalid URL')
+  })
+})
+
+// Test getUniqueNumber()
+describe('The unique number', () => {
+  it('is returned when given the correct ID key', () => {
+    const idHeaderName = 'id'
+    const id = getUniqueNumber(goodRequest, idHeaderName)
+    expect(id).toStrictEqual(goodRequest.headers.id)
+  })
+
+  it('is not case sensitive', () => {
+    const key = 'uniqueNumber'
+    const request = {
+      headers: {
+        uniquenumber: 'lower',
+        UNIQUENUMBER: 'UPPER',
+        uniqueNumber: 'mixedCase',
+      },
+    }
+
+    const mixed = getUniqueNumber(request, key)
+    expect(mixed).toStrictEqual(request.headers.uniquenumber)
+
+    const lower = getUniqueNumber(request, key.toLowerCase())
+    expect(lower).toStrictEqual(request.headers.uniquenumber)
+
+    const upper = getUniqueNumber(request, key.toUpperCase())
+    expect(upper).toStrictEqual(request.headers.uniquenumber)
+  })
+
+  // Current behavior is to return undefined.
+  // @TODO: Correct behavior to be implemented in #217
+  it('is not returned when given the incorrect ID key', () => {
+    const idHeaderName = 'key'
+    const id = getUniqueNumber(goodRequest, idHeaderName)
+    expect(id).toStrictEqual(undefined)
   })
 })
 

--- a/utils/queryApiGateway.tsx
+++ b/utils/queryApiGateway.tsx
@@ -66,6 +66,14 @@ export function extractJSON(responseBody: string): Claim {
 }
 
 /**
+ * Return the unique number.
+ */
+export function getUniqueNumber(req: IncomingMessage, idHeaderName: string): string {
+  // Request converts all headers to lowercase, so we need to convert the key to lowercase too.
+  return req.headers[idHeaderName.toLowerCase()] as string
+}
+
+/**
  * Returns results from API Gateway
  *
  * @param {Qbject} request
@@ -90,7 +98,7 @@ export default async function queryApiGateway(req: IncomingMessage): Promise<Cla
 
   const apiUrlParams: QueryParams = {
     user_key: apiEnvVars.apiUserKey,
-    uniqueNumber: req.headers[apiEnvVars.idHeaderName] as string,
+    uniqueNumber: getUniqueNumber(req, apiEnvVars.idHeaderName),
   }
 
   const apiUrl: RequestInfo = buildApiUrl(apiEnvVars.apiUrl, apiUrlParams)


### PR DESCRIPTION
## Changes

- Breaks out retrieving the unique number into a separate helper function for easier testing
- Converts the `ID_HEADER_NAME` env var to lowercase

## Context

I discovered that the `req` argument in `GetServerSideProps()` passes the header keys as lowercase (e.g. `user-agent` instead of `User-Agent`). To be able to retrieve the unique number correctly, we need to convert the value of `ID_HEADER_NAME` env var to lowercase as well.

## Testing Instructions

`yarn test`