### PR TITLE
Azure pipelines should only install production dependencies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,14 +4,13 @@
 # https://aka.ms/yaml
 
 trigger:
-- main
-
+  - main
 
 # no PR triggers
 pr: none
 
 pool:
-  vmImage: "ubuntu-latest"
+  vmImage: 'ubuntu-latest'
 
 steps:
   - task: NodeAndNpmTool@1
@@ -21,7 +20,7 @@ steps:
 
   - script: sudo npm install -g yarn
 
-  - script: yarn install
+  - script: yarn install --production
     displayName: 'Install dependencies'
 
   - script: yarn build
@@ -29,14 +28,14 @@ steps:
 
   - task: ArchiveFiles@2
     inputs:
-      rootFolderOrFile: "$(build.sourcesDirectory)"
+      rootFolderOrFile: '$(build.sourcesDirectory)'
       includeRootFolder: false
 
   - script: zip -r --symlinks '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip' .
     displayName: 'ZIP com SymLinks'
 
   - task: PublishBuildArtifacts@1
-    displayName: "Publish artifacts: drop"
+    displayName: 'Publish artifacts: drop'
 
   - task: Veracode@3
     displayName: 'Upload and scan: $(build.artifactstagingdirectory)'


### PR DESCRIPTION
## Ticket

Closes #285 

## Changes

- Updates Azure Pipelines to only install production dependencies

## Context

We don't need to install development dependencies on production environments and can reduce are attack surface area by reducing the number of dependencies that are installed in prod.

## Test

1. Open Azure Devops
2. Run a pipeline for this branch