### PR TITLE
Add complex value to the Page story

### DIFF
--- a/stories/Page.stories.tsx
+++ b/stories/Page.stories.tsx
@@ -15,6 +15,7 @@ export default {
       type: { name: ScenarioType, required: false },
       options: Object.keys(ScenarioType),
       mapping: Object.keys(ScenarioType), // return the key instead of the value
+      defaultValue: 'BaseNoPending',
       control: {
         type: 'select',
         labels: ScenarioType,
@@ -29,11 +30,7 @@ interface StoryHomeProps extends HomeProps {
 }
 
 const Template: Story<StoryHomeProps> = ({ ...args }) => {
-  let scenarioType: ScenarioType = ScenarioType.BaseNoPending
-  if (args.scenario) {
-    scenarioType = ScenarioType[args.scenario]
-  }
-  args.scenarioContent = getScenarioContent(apiGatewayStub(scenarioType))
+  args.scenarioContent = getScenarioContent(apiGatewayStub(ScenarioType[args.scenario]))
   return <Home {...args} />
 }
 

--- a/stories/Page.stories.tsx
+++ b/stories/Page.stories.tsx
@@ -2,19 +2,42 @@ import { Story, Meta } from '@storybook/react'
 import { withNextRouter } from 'storybook-addon-next-router'
 
 import Home, { HomeProps } from '../pages/index'
-import * as MainStories from './Main.stories'
-import { ScenarioContent } from '../types/common'
+import getScenarioContent, { ScenarioType, ScenarioTypeKey } from '../utils/getScenarioContent'
+import apiGatewayStub from '../utils/apiGatewayStub'
 
+// See https://storybook.js.org/docs/riot/essentials/controls#dealing-with-complex-values
 export default {
   title: 'Claim Tracker/Page',
   component: Home,
   decorators: [withNextRouter],
+  argTypes: {
+    scenario: {
+      type: { name: ScenarioType, required: false },
+      options: Object.keys(ScenarioType),
+      mapping: Object.keys(ScenarioType), // return the key instead of the value
+      control: {
+        type: 'select',
+        labels: ScenarioType,
+      },
+    },
+  },
 } as Meta
 
-const Template: Story<HomeProps> = (args) => <Home {...args} />
+// Extend HomeProps to add a complex story value
+interface StoryHomeProps extends HomeProps {
+  scenario: ScenarioTypeKey
+}
+
+const Template: Story<StoryHomeProps> = ({ ...args }) => {
+  let scenarioType: ScenarioType = ScenarioType.BaseNoPending
+  if (args.scenario) {
+    scenarioType = ScenarioType[args.scenario]
+  }
+  args.scenarioContent = getScenarioContent(apiGatewayStub(scenarioType))
+  return <Home {...args} />
+}
 
 export const Page = Template.bind({})
 Page.args = {
-  scenarioContent: MainStories.Main.args as ScenarioContent,
   errorCode: null,
 }

--- a/stories/Page.stories.tsx
+++ b/stories/Page.stories.tsx
@@ -12,7 +12,6 @@ export default {
   decorators: [withNextRouter],
   argTypes: {
     scenario: {
-      type: { name: ScenarioType, required: false },
       options: Object.keys(ScenarioType),
       mapping: Object.keys(ScenarioType), // return the key instead of the value
       defaultValue: 'BaseNoPending',

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -16,9 +16,11 @@ export interface ClaimDetailsResult {
 
 export interface Claim {
   ClaimType?: null | undefined | string
+  uniqueNumber?: null | string
+  claimDetails?: null | ClaimDetailsResult
   hasPendingWeeks?: null | undefined | boolean
+  hasCertificationWeeksAvailable?: null | boolean
   pendingDetermination?: null | [PendingDetermination]
-  claimDetails?: ClaimDetailsResult
 }
 
 // Type interfaces for Claim Status and Claim Details

--- a/utils/apiGatewayStub.tsx
+++ b/utils/apiGatewayStub.tsx
@@ -1,0 +1,35 @@
+import { ScenarioType } from '../utils/getScenarioContent'
+import { Claim } from '../types/common'
+
+/**
+ * Stub the API gateway response for a given scenario.
+ */
+export default function apiGatewayStub(scenarioType: ScenarioType): Claim {
+  console.log('apiGatewayStub')
+  const claim: Claim = {
+    uniqueNumber: null,
+    claimDetails: null,
+    hasCertificationWeeksAvailable: false,
+    hasPendingWeeks: false,
+    pendingDetermination: null,
+  }
+
+  switch (scenarioType) {
+    case ScenarioType.PendingDetermination:
+      claim.pendingDetermination = [{ determinationStatus: null }]
+      break
+
+    case ScenarioType.BasePending:
+      claim.hasPendingWeeks = true
+      break
+
+    // @TODO: This scenario should probably not be the default case.
+    // case ScenarioType.BaseNoPending:
+
+    // @TODO: No match should throw an error
+    // default:
+    //   throw new Error('Unknown scenario type')
+  }
+
+  return claim
+}

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -1,5 +1,7 @@
 import { Claim, ClaimDetailsContent, ClaimStatusContent, ScenarioContent } from '../types/common'
 
+export type ScenarioTypeKey = keyof typeof ScenarioType
+
 export enum ScenarioType {
   PendingDetermination = 'Pending determination scenario',
   BasePending = 'Base state with pending weeks',


### PR DESCRIPTION
## Changes

- Adds the ability to select a scenario in the `Page` story to display all content that will be displayed for that scenario (currently only the Claim Status description)
- Removes the JSON blob for `scenarioContent` on the `Page` story (causes conflicts)
- Adds`apiGatewayStub` function to stub responses from the API gateway (now needed for both tests and stories)
- Builds out the `Claim` type a little bit more

## Context

I'm getting close to the point where I'm going to stop displaying placeholder content when the request doesn't contain the unique number. So I need a way to view the content for each scenario. 

This PR sets the foundation for more complex story controls. In a near-future PR, I'll likely extend this foundation so that we can also specify whether there are certification weeks available (which impacts what Next Steps are shown).

## Testing

`yarn storybook`
