### PR TITLE
Update base state and pending state scenarios

### DIFF
--- a/components/ClaimSection.tsx
+++ b/components/ClaimSection.tsx
@@ -9,11 +9,7 @@ export interface ClaimSectionProps extends ScenarioContent {
 export const ClaimSection: React.FC<ClaimSectionProps> = ({ loading = false, statusContent, detailsContent }) => {
   return (
     <div className="claim-section">
-      <ClaimStatus
-        loading={loading}
-        statusDescription={statusContent.statusDescription}
-        nextSteps={statusContent.nextSteps}
-      />
+      <ClaimStatus loading={loading} heading={statusContent.heading} nextSteps={statusContent.nextSteps} />
       <ClaimDetails
         loading={loading}
         programType={detailsContent.programType}

--- a/components/ClaimSection.tsx
+++ b/components/ClaimSection.tsx
@@ -9,7 +9,12 @@ export interface ClaimSectionProps extends ScenarioContent {
 export const ClaimSection: React.FC<ClaimSectionProps> = ({ loading = false, statusContent, detailsContent }) => {
   return (
     <div className="claim-section">
-      <ClaimStatus loading={loading} heading={statusContent.heading} nextSteps={statusContent.nextSteps} />
+      <ClaimStatus
+        loading={loading}
+        heading={statusContent.heading}
+        summary={statusContent.summary}
+        nextSteps={statusContent.nextSteps}
+      />
       <ClaimDetails
         loading={loading}
         programType={detailsContent.programType}

--- a/components/ClaimStatus.tsx
+++ b/components/ClaimStatus.tsx
@@ -2,13 +2,14 @@ import { useTranslation } from 'next-i18next'
 
 import { NextSteps } from './NextSteps'
 import { TextLine } from './TextLine'
+import { TransLine } from './TransLine'
 import { ClaimStatusContent } from '../types/common'
 
 export interface ClaimStatusProps extends ClaimStatusContent {
   loading: boolean
 }
 
-export const ClaimStatus: React.FC<ClaimStatusProps> = ({ loading = false, heading, nextSteps }) => {
+export const ClaimStatus: React.FC<ClaimStatusProps> = ({ loading = false, heading, summary, nextSteps }) => {
   const { t } = useTranslation(['common', 'claim-status'])
 
   return (
@@ -16,6 +17,9 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({ loading = false, headi
       <h2>{t('claim-status.title')}</h2>
       <div className="pending-status">
         <TextLine loading={loading} text={t(heading)} />
+      </div>
+      <div className="summary">
+        <TransLine i18nKey={summary.i18nKey} links={summary.links} />
       </div>
       <div className="status-box">
         <div className="topbar">

--- a/components/ClaimStatus.tsx
+++ b/components/ClaimStatus.tsx
@@ -8,14 +8,14 @@ export interface ClaimStatusProps extends ClaimStatusContent {
   loading: boolean
 }
 
-export const ClaimStatus: React.FC<ClaimStatusProps> = ({ loading = false, statusDescription, nextSteps }) => {
+export const ClaimStatus: React.FC<ClaimStatusProps> = ({ loading = false, heading, nextSteps }) => {
   const { t } = useTranslation(['common', 'claim-status'])
 
   return (
     <div className="claim-status">
       <h2>{t('claim-status.title')}</h2>
       <div className="pending-status">
-        <TextLine loading={loading} text={t(statusDescription)} />
+        <TextLine loading={loading} text={t(heading)} />
       </div>
       <div className="status-box">
         <div className="topbar">

--- a/components/TransLine.tsx
+++ b/components/TransLine.tsx
@@ -2,7 +2,7 @@ import { Trans } from 'react-i18next'
 import React from 'react'
 import { TransLineProps } from '../types/common'
 
-export const TransLine: React.FC<TransLineProps> = ({ i18nKey, links = null }) => {
+export const TransLine: React.FC<TransLineProps> = ({ i18nKey, links = [] }) => {
   let linkComponents: JSX.Element[] = []
   if (links && links.length > 0) {
     // Disabling some linting rules for this line. The anchor <a> element will

--- a/components/TransLine.tsx
+++ b/components/TransLine.tsx
@@ -1,11 +1,6 @@
 import { Trans } from 'react-i18next'
 import React from 'react'
-import { I18nString } from '../types/common'
-
-export interface TransLineProps {
-  i18nKey: I18nString
-  links?: string[] | null
-}
+import { TransLineProps } from '../types/common'
 
 export const TransLine: React.FC<TransLineProps> = ({ i18nKey, links = null }) => {
   let linkComponents: JSX.Element[] = []

--- a/public/locales/en/claim-status.json
+++ b/public/locales/en/claim-status.json
@@ -2,31 +2,19 @@
   "scenarios": {
     "scenario1": {
       "heading": "Pending Eligibility - Phone Interview Will Be Scheduled",
-      "summary": {
-        "text": "We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.",
-        "links": []
-      }
+      "summary": "We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview."
     },
     "scenario4": {
       "heading": "Review Required",
-      "summary": {
-        "text": "We identified an issue and may need to determine your eligibility or verify your information.",
-        "links": []
-      }
+      "summary": "We identified an issue and may need to determine your eligibility or verify your information."
     },
     "scenario5": {
       "heading": "No Weeks Available to Certify",
-      "summary": {
-        "text": "You currently have no weeks available to certify for benefits.",
-        "links": []
-      }
+      "summary": "You currently have no weeks available to certify for benefits."
     },
     "scenario6": {
       "heading": "Weeks Available to Certify",
-      "summary": {
-        "text": "You have weeks available to <0>certify for benefits</0>.",
-        "links": ["edd-ui-certify"]
-      }
+      "summary": "You have weeks available to <0>certify for benefits</0>."
     }
   },
   "conditional-next-steps": {

--- a/public/locales/en/claim-status.json
+++ b/public/locales/en/claim-status.json
@@ -1,20 +1,32 @@
 {
   "scenarios": {
     "scenario1": {
-      "description": "We need to confirm your eligibility for benefits."
+      "heading": "Pending Eligibility - Phone Interview Will Be Scheduled",
+      "summary": {
+        "text": "We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.",
+        "links": []
+      }
     },
-    "scenario7": {
-      "description": "There are no pending issues at this time."
+    "scenario4": {
+      "heading": "Review Required",
+      "summary": {
+        "text": "We identified an issue and may need to determine your eligibility or verify your information.",
+        "links": []
+      }
     },
-    "scenario8": {
-      "description": "Your claim is active and there are no pending issues at this time."
+    "scenario5": {
+      "heading": "No Weeks Available to Certify",
+      "summary": {
+        "text": "You currently have no weeks available to certify for benefits.",
+        "links": []
+      }
     },
-    "scenario9": {
-      "description": "Your payments are pending further review.",
-      "next-step": "Check your UI Online inbox for the latest updates."
-    },
-    "scenario10": {
-      "description": "[this copy may or may not be unique] Your payments are pending further review."
+    "scenario6": {
+      "heading": "Weeks Available to Certify",
+      "summary": {
+        "text": "You have weeks available to <0>certify for benefits</0>.",
+        "links": ["edd-ui-certify"]
+      }
     }
   },
   "conditional-next-steps": {

--- a/public/locales/en/claim-status.json
+++ b/public/locales/en/claim-status.json
@@ -3,22 +3,19 @@
     "scenario1": {
       "heading": "Pending Eligibility - Phone Interview Will Be Scheduled",
       "summary": {
-        "text": "We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.",
-        "links": []
+        "text": "We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview."
       }
     },
     "scenario4": {
       "heading": "Review Required",
       "summary": {
-        "text": "We identified an issue and may need to determine your eligibility or verify your information.",
-        "links": []
+        "text": "We identified an issue and may need to determine your eligibility or verify your information."
       }
     },
     "scenario5": {
       "heading": "No Weeks Available to Certify",
       "summary": {
-        "text": "You currently have no weeks available to certify for benefits.",
-        "links": []
+        "text": "You currently have no weeks available to certify for benefits."
       }
     },
     "scenario6": {

--- a/public/locales/en/claim-status.json
+++ b/public/locales/en/claim-status.json
@@ -2,19 +2,31 @@
   "scenarios": {
     "scenario1": {
       "heading": "Pending Eligibility - Phone Interview Will Be Scheduled",
-      "summary": "We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview."
+      "summary": {
+        "text": "We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.",
+        "links": []
+      }
     },
     "scenario4": {
       "heading": "Review Required",
-      "summary": "We identified an issue and may need to determine your eligibility or verify your information."
+      "summary": {
+        "text": "We identified an issue and may need to determine your eligibility or verify your information.",
+        "links": []
+      }
     },
     "scenario5": {
       "heading": "No Weeks Available to Certify",
-      "summary": "You currently have no weeks available to certify for benefits."
+      "summary": {
+        "text": "You currently have no weeks available to certify for benefits.",
+        "links": []
+      }
     },
     "scenario6": {
       "heading": "Weeks Available to Certify",
-      "summary": "You have weeks available to <0>certify for benefits</0>."
+      "summary": {
+        "text": "You have weeks available to <0>certify for benefits</0>.",
+        "links": ["edd-ui-certify"]
+      }
     }
   },
   "conditional-next-steps": {

--- a/public/locales/es/claim-status.json
+++ b/public/locales/es/claim-status.json
@@ -1,19 +1,28 @@
 {
   "scenarios": {
     "scenario1": {
-      "description": "Necesitamos confirmar su elegibilidad para los beneficios."
+      "heading": "Elegibilidad pendiente - Se programará una entrevista telefónica",
+      "summary": {
+        "text": "Identificamos un problema que podría hacer que no sea elegible para los beneficios. Necesitamos confirmar su elegibilidad en una entrevista telefónica."
+      }
     },
-    "scenario7": {
-      "description": "No hay asuntos pendientes en este momento."
+    "scenario4": {
+      "heading": "Revisión requerida",
+      "summary": {
+        "text": "Identificamos un problema y es posible que necesitemos determinar su elegibilidad o verificar su información."
+      }
     },
-    "scenario8": {
-      "description": "Su reclamo está activo y no hay problemas pendientes en este momento."
+    "scenario5": {
+      "heading": "No hay semanas disponibles para certificar",
+      "summary": {
+        "text": "Actualmente no tiene semanas disponibles para certificar los beneficios."
+      }
     },
-    "scenario9": {
-      "description": "Sus pagos están pendientes de revisión adicional."
-    },
-    "scenario10": {
-      "description": "Sus pagos están pendientes de revisión adicional."
+    "scenario6": {
+      "heading": "Semanas disponibles para certificar",
+      "summary": {
+        "text": "Tiene semanas disponibles para <0> certificar los beneficios </0>."
+      }
     }
   },
   "conditional-next-steps": {

--- a/stories/ClaimStatus.stories.tsx
+++ b/stories/ClaimStatus.stories.tsx
@@ -11,6 +11,9 @@ const Template: Story<ClaimStatusProps> = (args) => <ClaimStatusComponent {...ar
 
 export const ClaimStatus = Template.bind({})
 ClaimStatus.args = {
-  heading: 'claim-status:scenarios:scenario1.heading',
+  heading: 'claim-status:scenarios.scenario1.heading',
+  summary: {
+    i18nKey: 'claim-status:scenarios.scenario1.summary',
+  },
   nextSteps: ['step one', 'step two'],
 }

--- a/stories/ClaimStatus.stories.tsx
+++ b/stories/ClaimStatus.stories.tsx
@@ -13,7 +13,7 @@ export const ClaimStatus = Template.bind({})
 ClaimStatus.args = {
   heading: 'claim-status:scenarios.scenario1.heading',
   summary: {
-    i18nKey: 'claim-status:scenarios.scenario1.summary',
+    i18nKey: 'claim-status:scenarios.scenario1.summary.text',
   },
   nextSteps: ['step one', 'step two'],
 }

--- a/stories/ClaimStatus.stories.tsx
+++ b/stories/ClaimStatus.stories.tsx
@@ -11,6 +11,6 @@ const Template: Story<ClaimStatusProps> = (args) => <ClaimStatusComponent {...ar
 
 export const ClaimStatus = Template.bind({})
 ClaimStatus.args = {
-  statusDescription: 'claim-status:scenarios:scenario1.description',
+  heading: 'claim-status:scenarios:scenario1.heading',
   nextSteps: ['step one', 'step two'],
 }

--- a/stories/TransLine.stories.tsx
+++ b/stories/TransLine.stories.tsx
@@ -1,5 +1,6 @@
 import { Story, Meta } from '@storybook/react'
-import { TransLine as TransLineComponent, TransLineProps } from '../components/TransLine'
+import { TransLine as TransLineComponent } from '../components/TransLine'
+import { TransLineProps } from '../types/common'
 
 export default {
   title: 'Component/Atoms/Trans Line',

--- a/tests/components/ClaimStatus.test.tsx
+++ b/tests/components/ClaimStatus.test.tsx
@@ -6,13 +6,7 @@ import { ClaimStatusContent } from '../../types/common'
 
 function getClaimStatusJson(statusContent: ClaimStatusContent): string {
   return renderer
-    .create(
-      <ClaimStatus
-        loading={false}
-        statusDescription={statusContent.statusDescription}
-        nextSteps={statusContent.nextSteps}
-      />,
-    )
+    .create(<ClaimStatus loading={false} heading={statusContent.heading} nextSteps={statusContent.nextSteps} />)
     .toJSON()
 }
 
@@ -25,16 +19,13 @@ describe('ClaimStatus', () => {
   it('renders for Scenario1', () => {
     expect(testClaimStatus(ScenarioType.Scenario1)).toMatchSnapshot()
   })
-  it('renders for Scenario7', () => {
-    expect(testClaimStatus(ScenarioType.Scenario7)).toMatchSnapshot()
+  it('renders for Scenario4', () => {
+    expect(testClaimStatus(ScenarioType.Scenario4)).toMatchSnapshot()
   })
-  it('renders for Scenario8', () => {
-    expect(testClaimStatus(ScenarioType.Scenario8)).toMatchSnapshot()
+  it('renders for Scenario5', () => {
+    expect(testClaimStatus(ScenarioType.Scenario5)).toMatchSnapshot()
   })
-  it('renders for Scenario9', () => {
-    expect(testClaimStatus(ScenarioType.Scenario9)).toMatchSnapshot()
-  })
-  it('renders for Scenario10', () => {
-    expect(testClaimStatus(ScenarioType.Scenario10)).toMatchSnapshot()
+  it('renders for Scenario6', () => {
+    expect(testClaimStatus(ScenarioType.Scenario6)).toMatchSnapshot()
   })
 })

--- a/tests/components/ClaimStatus.test.tsx
+++ b/tests/components/ClaimStatus.test.tsx
@@ -4,15 +4,22 @@ import getScenarioContent, { ScenarioType } from '../../utils/getScenarioContent
 import apiGatewayStub from '../../utils/apiGatewayStub'
 import { ClaimStatusContent } from '../../types/common'
 
-function getClaimStatusJson(statusContent: ClaimStatusContent): string {
+function renderClaimStatusComponent(statusContent: ClaimStatusContent): string {
   return renderer
-    .create(<ClaimStatus loading={false} heading={statusContent.heading} nextSteps={statusContent.nextSteps} />)
+    .create(
+      <ClaimStatus
+        loading={false}
+        heading={statusContent.heading}
+        summary={statusContent.summary}
+        nextSteps={statusContent.nextSteps}
+      />,
+    )
     .toJSON()
 }
 
 function testClaimStatus(scenarioType: ScenarioType): string {
   const scenarioContent = getScenarioContent(apiGatewayStub(scenarioType))
-  return getClaimStatusJson(scenarioContent.statusContent)
+  return renderClaimStatusComponent(scenarioContent.statusContent)
 }
 
 describe('ClaimStatus', () => {

--- a/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
+++ b/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`ClaimStatus renders for Scenario1 1`] = `
     <span
       className="text-line"
     >
-      We need to confirm your eligibility for benefits.
+      Pending Eligibility - Phone Interview Will Be Scheduled
     </span>
   </div>
   <div
@@ -52,7 +52,7 @@ exports[`ClaimStatus renders for Scenario1 1`] = `
 </div>
 `;
 
-exports[`ClaimStatus renders for Scenario7 1`] = `
+exports[`ClaimStatus renders for Scenario4 1`] = `
 <div
   className="claim-status"
 >
@@ -65,7 +65,7 @@ exports[`ClaimStatus renders for Scenario7 1`] = `
     <span
       className="text-line"
     >
-      There are no pending issues at this time.
+      Review Required
     </span>
   </div>
   <div
@@ -104,7 +104,7 @@ exports[`ClaimStatus renders for Scenario7 1`] = `
 </div>
 `;
 
-exports[`ClaimStatus renders for Scenario8 1`] = `
+exports[`ClaimStatus renders for Scenario5 1`] = `
 <div
   className="claim-status"
 >
@@ -117,7 +117,7 @@ exports[`ClaimStatus renders for Scenario8 1`] = `
     <span
       className="text-line"
     >
-      Your claim is active and there are no pending issues at this time.
+      No Weeks Available to Certify
     </span>
   </div>
   <div
@@ -156,7 +156,7 @@ exports[`ClaimStatus renders for Scenario8 1`] = `
 </div>
 `;
 
-exports[`ClaimStatus renders for Scenario9 1`] = `
+exports[`ClaimStatus renders for Scenario6 1`] = `
 <div
   className="claim-status"
 >
@@ -169,59 +169,7 @@ exports[`ClaimStatus renders for Scenario9 1`] = `
     <span
       className="text-line"
     >
-      Your payments are pending further review.
-    </span>
-  </div>
-  <div
-    className="status-box"
-  >
-    <div
-      className="topbar"
-    >
-      <h3
-        className="next-steps"
-      >
-        Next Steps
-      </h3>
-    </div>
-    <div
-      className="explanation"
-    >
-      <div
-        className="next-steps"
-      >
-        <ul>
-          <li
-            className="next-step"
-          >
-            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-          </li>
-          <li
-            className="next-step"
-          >
-            Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`ClaimStatus renders for Scenario10 1`] = `
-<div
-  className="claim-status"
->
-  <h2>
-    Claim Status
-  </h2>
-  <div
-    className="pending-status"
-  >
-    <span
-      className="text-line"
-    >
-      [this copy may or may not be unique] Your payments are pending further review.
+      Weeks Available to Certify
     </span>
   </div>
   <div

--- a/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
+++ b/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
@@ -17,6 +17,11 @@ exports[`ClaimStatus renders for Scenario1 1`] = `
     </span>
   </div>
   <div
+    className="summary"
+  >
+    We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+  </div>
+  <div
     className="status-box"
   >
     <div
@@ -67,6 +72,11 @@ exports[`ClaimStatus renders for Scenario4 1`] = `
     >
       Review Required
     </span>
+  </div>
+  <div
+    className="summary"
+  >
+    We identified an issue and may need to determine your eligibility or verify your information.
   </div>
   <div
     className="status-box"
@@ -121,6 +131,11 @@ exports[`ClaimStatus renders for Scenario5 1`] = `
     </span>
   </div>
   <div
+    className="summary"
+  >
+    You currently have no weeks available to certify for benefits.
+  </div>
+  <div
     className="status-box"
   >
     <div
@@ -171,6 +186,17 @@ exports[`ClaimStatus renders for Scenario6 1`] = `
     >
       Weeks Available to Certify
     </span>
+  </div>
+  <div
+    className="summary"
+  >
+    You have weeks available to 
+    <a
+      href="https://edd.ca.gov/Unemployment/certify.htm"
+    >
+      certify for benefits
+    </a>
+    .
   </div>
   <div
     className="status-box"

--- a/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/tests/pages/__snapshots__/index.test.tsx.snap
@@ -227,7 +227,7 @@ exports[`Exemplar react-test-renderer Snapshot test renders homepage unchanged 1
             <span
               className="text-line"
             >
-              We need to confirm your eligibility for benefits.
+              Pending Eligibility - Phone Interview Will Be Scheduled
             </span>
           </div>
           <div

--- a/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/tests/pages/__snapshots__/index.test.tsx.snap
@@ -231,6 +231,11 @@ exports[`Exemplar react-test-renderer Snapshot test renders homepage unchanged 1
             </span>
           </div>
           <div
+            className="summary"
+          >
+            We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+          </div>
+          <div
             className="status-box"
           >
             <div

--- a/tests/utils/apiGatewayStub.test.tsx
+++ b/tests/utils/apiGatewayStub.test.tsx
@@ -8,32 +8,27 @@ describe('The API gateway stub response for the Pending Determination scenario',
   })
 })
 
+describe('The API gateway stub response for the Generic Pending state', () => {
+  it('is correct for Scenario 4', () => {
+    const response = apiGatewayStub(ScenarioType.Scenario4)
+    expect([null, [], false, undefined]).toContain(response.pendingDetermination)
+    expect(response.hasPendingWeeks).toBe(true)
+    expect([true, false]).toContain(response.hasCertificationWeeksAvailable)
+  })
+})
+
 describe('The API gateway stub response for the Base States', () => {
-  it('is correct for Scenario 7', () => {
-    const response = apiGatewayStub(ScenarioType.Scenario7)
+  it('is correct for Scenario 5', () => {
+    const response = apiGatewayStub(ScenarioType.Scenario5)
     expect([null, [], false, undefined]).toContain(response.pendingDetermination)
     expect(response.hasPendingWeeks).toBe(false)
     expect(response.hasCertificationWeeksAvailable).toBe(false)
   })
 
-  it('is correct for Scenario 8', () => {
-    const response = apiGatewayStub(ScenarioType.Scenario8)
+  it('is correct for Scenario 6', () => {
+    const response = apiGatewayStub(ScenarioType.Scenario6)
     expect([null, [], false, undefined]).toContain(response.pendingDetermination)
     expect(response.hasPendingWeeks).toBe(false)
-    expect(response.hasCertificationWeeksAvailable).toBe(true)
-  })
-
-  it('is correct for Scenario 9', () => {
-    const response = apiGatewayStub(ScenarioType.Scenario9)
-    expect([null, [], false, undefined]).toContain(response.pendingDetermination)
-    expect(response.hasPendingWeeks).toBe(true)
-    expect(response.hasCertificationWeeksAvailable).toBe(false)
-  })
-
-  it('is correct for Scenario 10', () => {
-    const response = apiGatewayStub(ScenarioType.Scenario10)
-    expect([null, [], false, undefined]).toContain(response.pendingDetermination)
-    expect(response.hasPendingWeeks).toBe(true)
     expect(response.hasCertificationWeeksAvailable).toBe(true)
   })
 })

--- a/tests/utils/getClaimStatus.test.tsx
+++ b/tests/utils/getClaimStatus.test.tsx
@@ -13,22 +13,21 @@ describe('The Claim Status heading', () => {
 })
 
 // Test getClaimStatusSummary()
+// Note: These tests test against real content
 describe('The Claim Status summary', () => {
-  it('is correct for each scenario', () => {
-    for (const key of getNumericEnumKeys(ScenarioType)) {
-      const summary = getClaimStatusSummary(key)
-      const scenarioString = ScenarioType[key].toLowerCase() as keyof typeof claimStatusJson.scenarios
-
-      // Test the summary text.
-      expect(summary.i18nKey).toEqual(`claim-status:scenarios.${scenarioString}.summary.text`)
-
-      // Test the summary links.
-      const scenarioLinks = claimStatusJson.scenarios[scenarioString].summary.links
-      if (scenarioLinks) {
-        expect(summary.links.length).toEqual(claimStatusJson.scenarios[scenarioString].summary.links.length)
-      } else {
-        expect(summary.links).ToBe(undefined)
-      }
+  it('is correct for scenarios with no links', () => {
+    const scenarioType = ScenarioType.Scenario1
+    const expected = {
+      i18nKey: 'claim-status:scenarios.scenario1.summary.text',
+      links: [],
     }
+    expect(getClaimStatusSummary(scenarioType)).toEqual(expected)
+  })
+
+  it('is correct for scenarios with links', () => {
+    const scenarioType = ScenarioType.Scenario6
+    const summary = getClaimStatusSummary(scenarioType)
+    expect(summary.i18nKey).toEqual('claim-status:scenarios.scenario6.summary.text')
+    expect(summary.links.length).toEqual(1)
   })
 })

--- a/tests/utils/getClaimStatus.test.tsx
+++ b/tests/utils/getClaimStatus.test.tsx
@@ -1,7 +1,6 @@
 import { getClaimStatusHeading, getClaimStatusSummary } from '../../utils/getClaimStatus'
 import { ScenarioType } from '../../utils/getScenarioContent'
 import { getNumericEnumKeys } from '../../utils/numericEnum'
-import claimStatusJson from '../../public/locales/en/claim-status.json'
 
 // Test getClaimStatusHeading()
 describe('The Claim Status heading', () => {

--- a/tests/utils/getClaimStatus.test.tsx
+++ b/tests/utils/getClaimStatus.test.tsx
@@ -1,4 +1,4 @@
-import { getClaimStatusHeading, getClaimStatusSummary } from '../../utils/getClaimStatus'
+import { getClaimStatusHeading } from '../../utils/getClaimStatus'
 import { ScenarioType } from '../../utils/getScenarioContent'
 import { getNumericEnumKeys } from '../../utils/numericEnum'
 
@@ -8,25 +8,5 @@ describe('The Claim Status heading', () => {
     for (const key of getNumericEnumKeys(ScenarioType)) {
       expect(getClaimStatusHeading(key)).toEqual(expect.stringMatching(/claim-status:scenarios.scenario[0-9]+.heading/))
     }
-  })
-})
-
-// Test getClaimStatusSummary()
-// Note: These tests test against real content
-describe('The Claim Status summary', () => {
-  it('is correct for scenarios with no links', () => {
-    const scenarioType = ScenarioType.Scenario1
-    const expected = {
-      i18nKey: 'claim-status:scenarios.scenario1.summary.text',
-      links: [],
-    }
-    expect(getClaimStatusSummary(scenarioType)).toEqual(expected)
-  })
-
-  it('is correct for scenarios with links', () => {
-    const scenarioType = ScenarioType.Scenario6
-    const summary = getClaimStatusSummary(scenarioType)
-    expect(summary.i18nKey).toEqual('claim-status:scenarios.scenario6.summary.text')
-    expect(summary.links.length).toEqual(1)
   })
 })

--- a/tests/utils/getClaimStatus.test.tsx
+++ b/tests/utils/getClaimStatus.test.tsx
@@ -1,14 +1,12 @@
-import { getClaimStatusDescription } from '../../utils/getClaimStatus'
+import { getClaimStatusHeading } from '../../utils/getClaimStatus'
 import { ScenarioType } from '../../utils/getScenarioContent'
 import { getNumericEnumKeys } from '../../utils/numericEnum'
 
-// Test getClaimStatusDescripton()
-describe('Getting the Claim Status description', () => {
-  it('returns the correct description for the scenario', () => {
+// Test getClaimStatusHeading()
+describe('The Claim Status heading', () => {
+  it('is correct for each scenario', () => {
     for (const key of getNumericEnumKeys(ScenarioType)) {
-      expect(getClaimStatusDescription(key)).toEqual(
-        expect.stringMatching(/claim-status:scenarios.scenario[0-9]+.description/),
-      )
+      expect(getClaimStatusHeading(key)).toEqual(expect.stringMatching(/claim-status:scenarios.scenario[0-9]+.heading/))
     }
   })
 })

--- a/tests/utils/getClaimStatus.test.tsx
+++ b/tests/utils/getClaimStatus.test.tsx
@@ -1,12 +1,34 @@
-import { getClaimStatusHeading } from '../../utils/getClaimStatus'
+import { getClaimStatusHeading, getClaimStatusSummary } from '../../utils/getClaimStatus'
 import { ScenarioType } from '../../utils/getScenarioContent'
 import { getNumericEnumKeys } from '../../utils/numericEnum'
+import claimStatusJson from '../../public/locales/en/claim-status.json'
 
 // Test getClaimStatusHeading()
 describe('The Claim Status heading', () => {
   it('is correct for each scenario', () => {
     for (const key of getNumericEnumKeys(ScenarioType)) {
       expect(getClaimStatusHeading(key)).toEqual(expect.stringMatching(/claim-status:scenarios.scenario[0-9]+.heading/))
+    }
+  })
+})
+
+// Test getClaimStatusSummary()
+describe('The Claim Status summary', () => {
+  it('is correct for each scenario', () => {
+    for (const key of getNumericEnumKeys(ScenarioType)) {
+      const summary = getClaimStatusSummary(key)
+      const scenarioString = ScenarioType[key].toLowerCase() as keyof typeof claimStatusJson.scenarios
+
+      // Test the summary text.
+      expect(summary.i18nKey).toEqual(`claim-status:scenarios.${scenarioString}.summary.text`)
+
+      // Test the summary links.
+      const scenarioLinks = claimStatusJson.scenarios[scenarioString].summary.links
+      if (scenarioLinks) {
+        expect(summary.links.length).toEqual(claimStatusJson.scenarios[scenarioString].summary.links.length)
+      } else {
+        expect(summary.links).ToBe(undefined)
+      }
     }
   })
 })

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -44,15 +44,18 @@ describe('Scenario 1', () => {
   })
 })
 
-// Scenarios 7-10
+// Scenario 4
+describe('The Generic Pending scenario', () => {
+  it('is returned as expected', () => {
+    const scenarioType = ScenarioType.Scenario4
+    expect(getScenario(apiGatewayStub(scenarioType))).toBe(scenarioType)
+  })
+})
+
+// Scenarios 5 & 6
 describe('The Base State scenarios', () => {
   it('are returned as expected', () => {
-    const baseScenarios = [
-      ScenarioType.Scenario7,
-      ScenarioType.Scenario8,
-      ScenarioType.Scenario9,
-      ScenarioType.Scenario10,
-    ]
+    const baseScenarios = [ScenarioType.Scenario5, ScenarioType.Scenario6]
     for (const scenarioType of baseScenarios) {
       expect(getScenario(apiGatewayStub(scenarioType))).toBe(scenarioType)
     }

--- a/tests/utils/getUrl.test.tsx
+++ b/tests/utils/getUrl.test.tsx
@@ -1,0 +1,12 @@
+import getUrl from '../../utils/getUrl'
+
+describe('Retrieving urls', () => {
+  // Note: This tests against real content
+  it('works for real keys', () => {
+    expect(getUrl('edd-ui-claim-status')).toBe('https://www.edd.ca.gov/unemployment/claim-status.htm')
+  })
+
+  it('returns undefined for unknown keys', () => {
+    expect(getUrl('foo')).toBe(undefined)
+  })
+})

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -35,6 +35,7 @@ export interface Claim {
 // Type interfaces for Claim Status and Claim Details
 export interface ClaimStatusContent {
   heading: I18nString
+  summary: TransLineProps
   nextSteps?: string[]
 }
 

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -1,13 +1,19 @@
 // Type aliases
 export type I18nString = string
 
-// Type interfaces for TransLine component
+// Types for TransLine component
 export interface TransLineProps {
   i18nKey: I18nString
   links?: string[] | null
 }
 
-// Type interfaces for API gateway result
+// Types for translation file JSON
+export interface TextOptionalLink {
+  text: string
+  links?: string[]
+}
+
+// Types for API gateway result
 export interface PendingDetermination {
   determinationStatus?: null | undefined | string
 }
@@ -32,7 +38,7 @@ export interface Claim {
   pendingDetermination?: null | [PendingDetermination]
 }
 
-// Type interfaces for Claim Status and Claim Details
+// Types for Claim Status and Claim Details
 export interface ClaimStatusContent {
   heading: I18nString
   summary: TransLineProps

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -4,7 +4,7 @@ export type I18nString = string
 // Types for TransLine component
 export interface TransLineProps {
   i18nKey: I18nString
-  links?: string[] | null
+  links?: string[]
 }
 
 // Types for translation file JSON

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -1,6 +1,12 @@
 // Type aliases
 export type I18nString = string
 
+// Type interfaces for TransLine component
+export interface TransLineProps {
+  i18nKey: I18nString
+  links?: string[] | null
+}
+
 // Type interfaces for API gateway result
 export interface PendingDetermination {
   determinationStatus?: null | undefined | string
@@ -28,7 +34,7 @@ export interface Claim {
 
 // Type interfaces for Claim Status and Claim Details
 export interface ClaimStatusContent {
-  statusDescription: string // This is an i18n string
+  heading: I18nString
   nextSteps?: string[]
 }
 

--- a/utils/apiGatewayStub.tsx
+++ b/utils/apiGatewayStub.tsx
@@ -11,6 +11,7 @@ import { Claim } from '../types/common'
  * Stub the API gateway response for a given scenario.
  */
 export default function apiGatewayStub(scenarioType: ScenarioType, hasClaimDetails = true): Claim {
+  // Default empty response from the API gateway
   const claim: Claim = {
     uniqueNumber: null,
     claimDetails: null,
@@ -19,30 +20,33 @@ export default function apiGatewayStub(scenarioType: ScenarioType, hasClaimDetai
     pendingDetermination: null,
   }
 
+  // If this is a known scenarioType, set a uniqueNumber.
+  if (scenarioType in ScenarioType) {
+    claim.uniqueNumber = '12345'
+  }
+
   switch (scenarioType) {
     case ScenarioType.Scenario1:
       claim.pendingDetermination = [{ determinationStatus: null }]
       break
 
-    // @TODO: This scenario should probably not be the default case.
-    // case ScenarioType.Scenario7:
-
-    case ScenarioType.Scenario8:
-      claim.hasCertificationWeeksAvailable = true
-      break
-
-    case ScenarioType.Scenario9:
+    case ScenarioType.Scenario4:
       claim.hasPendingWeeks = true
       break
 
-    case ScenarioType.Scenario10:
-      claim.hasPendingWeeks = true
+    case ScenarioType.Scenario5:
+      claim.hasPendingWeeks = false
+      claim.hasCertificationWeeksAvailable = false
+      break
+
+    case ScenarioType.Scenario6:
+      claim.hasPendingWeeks = false
       claim.hasCertificationWeeksAvailable = true
       break
 
-    // @TODO: No match should throw an error
-    // default:
-    //   throw new Error('Unknown scenario type')
+    // No match should throw an error
+    default:
+      throw new Error('Unknown scenario type')
   }
 
   if (hasClaimDetails) {

--- a/utils/getClaimStatus.tsx
+++ b/utils/getClaimStatus.tsx
@@ -3,7 +3,7 @@
  */
 
 import claimStatusJson from '../public/locales/en/claim-status.json'
-import { ClaimStatusContent, I18nString, TransLineProps } from '../types/common'
+import { ClaimStatusContent, I18nString, TextOptionalLink, TransLineProps } from '../types/common'
 import { ScenarioType } from './getScenarioContent'
 import getUrl, { UrlType } from './getUrl'
 
@@ -37,7 +37,8 @@ export function getClaimStatusSummary(scenarioType: ScenarioType): TransLineProp
   // (i.e. scenario1 | scenario2 etc)
   const scenarioString = ScenarioType[scenarioType].toLowerCase() as keyof typeof claimStatusJson.scenarios
   // Retrieve the summary links for the current scenario.
-  const linkKeys = claimStatusJson.scenarios[scenarioString].summary.links as string[]
+  const summary = claimStatusJson.scenarios[scenarioString].summary as TextOptionalLink
+  const linkKeys = summary.links
 
   // Lookup each link and send the array to the TransLine component.
   if (linkKeys && linkKeys.length > 0) {

--- a/utils/getClaimStatus.tsx
+++ b/utils/getClaimStatus.tsx
@@ -2,10 +2,10 @@
  * Utility file to get content for the Claim Status section.
  */
 
-import urls from '../public/urls.json'
 import claimStatusJson from '../public/locales/en/claim-status.json'
 import { ClaimStatusContent, I18nString, TransLineProps } from '../types/common'
 import { ScenarioType } from './getScenarioContent'
+import getUrl, { UrlType } from './getUrl'
 
 /**
  * Helper function to get shared Claim Status translation string prefix.
@@ -43,8 +43,8 @@ export function getClaimStatusSummary(scenarioType: ScenarioType): TransLineProp
   if (linkKeys && linkKeys.length > 0) {
     for (const linkKey of linkKeys) {
       // Explicitly cast to one of the allowed keys in urls.json
-      const key = linkKey as keyof typeof urls
-      const url = urls[key]
+      const key = linkKey as UrlType
+      const url = getUrl(key)
       if (url) {
         transLineProps.links.push(url)
       }

--- a/utils/getClaimStatus.tsx
+++ b/utils/getClaimStatus.tsx
@@ -23,15 +23,10 @@ export function getClaimStatusHeading(scenarioType: ScenarioType): I18nString {
  * Get Claim Status summary.
  */
 export function getClaimStatusSummary(scenarioType: ScenarioType): TransLineProps {
-  const transLineProps = {
-    i18nKey: getTranslationPrefix(scenarioType) + '.summary.text',
+  const transLineProps: TransLineProps = {
+    i18nKey: getTranslationPrefix(scenarioType) + '.summary',
+    links: [],
   }
-  const linkKeys = getTranslationPrefix(scenarioType) + '.summary.links'
-  // console.log(getUrls())
-  // const urls = getUrls(linkKeys)
-  // if (urls) {
-  //   transLineProps.links = urls
-  // }
   return transLineProps
 }
 
@@ -42,6 +37,7 @@ export default function getClaimStatus(scenarioType: ScenarioType): ClaimStatusC
   getClaimStatusSummary(scenarioType)
   const statusContent: ClaimStatusContent = {
     heading: getClaimStatusHeading(scenarioType),
+    summary: getClaimStatusSummary(scenarioType),
     nextSteps: [
       'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
       'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',

--- a/utils/getClaimStatus.tsx
+++ b/utils/getClaimStatus.tsx
@@ -2,6 +2,8 @@
  * Utility file to get content for the Claim Status section.
  */
 
+import urls from '../public/urls.json'
+import claimStatusJson from '../public/locales/en/claim-status.json'
 import { ClaimStatusContent, I18nString, TransLineProps } from '../types/common'
 import { ScenarioType } from './getScenarioContent'
 
@@ -21,11 +23,32 @@ export function getClaimStatusHeading(scenarioType: ScenarioType): I18nString {
 
 /**
  * Get Claim Status summary.
+ *
+ * Note: This function has a lot of verbosity due to Typescript + eslint.
  */
 export function getClaimStatusSummary(scenarioType: ScenarioType): TransLineProps {
   const transLineProps: TransLineProps = {
-    i18nKey: getTranslationPrefix(scenarioType) + '.summary',
-    links: [],
+    i18nKey: getTranslationPrefix(scenarioType) + '.summary.text',
+  }
+  // Explicitly initialize to an empty array.
+  transLineProps.links = []
+
+  // Explicitly cast the scenarioType into one of the keys of claim-status.json
+  // (i.e. scenario1 | scenario2 etc)
+  const scenarioString = ScenarioType[scenarioType].toLowerCase() as keyof typeof claimStatusJson.scenarios
+  // Retrieve the summary links for the current scenario.
+  const linkKeys = claimStatusJson.scenarios[scenarioString].summary.links as string[]
+
+  // Lookup each link and send the array to the TransLine component.
+  if (linkKeys && linkKeys.length > 0) {
+    for (const linkKey of linkKeys) {
+      // Explicitly cast to one of the allowed keys in urls.json
+      const key = linkKey as keyof typeof urls
+      const url = urls[key]
+      if (url) {
+        transLineProps.links.push(url)
+      }
+    }
   }
   return transLineProps
 }

--- a/utils/getClaimStatus.tsx
+++ b/utils/getClaimStatus.tsx
@@ -2,22 +2,46 @@
  * Utility file to get content for the Claim Status section.
  */
 
-import { ClaimStatusContent, I18nString } from '../types/common'
+import { ClaimStatusContent, I18nString, TransLineProps } from '../types/common'
 import { ScenarioType } from './getScenarioContent'
 
 /**
- * Get Claim Status description content.
+ * Helper function to get shared Claim Status translation string prefix.
  */
-export function getClaimStatusDescription(scenarioType: ScenarioType): I18nString {
-  return `claim-status:scenarios.${ScenarioType[scenarioType].toLowerCase()}.description`
+function getTranslationPrefix(scenarioType: ScenarioType): I18nString {
+  return `claim-status:scenarios.${ScenarioType[scenarioType].toLowerCase()}`
+}
+
+/**
+ * Get Claim Status heading.
+ */
+export function getClaimStatusHeading(scenarioType: ScenarioType): I18nString {
+  return getTranslationPrefix(scenarioType) + '.heading'
+}
+
+/**
+ * Get Claim Status summary.
+ */
+export function getClaimStatusSummary(scenarioType: ScenarioType): TransLineProps {
+  const transLineProps = {
+    i18nKey: getTranslationPrefix(scenarioType) + '.summary.text',
+  }
+  const linkKeys = getTranslationPrefix(scenarioType) + '.summary.links'
+  // console.log(getUrls())
+  // const urls = getUrls(linkKeys)
+  // if (urls) {
+  //   transLineProps.links = urls
+  // }
+  return transLineProps
 }
 
 /**
  * Get combined Claim Status content.
  */
 export default function getClaimStatus(scenarioType: ScenarioType): ClaimStatusContent {
+  getClaimStatusSummary(scenarioType)
   const statusContent: ClaimStatusContent = {
-    statusDescription: getClaimStatusDescription(scenarioType),
+    heading: getClaimStatusHeading(scenarioType),
     nextSteps: [
       'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
       'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -13,18 +13,16 @@ import getClaimStatus from './getClaimStatus'
 
 export enum ScenarioType {
   Scenario1,
-  Scenario7,
-  Scenario8,
-  Scenario9,
-  Scenario10,
+  Scenario4,
+  Scenario5,
+  Scenario6,
 }
 
 export const ScenarioTypeNames = {
   [ScenarioType.Scenario1]: 'Pending determination scenario',
-  [ScenarioType.Scenario7]: 'Base state; No pending weeks; No weeks to certify',
-  [ScenarioType.Scenario8]: 'Base state; No pending weeks; Has weeks to certify',
-  [ScenarioType.Scenario9]: 'Base state; Has pending weeks; No weeks to certify',
-  [ScenarioType.Scenario10]: 'Base state; Has pending weeks; Has weeks to certify',
+  [ScenarioType.Scenario4]: 'Generic pending state: pending weeks',
+  [ScenarioType.Scenario5]: 'Base state: no pending weeks, no weeks to certify',
+  [ScenarioType.Scenario6]: 'Base state: no pending weeks, weeks to certify',
 }
 
 /**
@@ -40,29 +38,25 @@ export function getScenario(claimData: Claim): ScenarioType {
     return ScenarioType.Scenario1
   }
 
-  // No pendingDetermination objects: display a Base State scenario.
+  // No pendingDetermination objects.
   else {
     // @TODO: Validate that hasPendingWeeks is a boolean
-    if (claimData.hasPendingWeeks === false) {
+    if (claimData.hasPendingWeeks === true) {
       // @TODO: Validate that hasCertificationWeeks is a boolean
-      if (claimData.hasCertificationWeeksAvailable === false) {
-        return ScenarioType.Scenario7
-      } else {
-        return ScenarioType.Scenario8
-      }
+      return ScenarioType.Scenario4
     }
-    // hasPendingWeeks === true
+    // hasPendingWeeks === false
     else {
       if (claimData.hasCertificationWeeksAvailable === false) {
-        return ScenarioType.Scenario9
+        return ScenarioType.Scenario5
       } else {
-        return ScenarioType.Scenario10
+        return ScenarioType.Scenario6
       }
     }
   }
 }
 
-/**
+/*
  * Return scenario content.
  */
 export default function getScenarioContent(claimData: Claim): ScenarioContent {

--- a/utils/getUrl.tsx
+++ b/utils/getUrl.tsx
@@ -1,0 +1,15 @@
+/**
+ * Utility file to retrieve urls from the urls.json file.
+ */
+
+import urls from '../public/urls.json'
+
+// Type alias for the keys in urls.json
+export type UrlType = keyof typeof urls
+
+/**
+ * Get url from urls.json
+ */
+export default function getUrl(key: UrlType): string | undefined {
+  return urls[key]
+}


### PR DESCRIPTION
## Ticket

Resolves #291 

## Changes

- Re-numbers the scenarios and updates claim-status.json based on latest content
- Splits claim status description into two fields: `heading` and `summary` according to content docs
- Uses the `<TransLine>` component because the claim status summary field can contain links
- Introduces looking up urls in `urls.json` by key

## Context

Based on the latest content, this PR replaces Scenarios 7-10 with Scenarios 4-6. The new content introduces a different claim status heading for each scenario, as well as a claim status "summary". The claim status summary text can contain links, so we need to start using `<TransLine>`.

In an effort to make it easier to update content, I'm using the following concepts:
- All urls are stored as key value pairs in `urls.json`
- The English translation file (e.g. `public/locales/en/claim-status.json`) includes an array of keys for `urls.json`

This allows us to:
1. Keep the content together in one document (the translation file)
2. Declare urls once, rather than copy/pasting them multiple times and introducing types

## Testing

`yarn test`

and 

While #299 is not resolved, comment out these lines, then run `yarn storybook`, and check that each scenario displays the heading and summary from the latest content (including correct links): https://github.com/cagov/ui-claim-tracker/blob/32990f892c6b84017c30af5d273fdd94410649e7/pages/index.tsx#L95-L98