### PR TITLE
Small storybook fixes

### DIFF
--- a/stories/ClaimStatus.stories.tsx
+++ b/stories/ClaimStatus.stories.tsx
@@ -11,6 +11,6 @@ const Template: Story<ClaimStatusProps> = (args) => <ClaimStatusComponent {...ar
 
 export const ClaimStatus = Template.bind({})
 ClaimStatus.args = {
-  statusDescription: 'claim-status:base-pending.description',
+  statusDescription: 'claim-status:scenarios:scenario1.description',
   nextSteps: ['step one', 'step two'],
 }

--- a/stories/Page.stories.tsx
+++ b/stories/Page.stories.tsx
@@ -20,6 +20,11 @@ export default {
         labels: ScenarioTypeNames,
       },
     },
+    errorCode: {
+      control: {
+        type: 'text',
+      },
+    },
   },
 } as Meta
 


### PR DESCRIPTION
## Changes

- Fixes the `ClaimStatus` story for the new scenarios as of #266 
- Fixes the `errorCode` control on Page after #305 

## Context

A couple very small storybook-related fixes.

## Testing

While #299 is not resolved, comment out these lines and then run `yarn storybook`: https://github.com/cagov/ui-claim-tracker/blob/32990f892c6b84017c30af5d273fdd94410649e7/pages/index.tsx#L95-L98
