### PR TITLE
Split out getClaimStatus

### DIFF
--- a/tests/utils/getClaimStatus.test.tsx
+++ b/tests/utils/getClaimStatus.test.tsx
@@ -1,0 +1,14 @@
+import { getClaimStatusDescription } from '../../utils/getClaimStatus'
+import { ScenarioType } from '../../utils/getScenarioContent'
+import { getNumericEnumKeys } from '../../utils/numericEnum'
+
+// Test getClaimStatusDescripton()
+describe('Getting the Claim Status description', () => {
+  it('returns the correct description for the scenario', () => {
+    for (const key of getNumericEnumKeys(ScenarioType)) {
+      expect(getClaimStatusDescription(key)).toEqual(
+        expect.stringMatching(/claim-status:scenarios.scenario[0-9]+.description/),
+      )
+    }
+  })
+})

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -1,21 +1,5 @@
-import { getClaimStatusDescription, getScenario, ScenarioType } from '../../utils/getScenarioContent'
+import { getScenario, ScenarioType } from '../../utils/getScenarioContent'
 import apiGatewayStub from '../../utils/apiGatewayStub'
-import { getNumericEnumKeys } from '../../utils/numericEnum'
-
-/**
- * Begin tests
- */
-
-// Test getClaimStatusDescripton()
-describe('Getting the Claim Status description', () => {
-  it('returns the correct description for the scenario', () => {
-    for (const key of getNumericEnumKeys(ScenarioType)) {
-      expect(getClaimStatusDescription(key)).toEqual(
-        expect.stringMatching(/claim-status:scenarios.scenario[0-9]+.description/),
-      )
-    }
-  })
-})
 
 /**
  * Test getScenario()

--- a/utils/getClaimStatus.tsx
+++ b/utils/getClaimStatus.tsx
@@ -1,0 +1,28 @@
+/**
+ * Utility file to get content for the Claim Status section.
+ */
+
+import { ClaimStatusContent, I18nString } from '../types/common'
+import { ScenarioType } from './getScenarioContent'
+
+/**
+ * Get Claim Status description content.
+ */
+export function getClaimStatusDescription(scenarioType: ScenarioType): I18nString {
+  return `claim-status:scenarios.${ScenarioType[scenarioType].toLowerCase()}.description`
+}
+
+/**
+ * Get combined Claim Status content.
+ */
+export default function getClaimStatus(scenarioType: ScenarioType): ClaimStatusContent {
+  const statusContent: ClaimStatusContent = {
+    statusDescription: getClaimStatusDescription(scenarioType),
+    nextSteps: [
+      'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+      'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
+    ],
+  }
+
+  return statusContent
+}

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -7,8 +7,9 @@
  * description in ScenarioTypeNames for easy(ish) reference.
  */
 
-import { Claim, ClaimDetailsContent, ClaimStatusContent, I18nString, ScenarioContent } from '../types/common'
+import { Claim, ClaimDetailsContent, ScenarioContent } from '../types/common'
 import getClaimDetails from './getClaimDetails'
+import getClaimStatus from './getClaimStatus'
 
 export enum ScenarioType {
   Scenario1,
@@ -62,28 +63,6 @@ export function getScenario(claimData: Claim): ScenarioType {
 }
 
 /**
- * Get Claim Status description content.
- */
-export function getClaimStatusDescription(scenarioType: ScenarioType): I18nString {
-  return `claim-status:scenarios.${ScenarioType[scenarioType].toLowerCase()}.description`
-}
-
-/**
- * Get Claim Status content.
- */
-export function buildClaimStatusContent(scenarioType: ScenarioType): ClaimStatusContent {
-  const statusContent: ClaimStatusContent = {
-    statusDescription: getClaimStatusDescription(scenarioType),
-    nextSteps: [
-      'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
-      'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-    ],
-  }
-
-  return statusContent
-}
-
-/**
  * Return scenario content.
  */
 export default function getScenarioContent(claimData: Claim): ScenarioContent {
@@ -91,7 +70,7 @@ export default function getScenarioContent(claimData: Claim): ScenarioContent {
   const scenarioType = getScenario(claimData)
 
   // Construct claim status content.
-  const statusContent = buildClaimStatusContent(scenarioType)
+  const statusContent = getClaimStatus(scenarioType)
 
   // Construct claim details content.
   if (!claimData.claimDetails) {


### PR DESCRIPTION
## Ticket

Resolves #310 

## Changes

- Breaks out a separate `getClaimStatus.tsx` file

## Context

The upcoming PR for #291 is going to add a lot of changes related to claim status, so I'm breaking out a smaller PR in anticipation of that work.

Note: This PR stacks on top of #307 

## Testing

`yarn test`