### PR TITLE
Configure streaming to Application Insights 

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,16 +1,16 @@
 const { i18n } = require('./next-i18next.config')
 
-const isProd = process.env.NODE_ENV === 'production'
+const isAzureEnv = process.env.NODE_ENV === 'production'
 
 module.exports = {
-  // The Claim Tracker application must live at /claimstatus because IDM Webgate 
+  // The Claim Tracker application must live at /claimstatus because IDM Webgate
   // expects the "context root" to be /claimstatus, and all other pages must be sub-paths.
   basePath: '/claimstatus',
-  assetPrefix: isProd ? '/claimstatus' : '',
+  assetPrefix: isAzureEnv ? '/claimstatus' : '',
   i18n,
   webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
     config.node = {
-      fs: 'empty'
+      fs: 'empty',
     }
     return config
   },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "next": "10.0.8",
     "node-fetch": "^2.6.1",
     "pino": "^6.11.3",
+    "pino-applicationinsights": "^2.1.0",
     "react": "17.0.1",
     "react-bootstrap": "^1.5.2",
     "react-dom": "17.0.1"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@testing-library/react": "^11.2.5",
     "@types/node": "^14.14.33",
     "@types/pem": "^1.9.5",
+    "@types/pumpify": "^1.4.1",
     "@types/react": "^17.0.3",
     "@types/react-test-renderer": "^17.0.1",
     "@typescript-eslint/eslint-plugin": "^4.19.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -86,13 +86,13 @@ export default function Home({
 }
 
 export const getServerSideProps: GetServerSideProps = async ({ req, locale }) => {
-  const isProd = process.env.NODE_ENV === 'production'
+  const isAzureEnv = process.env.NODE_ENV === 'production'
 
-  // Pino: use pretty print and log to STDOUT if not in production mode.
+  // Pino: use pretty print and log to STDOUT for local environments.
   let logger = pino({ prettyPrint: true })
 
   // Pino: otherwise, log to Azure Application Insights.
-  if (isProd) {
+  if (isAzureEnv) {
     const appInsightsStream = await appInsights.createWriteStream()
     logger = pino(appInsightsStream)
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,8 @@
 import Head from 'next/head'
 import Container from 'react-bootstrap/Container'
 import pino from 'pino'
+import appInsights from 'pino-applicationinsights'
+// import appInsights = require('pino-applicationinsights')
 import { ReactElement } from 'react'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
@@ -85,8 +87,17 @@ export default function Home({
 }
 
 export const getServerSideProps: GetServerSideProps = async ({ req, locale }) => {
-  const isProd = process.env.NODE_ENV === 'production'
-  const logger = isProd ? pino({}) : pino({ prettyPrint: true })
+  // const isProd = process.env.NODE_ENV === 'production'
+  const isProd = true
+
+  let logger = pino({ prettyPrint: true })
+  if (isProd) {
+    const appInsightsStream = await appInsights.createWriteStream({ key: 'something' })
+    // const appInsightsStream = await createWriteStream({ key: 'something' })
+    console.log(appInsightsStream)
+    logger = pino(appInsightsStream)
+  }
+
   logger.info(req)
 
   let errorCode: number | null = null
@@ -100,7 +111,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale }) =>
     scenarioContent = getScenarioContent(claimData)
   } catch (error) {
     // If an error occurs, log it and show 500.
-    logger.error(error)
+    logger.error(error, 'Application error')
     errorCode = 500
   }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -93,7 +93,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale }) =>
 
   // Pino: otherwise, log to Azure Application Insights.
   if (isProd) {
-    const appInsightsStream = await appInsights.createWriteStream({ key: 'something' })
+    const appInsightsStream = await appInsights.createWriteStream()
     logger = pino(appInsightsStream)
   }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,6 @@ import Head from 'next/head'
 import Container from 'react-bootstrap/Container'
 import pino from 'pino'
 import appInsights from 'pino-applicationinsights'
-// import appInsights = require('pino-applicationinsights')
 import { ReactElement } from 'react'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
@@ -87,14 +86,14 @@ export default function Home({
 }
 
 export const getServerSideProps: GetServerSideProps = async ({ req, locale }) => {
-  // const isProd = process.env.NODE_ENV === 'production'
-  const isProd = true
+  const isProd = process.env.NODE_ENV === 'production'
 
+  // Pino: use pretty print and log to STDOUT if not in production mode.
   let logger = pino({ prettyPrint: true })
+
+  // Pino: otherwise, log to Azure Application Insights.
   if (isProd) {
     const appInsightsStream = await appInsights.createWriteStream({ key: 'something' })
-    // const appInsightsStream = await createWriteStream({ key: 'something' })
-    console.log(appInsightsStream)
     logger = pino(appInsightsStream)
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,10 +14,6 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "ts-node": {
-    "files": true
-  },
-  "files": ["types/pino-applicationinsights/index.d.ts"],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types"],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -18,12 +14,10 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "ts-node": {
+    "files": true
+  },
+  "files": ["types/pino-applicationinsights/index.d.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types"],
+  "exclude": ["node_modules"]
 }

--- a/types/pino-applicationinsights/index.d.ts
+++ b/types/pino-applicationinsights/index.d.ts
@@ -1,0 +1,9 @@
+declare module 'pino-applicationinsights' {
+  import Pumpify from 'pumpify'
+
+  interface WriteStreamOptions {
+    key?: string
+  }
+
+  function createWriteStream(options: WriteStreamOptions): Promise<Pumpify>
+}

--- a/types/pino-applicationinsights/index.d.ts
+++ b/types/pino-applicationinsights/index.d.ts
@@ -1,9 +1,11 @@
 declare module 'pino-applicationinsights' {
   import Pumpify from 'pumpify'
+  import ApplicationInsights from 'appliactioninsights'
 
   interface WriteStreamOptions {
     key?: string
+    setup?: (applicationInsights: ApplicationInsights) => void
   }
 
-  function createWriteStream(options: WriteStreamOptions): Promise<Pumpify>
+  function createWriteStream(options?: WriteStreamOptions): Promise<Pumpify>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3103,6 +3103,13 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/duplexify@*":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@types/duplexify/-/duplexify-3.6.0.tgz#dfc82b64bd3a2168f5bd26444af165bf0237dcd8"
+  integrity sha512-5zOA53RUlzN74bvrSGwjudssD9F3a797sDZQkiYpUOxW+WHaXTCPz4/d5Dgi6FKnOqZ2CpaTo0DhgIfsXAOE/A==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob-base@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@types/glob-base/-/glob-base-0.3.0.tgz#a581d688347e10e50dd7c17d6f2880a10354319d"
@@ -3316,6 +3323,14 @@
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/pumpify@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@types/pumpify/-/pumpify-1.4.1.tgz#5a0650f39a3f8f077c7e544d0c5ae2899b28394c"
+  integrity sha512-l7u/Dnh1OG9T7VH6TvulR0g8oE8hgIW5409mSUKi8Vxw2+JV18aTa06Sv5bvNjrD0zbsB/cuZ/iTFQgFNfzIuw==
+  dependencies:
+    "@types/duplexify" "*"
+    "@types/node" "*"
 
 "@types/qs@^6.9.5":
   version "6.9.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3938,6 +3938,16 @@ app-root-dir@^1.0.2:
   resolved "https://registry.yarnpkg.com/app-root-dir/-/app-root-dir-1.0.2.tgz#38187ec2dea7577fff033ffcb12172692ff6e118"
   integrity sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=
 
+applicationinsights@^1.8.3:
+  version "1.8.10"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.8.10.tgz#fffa482cd1519880fb888536a87081ac05130667"
+  integrity sha512-ZLDA7mShh4mP2Z/HlFolmvhBPX1LfnbIWXrselyYVA7EKjHhri1fZzpu2EiWAmfbRxNBY6fRjoPJWbx5giKy4A==
+  dependencies:
+    cls-hooked "^4.2.2"
+    continuation-local-storage "^3.2.1"
+    diagnostic-channel "0.3.1"
+    diagnostic-channel-publishers "0.4.4"
+
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -4136,10 +4146,25 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
+async-hook-jl@^1.7.6:
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
+  integrity sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==
+  dependencies:
+    stack-chain "^1.3.7"
+
 async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
+async-listener@^0.6.0:
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.10.tgz#a7c97abe570ba602d782273c0de60a51e3e17cbc"
+  integrity sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==
+  dependencies:
+    semver "^5.3.0"
+    shimmer "^1.1.0"
 
 async-retry@^1.3.1:
   version "1.3.1"
@@ -4469,6 +4494,13 @@ batch-processor@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/batch-processor/-/batch-processor-1.0.0.tgz#75c95c32b748e0850d10c2b168f6bdbe9891ace8"
   integrity sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg=
+
+batch2@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/batch2/-/batch2-2.0.0.tgz#5dfd62e73aa895dd0f151ffffc2bd8822171d590"
+  integrity sha512-aUjwtuR/V1pgc6nTkao5T/vvNrvbX70iseoYijPjydc48dYzyCxHOWwlNAdSbK5aC609cSAfTsZKSUhVpVbzRQ==
+  dependencies:
+    through2 "^4.0.2"
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -5215,6 +5247,15 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+cls-hooked@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
+  integrity sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
+  dependencies:
+    async-hook-jl "^1.7.6"
+    emitter-listener "^1.0.1"
+    semver "^5.4.1"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -5299,7 +5340,7 @@ commander@^4.1.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-commander@^6.2.0, commander@^6.2.1:
+commander@^6.1.0, commander@^6.2.0, commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
@@ -5382,6 +5423,14 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
+
+continuation-local-storage@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz#11f613f74e914fe9b34c92ad2d28fe6ae1db7ffb"
+  integrity sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==
+  dependencies:
+    async-listener "^0.6.0"
+    emitter-listener "^1.1.1"
 
 convert-source-map@1.7.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.7.0"
@@ -5916,6 +5965,18 @@ detect-port@^1.3.0:
     address "^1.0.1"
     debug "^2.6.0"
 
+diagnostic-channel-publishers@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.4.tgz#57c3b80b7e7f576f95be3a257d5e94550f0082d6"
+  integrity sha512-l126t01d2ZS9EreskvEtZPrcgstuvH3rbKy82oUhUrVmBaGx4hO9wECdl3cvZbKDYjMF3QJDB5z5dL9yWAjvZQ==
+
+diagnostic-channel@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz#7faa143e107f861be3046539eb4908faab3f53fd"
+  integrity sha512-6eb9YRrimz8oTr5+JDzGmSYnXy5V7YnK5y/hd8AUDK1MssHjQKm9LlD6NSrHx4vMDF3+e/spI2hmWTviElgWZA==
+  dependencies:
+    semver "^5.3.0"
+
 diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
@@ -6115,6 +6176,16 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+duplexify@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-4.1.1.tgz#7027dc374f157b122a8ae08c2d3ea4d2d953aa61"
+  integrity sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==
+  dependencies:
+    end-of-stream "^1.4.1"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+    stream-shift "^1.0.0"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -6157,6 +6228,18 @@ elliptic@^6.5.3:
     inherits "^2.0.4"
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
+
+emitter-component@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/emitter-component/-/emitter-component-1.1.1.tgz#065e2dbed6959bf470679edabeaf7981d1003ab6"
+  integrity sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY=
+
+emitter-listener@^1.0.1, emitter-listener@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
+  integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
+  dependencies:
+    shimmer "^1.2.0"
 
 emittery@^0.7.1:
   version "0.7.2"
@@ -6207,7 +6290,7 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -10983,6 +11066,19 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
+pino-applicationinsights@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pino-applicationinsights/-/pino-applicationinsights-2.1.0.tgz#145da81717fffff24c2344aeff8e569539359d5a"
+  integrity sha512-4xzTOfYOzfoUoAkid3LWZBbYeXF76EU+9OWymxqMP1YODVu0sIyWTu7LwbWjImkY8z42iciNjSLIY+DyZYOMgA==
+  dependencies:
+    applicationinsights "^1.8.3"
+    batch2 "^2.0.0"
+    commander "^6.1.0"
+    fast-json-parse "^1.0.3"
+    pumpify "^2.0.1"
+    split2 "^3.2.2"
+    stream "0.0.2"
+
 pino-pretty@^4.8.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-4.8.0.tgz#f2f3055bf222456217b14ffb04d8be0a0cc17fce"
@@ -11428,6 +11524,15 @@ pumpify@^1.3.3:
     duplexify "^3.6.0"
     inherits "^2.0.3"
     pump "^2.0.0"
+
+pumpify@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-2.0.1.tgz#abfc7b5a621307c728b551decbbefb51f0e4aa1e"
+  integrity sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==
+  dependencies:
+    duplexify "^4.1.1"
+    inherits "^2.0.3"
+    pump "^3.0.0"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -11900,7 +12005,7 @@ read-pkg@^5.2.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.0, readable-stream@^3.1.1, readable-stream@^3.5.0, readable-stream@^3.6.0:
+readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.1.1, readable-stream@^3.5.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -12504,7 +12609,7 @@ semver-regex@^3.1.2:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.2.tgz#34b4c0d361eef262e07199dbef316d0f2ab11807"
   integrity sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -12653,6 +12758,11 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+shimmer@^1.1.0, shimmer@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
+  integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -12846,7 +12956,7 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-split2@^3.1.1:
+split2@^3.1.1, split2@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/split2/-/split2-3.2.2.tgz#bf2cf2a37d838312c249c89206fd7a17dd12365f"
   integrity sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==
@@ -12891,6 +13001,11 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
+
+stack-chain@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
+  integrity sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=
 
 stack-utils@^2.0.2:
   version "2.0.3"
@@ -12997,6 +13112,13 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+stream@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stream/-/stream-0.0.2.tgz#7f5363f057f6592c5595f00bc80a27f5cec1f0ef"
+  integrity sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=
+  dependencies:
+    emitter-component "^1.1.1"
 
 string-argv@0.3.1:
   version "0.3.1"
@@ -13423,6 +13545,13 @@ through2@^2.0.0, through2@~2.0.3:
   dependencies:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
+
+through2@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-4.0.2.tgz#a7ce3ac2a7a8b0b966c80e7c49f0484c3b239764"
+  integrity sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==
+  dependencies:
+    readable-stream "3"
 
 through@^2.3.6, through@^2.3.8:
   version "2.3.8"


### PR DESCRIPTION
## Ticket

Related to #218 

## Changes

- Adds [`pino-applicationinsights`](https://github.com/ovhemert/pino-applicationinsights) as a dependency to log directly to Azure Application Insights in Production
- Adds a type declaration file for `pino-applicationinsights`

## Context

To facilitate setting up and tuning alerts, I'm using `pino-applicationinsights`'s [`createWriteStream()`](https://github.com/ovhemert/pino-applicationinsights/blob/master/docs/API.md) for Production environments (i.e. `process.env.NODE_ENV === 'production'`). In non-prod environments, `pino` will work as before (outputting to STDOUT and using pretty print).

Because `pino` is able to take a [WritableStream as a `destination`](https://github.com/pinojs/pino/blob/master/docs/api.md#destination), I didn't need to use [`pino-multi-stream`](https://github.com/pinojs/pino-multi-stream).

Note: This change means that in Production environments, we will no longer see the output of any `logger.whatever()` calls in the Azure App Services App Stream or Log Analytics. Instead, the output will go directly to the associated Azure Application Insights Logs (in the `traces` table).

Because `pino-applicationinsights` is basically a very nice wrapper around [`applicationinsights`](https://github.com/microsoft/ApplicationInsights-node.js#readme), it needs an Application Insights instrumentation key in order to send logs to the write App Insights. By default, `pino-applicationinsights` knows to look for `process.env.APPINSIGHTS_INSTRUMENTATIONKEY`.

### Type Declaration

Because `pino-applicationinsights` doesn't have a type declaration and none exists for this package in [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/), I created a rough one. I've opened #289 to polish it up and submit a PR to DefinitelyTyped. 

## Testing

1. Run a pipeline for this branch
2. Release the pipeline on a non-prod environment 
3. Navigate to the claim tracker URL in the non-prod environment
4. Trigger an error (will throw 500s right now because of unrelated certificate issue)
5. Navigate to Application Insights (not App Services!) in matching non-prod environment
6. View Logs and query for `traces` (may take a couple minutes for the logs to populate)
7. You should see a SEV3 with the message "Application error" for the timestamp that you loaded the page:
<img width="838" alt="Screen Shot 2021-07-07 at 4 40 13 PM" src="https://user-images.githubusercontent.com/67701/124841406-0171c180-df42-11eb-8c96-5c246fcb0d8e.png">
