### PR TITLE
Use default nextjs error page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -79,6 +79,8 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale }) =>
     // Run business logic to get content for the current scenario.
     scenarioContent = getScenarioContent(claimData)
   } catch (error) {
+    // If an error occurs, log it and show 500.
+    logger.error(error)
     errorCode = 500
   }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,7 @@ import { ReactElement } from 'react'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { GetServerSideProps } from 'next'
+import Error from 'next/error'
 
 import { Header } from '../components/Header'
 import { Main } from '../components/Main'
@@ -13,15 +14,16 @@ import { WorkInProgress } from '../components/WorkInProgress'
 
 import queryApiGateway from '../utils/queryApiGateway'
 import getScenarioContent from '../utils/getScenarioContent'
-import { ScenarioContent } from '../types/common'
+import { Claim, ScenarioContent } from '../types/common'
 import { useRouter } from 'next/router'
 
 export interface HomeProps {
   scenarioContent: ScenarioContent
   loading: boolean
+  errorCode?: number | null
 }
 
-export default function Home({ scenarioContent, loading }: HomeProps): ReactElement {
+export default function Home({ scenarioContent, loading, errorCode = null }: HomeProps): ReactElement {
   const { t } = useTranslation('common')
 
   // Note whether the user came from the main UIO website or UIO Mobile, and match
@@ -29,6 +31,22 @@ export default function Home({ scenarioContent, loading }: HomeProps): ReactElem
   const router = useRouter()
   const userArrivedFromUioMobile = router.query?.from === 'uiom'
 
+  // If any errorCode is provided, render the error page.
+  let mainComponent: JSX.Element
+  if (errorCode) {
+    mainComponent = <Error statusCode={errorCode} />
+  } else {
+    mainComponent = (
+      <Main
+        loading={loading}
+        userArrivedFromUioMobile={userArrivedFromUioMobile}
+        statusContent={scenarioContent.statusContent}
+        detailsContent={scenarioContent.detailsContent}
+      />
+    )
+  }
+
+  // Otherwise, render normally.
   return (
     <Container fluid className="index">
       <Head>
@@ -38,12 +56,7 @@ export default function Home({ scenarioContent, loading }: HomeProps): ReactElem
       </Head>
       <WorkInProgress />
       <Header userArrivedFromUioMobile={userArrivedFromUioMobile} />
-      <Main
-        loading={loading}
-        userArrivedFromUioMobile={userArrivedFromUioMobile}
-        statusContent={scenarioContent.statusContent}
-        detailsContent={scenarioContent.detailsContent}
-      />
+      {mainComponent}
       <Footer />
       {console.dir({ scenarioContent })} {/* @TODO: Remove. For development purposes only. */}
     </Container>
@@ -55,17 +68,26 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale }) =>
   const logger = isProd ? pino({}) : pino({ prettyPrint: true })
   logger.info(req)
 
-  // Make the API request and return the data.
-  const claimData = await queryApiGateway(req)
+  let errorCode: number | null = null
+  let claimData: Claim | null = null
+  let scenarioContent: ScenarioContent | null = null
 
-  // Run business logic to get content for the current scenario.
-  const scenarioContent = getScenarioContent(claimData)
+  try {
+    // Make the API request and return the data.
+    claimData = await queryApiGateway(req)
+
+    // Run business logic to get content for the current scenario.
+    scenarioContent = getScenarioContent(claimData)
+  } catch (error) {
+    errorCode = 500
+  }
 
   // Return Props.
   return {
     props: {
       scenarioContent: scenarioContent,
       loading: false,
+      errorCode: errorCode,
       ...(await serverSideTranslations(locale || 'en', ['common', 'claim-status'])),
     },
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,7 @@ import { WorkInProgress } from '../components/WorkInProgress'
 
 import queryApiGateway from '../utils/queryApiGateway'
 import getScenarioContent from '../utils/getScenarioContent'
-import { Claim, ScenarioContent } from '../types/common'
+import { ScenarioContent } from '../types/common'
 import { useRouter } from 'next/router'
 
 export interface HomeProps {
@@ -69,12 +69,11 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale }) =>
   logger.info(req)
 
   let errorCode: number | null = null
-  let claimData: Claim | null = null
   let scenarioContent: ScenarioContent | null = null
 
   try {
     // Make the API request and return the data.
-    claimData = await queryApiGateway(req)
+    const claimData = await queryApiGateway(req)
 
     // Run business logic to get content for the current scenario.
     scenarioContent = getScenarioContent(claimData)

--- a/stories/Page.stories.tsx
+++ b/stories/Page.stories.tsx
@@ -16,4 +16,5 @@ const Template: Story<HomeProps> = (args) => <Home {...args} />
 export const Page = Template.bind({})
 Page.args = {
   scenarioContent: MainStories.Main.args as ScenarioContent,
+  errorCode: null,
 }


### PR DESCRIPTION
## Changes

- Display default next.js error page if an error is encountered when querying the API gateway

## Context

For #242, I want to be able to throw errors and have them caught & display a 500 error (we may want to display 404 in some cases, but I'm not sure which ones yet).

I attempted to move the [`getServerSideProps()`](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) logic out of index.tsx and into main.tsx. However, I discovered that you can only use it in [Page level](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) components. In light of this, I have [changed my mind](https://github.com/cagov/ui-claim-tracker/pull/256#discussion_r658328707) and think that we should collapse main.tsx directly into index.tsx (not included in this PR). Let me know if this sounds good and I can make a ticket for it/feel free to make a ticket for it.

Note that we have a separate ticket (#123) for customizing the default next.js error pages.

## Test

`yarn storybook`