### PR TITLE
Display last payment amount in Claim Details

### DIFF
--- a/public/locales/en/claim-details.json
+++ b/public/locales/en/claim-details.json
@@ -5,9 +5,9 @@
     "pua": "Pandemic Unemployment Assistance (PUA)"
   },
   "extension-type": {
-    "peuc-1": "Pandemic Emergency Unemployment Compensation (PEUC) - Tier 1 Extension",
-    "peuc-2": "Pandemic Emergency Unemployment Compensation (PEUC) - Tier 2 Extension",
-    "peuc-2-augmentation": "Pandemic Emergency Unemployment Compensation (PEUC) - Tier 2 Augmentation",
+    "peuc": "Pandemic Emergency Unemployment Compensation (PEUC) — Tier 1 Extension",
+    "peux": "Pandemic Emergency Unemployment Compensation (PEUC) — Tier 2 Extension",
+    "peuy": "Pandemic Emergency Unemployment Compensation (PEUC) — Tier 2 Augmentation",
     "fed-ed": "Federal-State Extended Duration (FED-ED)",
     "tra": "Trade Readjustment Allowance Basic Extension",
     "tra-additional": "Trade Readjustment Allowance Additional Extension",

--- a/public/locales/en/claim-status.json
+++ b/public/locales/en/claim-status.json
@@ -1,7 +1,7 @@
 {
   "scenarios": {
     "scenario1": {
-      "heading": "Pending Eligibility - Phone Interview Will Be Scheduled",
+      "heading": "Pending Eligibility — Phone Interview Will Be Scheduled",
       "summary": {
         "text": "We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview."
       },

--- a/public/locales/es/claim-details.json
+++ b/public/locales/es/claim-details.json
@@ -5,9 +5,9 @@
     "pua": "Asistencia por desempleo pandémico (PUA)"
   },
   "extension-type": {
-    "peuc-1": "Compensación por desempleo de emergencia pandémica (PEUC) - Extensión de nivel 1",
-    "peuc-2": "Compensación por desempleo de emergencia pandémica (PEUC) - Extensión de nivel 2",
-    "peuc-2-augmentation": "Compensación por desempleo de emergencia pandémica (PEUC) - Tier 2 Augmentation",
+    "peuc": "Compensación por desempleo de emergencia pandémica (PEUC) — Extensión de nivel 1",
+    "peux": "Compensación por desempleo de emergencia pandémica (PEUC) — Extensión de nivel 2",
+    "peuy": "Compensación por desempleo de emergencia pandémica (PEUC) — Tier 2 Augmentation",
     "fed-ed": "Duración extendida federal-estatal (FED-ED)",
     "tra": "Extensión básica de la asignación por reajuste comercial",
     "tra-additional": "Extensión adicional de la asignación por reajuste comercial",

--- a/public/locales/es/claim-status.json
+++ b/public/locales/es/claim-status.json
@@ -1,7 +1,7 @@
 {
   "scenarios": {
     "scenario1": {
-      "heading": "Elegibilidad pendiente - Se programará una entrevista telefónica",
+      "heading": "Elegibilidad pendiente — Se programará una entrevista telefónica",
       "summary": {
         "text": "Identificamos un problema que podría hacer que no sea elegible para los beneficios. Necesitamos confirmar su elegibilidad en una entrevista telefónica."
       },

--- a/stories/Page.stories.tsx
+++ b/stories/Page.stories.tsx
@@ -2,8 +2,9 @@ import { Story, Meta } from '@storybook/react'
 import { withNextRouter } from 'storybook-addon-next-router'
 
 import Home, { HomeProps } from '../pages/index'
-import getScenarioContent, { ScenarioType, ScenarioTypeNames } from '../utils/getScenarioContent'
 import apiGatewayStub from '../utils/apiGatewayStub'
+import { programTypeNames } from '../utils/getClaimDetails'
+import getScenarioContent, { ScenarioType, ScenarioTypeNames } from '../utils/getScenarioContent'
 import { getNumericEnumKeys } from '../utils/numericEnum'
 
 // See https://storybook.js.org/docs/riot/essentials/controls#dealing-with-complex-values
@@ -20,6 +21,14 @@ export default {
         labels: ScenarioTypeNames,
       },
     },
+    programType: {
+      options: Object.values(programTypeNames),
+      defaultValue: 'UI',
+      control: {
+        type: 'select',
+        labels: programTypeNames,
+      },
+    },
     errorCode: {
       control: {
         type: 'text',
@@ -31,10 +40,11 @@ export default {
 // Extend HomeProps to add a complex story value
 interface StoryHomeProps extends HomeProps {
   scenario: number
+  programType: string
 }
 
 const Template: Story<StoryHomeProps> = ({ ...args }) => {
-  args.scenarioContent = getScenarioContent(apiGatewayStub(args.scenario))
+  args.scenarioContent = getScenarioContent(apiGatewayStub(args.scenario, args.programType))
   return <Home {...args} />
 }
 

--- a/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
+++ b/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`ClaimStatus renders for Scenario1 1`] = `
     <h3
       className="header-line"
     >
-      Pending Eligibility - Phone Interview Will Be Scheduled
+      Pending Eligibility — Phone Interview Will Be Scheduled
     </h3>
   </div>
   <div

--- a/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/tests/pages/__snapshots__/index.test.tsx.snap
@@ -178,7 +178,7 @@ exports[`Exemplar react-test-renderer Snapshot test renders homepage unchanged 1
             <h3
               className="header-line"
             >
-              Pending Eligibility - Phone Interview Will Be Scheduled
+              Pending Eligibility — Phone Interview Will Be Scheduled
             </h3>
           </div>
           <div
@@ -282,7 +282,7 @@ exports[`Exemplar react-test-renderer Snapshot test renders homepage unchanged 1
                   <div
                     className="info-entry"
                   >
-                    3/21/2020 - 3/20/2021
+                    3/21/2020–3/20/2021
                   </div>
                 </div>
                 <div
@@ -343,7 +343,7 @@ exports[`Exemplar react-test-renderer Snapshot test renders homepage unchanged 1
                   <div
                     className="info-entry"
                   >
-                    Pandemic Emergency Unemployment Compensation (PEUC) - Tier 2 Extension
+                    Pandemic Emergency Unemployment Compensation (PEUC) — Tier 2 Extension
                   </div>
                 </div>
               </div>

--- a/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/tests/pages/__snapshots__/index.test.tsx.snap
@@ -328,25 +328,6 @@ exports[`Exemplar react-test-renderer Snapshot test renders homepage unchanged 1
                   </div>
                 </div>
               </div>
-              <div
-                className="col-6"
-              >
-                <div />
-                <div
-                  className="info"
-                >
-                  <div
-                    className="info-label"
-                  >
-                    Extension Type
-                  </div>
-                  <div
-                    className="info-entry"
-                  >
-                    Pandemic Emergency Unemployment Compensation (PEUC) — Tier 2 Extension
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
         </div>

--- a/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/tests/pages/__snapshots__/index.test.tsx.snap
@@ -324,7 +324,7 @@ exports[`Exemplar react-test-renderer Snapshot test renders homepage unchanged 1
                   <div
                     className="info-entry"
                   >
-                    4/29/2021
+                    $100.00 on 4/29/2021
                   </div>
                 </div>
               </div>

--- a/tests/utils/getClaimDetails.test.tsx
+++ b/tests/utils/getClaimDetails.test.tsx
@@ -38,7 +38,7 @@ describe('Formatting dates', () => {
 describe('Constructing the benefit year', () => {
   it('results in a date range string', () => {
     const range = buildBenefitYear('2013-09-27T12:34:33', '2021-10-28T05:33:34')
-    expect(range).toBe('9/27/2013 - 10/28/2021')
+    expect(range).toBe('9/27/2013–10/28/2021')
   })
 })
 
@@ -68,7 +68,7 @@ describe('Constructing the Claim Details object', () => {
     // Expected results
     const expected = {
       programType: 'claim-details:program-type.ui',
-      benefitYear: '5/21/2021 - 5/20/2022',
+      benefitYear: '5/21/2021–5/20/2022',
       claimBalance: '$100.00',
       weeklyBenefitAmount: '$25.00',
       lastPaymentIssued: '3/12/2021',

--- a/tests/utils/getClaimDetails.test.tsx
+++ b/tests/utils/getClaimDetails.test.tsx
@@ -71,7 +71,7 @@ describe('Constructing the Claim Details object', () => {
       benefitYear: '5/21/2021–5/20/2022',
       claimBalance: '$100.00',
       weeklyBenefitAmount: '$25.00',
-      lastPaymentIssued: '3/12/2021',
+      lastPaymentIssued: '$10.00 on 3/12/2021',
       extensionType: '',
     }
     const claimDetails = getClaimDetails(rawDetails)

--- a/utils/apiGatewayStub.tsx
+++ b/utils/apiGatewayStub.tsx
@@ -10,7 +10,7 @@ import { Claim } from '../types/common'
 /**
  * Stub the API gateway response for a given scenario.
  */
-export default function apiGatewayStub(scenarioType: ScenarioType, hasClaimDetails = true): Claim {
+export default function apiGatewayStub(scenarioType: ScenarioType, programType = 'UI'): Claim {
   // Default empty response from the API gateway
   const claim: Claim = {
     uniqueNumber: null,
@@ -49,17 +49,15 @@ export default function apiGatewayStub(scenarioType: ScenarioType, hasClaimDetai
       throw new Error('Unknown scenario type')
   }
 
-  if (hasClaimDetails) {
-    claim.claimDetails = {
-      programType: 'PEUX - Tier 2 Extension',
-      benefitYearStartDate: '2020-03-21T00:00:00',
-      benefitYearEndDate: '2021-03-20T00:00:00',
-      claimBalance: 1100.45,
-      weeklyBenefitAmount: 111,
-      lastPaymentIssued: '2021-04-29T00:00:00',
-      lastPaymentAmount: 100,
-      monetaryStatus: 'Active',
-    }
+  claim.claimDetails = {
+    programType: programType,
+    benefitYearStartDate: '2020-03-21T00:00:00',
+    benefitYearEndDate: '2021-03-20T00:00:00',
+    claimBalance: 1100.45,
+    weeklyBenefitAmount: 111,
+    lastPaymentIssued: '2021-04-29T00:00:00',
+    lastPaymentAmount: 100,
+    monetaryStatus: 'Active',
   }
 
   return claim

--- a/utils/apiGatewayStub.tsx
+++ b/utils/apiGatewayStub.tsx
@@ -51,7 +51,7 @@ export default function apiGatewayStub(scenarioType: ScenarioType, hasClaimDetai
 
   if (hasClaimDetails) {
     claim.claimDetails = {
-      programType: 'PEUC - Tier 2 Extension',
+      programType: 'PEUX - Tier 2 Extension',
       benefitYearStartDate: '2020-03-21T00:00:00',
       benefitYearEndDate: '2021-03-20T00:00:00',
       claimBalance: 1100.45,

--- a/utils/getClaimDetails.tsx
+++ b/utils/getClaimDetails.tsx
@@ -16,8 +16,8 @@ export interface ProgramType {
 export const programTypeNames: ProgramType = {
   UI: 'UI',
   PEUC: 'PEUC - Tier 1 Extension',
-  PEUX: 'PEUC - Tier 2 Extension',
-  PEUY: 'PEUC - Tier 2 Augmentation',
+  PEUX: 'PEUX - Tier 2 Extension',
+  PEUY: 'PEUY - Tier 2 Augmentation',
   FEDED: 'FED-ED Extension',
   TRA: 'TRA Basic Extension',
   TRAAdditional: 'TRA Additional/Remedial Extension',
@@ -39,15 +39,15 @@ export const programExtensionPairs = {
   },
   PEUC: {
     programType: 'claim-details:program-type.ui',
-    extensionType: 'claim-details:extension-type.peuc-1',
+    extensionType: 'claim-details:extension-type.peuc',
   },
   PEUX: {
     programType: 'claim-details:program-type.ui',
-    extensionType: 'claim-details:extension-type.peuc-2',
+    extensionType: 'claim-details:extension-type.peux',
   },
   PEUY: {
     programType: 'claim-details:program-type.ui',
-    extensionType: 'claim-details:extension-type.peuc-2-augmentation',
+    extensionType: 'claim-details:extension-type.peuy',
   },
   FEDED: {
     programType: 'claim-details:program-type.ui',
@@ -100,7 +100,7 @@ export function formatDate(dateString: string): string {
  * Constrtuct the benefit year string.
  */
 export function buildBenefitYear(start: string, end: string): string {
-  return `${formatDate(start)} - ${formatDate(end)}`
+  return `${formatDate(start)}–${formatDate(end)}`
 }
 
 /**

--- a/utils/getClaimDetails.tsx
+++ b/utils/getClaimDetails.tsx
@@ -123,7 +123,7 @@ export default function getClaimDetails(rawDetails: ClaimDetailsResult): ClaimDe
     benefitYear: benefitYear,
     claimBalance: formatCurrency(rawDetails.claimBalance),
     weeklyBenefitAmount: formatCurrency(rawDetails.weeklyBenefitAmount),
-    lastPaymentIssued: formatDate(rawDetails.lastPaymentIssued),
+    lastPaymentIssued: `${formatCurrency(rawDetails.lastPaymentAmount)} on ${formatDate(rawDetails.lastPaymentIssued)}`,
     extensionType: pair.extensionType,
   }
 }


### PR DESCRIPTION
## Ticket

Resolves #321 

## Changes 

- Displays the last payment amount in the Claim Details section 
- Adds a control on the Page story for programType
- Fixes a mistake with program type names
- Modifies some hyphens to be mdashes and ndashes

## Context

We want to display the last payment amount in the format: `$100.00 on 7/15/2021` in the `Last Payment Issued` field in the Claim Details section. 

As part of this PR, I'm cleaning up a few minor Claim Details-related issues.

## Testing

`yarn test`

PLUS

While #299 is not resolved, comment out the following lines, then run `yarn storybook`, and check that each programType displays as expected (CC @nicoleslaw) and that the `Last Payment Issued` field matches the latest mockups: https://github.com/cagov/ui-claim-tracker/blob/32990f892c6b84017c30af5d273fdd94410649e7/pages/index.tsx#L95-L98