### PR TITLE
Add "continue to certify" conditional next step 

### DIFF
--- a/public/locales/en/claim-status.json
+++ b/public/locales/en/claim-status.json
@@ -90,8 +90,9 @@
     }
   },
   "conditional-next-steps": {
-    "certify-no-pending": "<0>Keep certifying</0> as long as you need benefits.",
-    "certify-pending": "<0>Keep certifying</0> as long as you need benefits, so your payments are not delayed further.",
-    "contact-info": "Make sure we have your current phone number and email address."
+    "continue-certifying": {
+      "text": "Continue to <0>certify for benefits</0> while we determine your eligibility.",
+      "links": ["edd-ui-certify"]
+    }
   }
 }

--- a/public/locales/es/claim-status.json
+++ b/public/locales/es/claim-status.json
@@ -84,7 +84,8 @@
     }
   },
   "conditional-next-steps": {
-    "certify-no-pending": "<0>Siga certificando</0> mientras necesite beneficios.",
-    "certify-pending": "<0>Siga certificando</0> mientras necesite beneficios, para que sus pagos no se retrasen más."
+    "continue-certifying": {
+      "text": "Continúe <0>certificando los beneficios</0> mientras determinamos su elegibilidad."
+    }
   }
 }

--- a/stories/Page.stories.tsx
+++ b/stories/Page.stories.tsx
@@ -29,6 +29,11 @@ export default {
         labels: programTypeNames,
       },
     },
+    hasCertificationWeeksAvailable: {
+      control: {
+        type: 'boolean',
+      },
+    },
     errorCode: {
       control: {
         type: 'text',
@@ -41,10 +46,13 @@ export default {
 interface StoryHomeProps extends HomeProps {
   scenario: number
   programType: string
+  hasCertificationWeeksAvailable: boolean
 }
 
 const Template: Story<StoryHomeProps> = ({ ...args }) => {
-  args.scenarioContent = getScenarioContent(apiGatewayStub(args.scenario, args.programType))
+  args.scenarioContent = getScenarioContent(
+    apiGatewayStub(args.scenario, args.hasCertificationWeeksAvailable, args.programType),
+  )
   return <Home {...args} />
 }
 

--- a/tests/components/ClaimStatus.test.tsx
+++ b/tests/components/ClaimStatus.test.tsx
@@ -18,22 +18,39 @@ function renderClaimStatusComponent(statusContent: ClaimStatusContent): string {
     .toJSON()
 }
 
-function testClaimStatus(scenarioType: ScenarioType): string {
-  const scenarioContent = getScenarioContent(apiGatewayStub(scenarioType))
+function testClaimStatus(scenarioType: ScenarioType, hasCertificationWeeksAvailable: boolean): string {
+  const scenarioContent = getScenarioContent(apiGatewayStub(scenarioType, hasCertificationWeeksAvailable))
   return renderClaimStatusComponent(scenarioContent.statusContent)
 }
 
-describe('ClaimStatus', () => {
-  it('renders for Scenario1', () => {
-    expect(testClaimStatus(ScenarioType.Scenario1)).toMatchSnapshot()
+describe('Scenario 1', () => {
+  it('matches when there are weeks to certify', () => {
+    expect(testClaimStatus(ScenarioType.Scenario1, true)).toMatchSnapshot()
   })
-  it('renders for Scenario4', () => {
-    expect(testClaimStatus(ScenarioType.Scenario4)).toMatchSnapshot()
+  it("matches when there aren't weeks to certify", () => {
+    expect(testClaimStatus(ScenarioType.Scenario1, false)).toMatchSnapshot()
   })
-  it('renders for Scenario5', () => {
+})
+
+describe('Scenario 4', () => {
+  it('matches when there are weeks to certify', () => {
+    expect(testClaimStatus(ScenarioType.Scenario4, true)).toMatchSnapshot()
+  })
+  it("matches when there aren't weeks to certify", () => {
+    expect(testClaimStatus(ScenarioType.Scenario4, false)).toMatchSnapshot()
+  })
+})
+
+// Note that Scenarios 5 & 6 explicitly differ based on whether hasCertificationWeeksAvailable
+// is true or false, so it doesn't make sense to test again.
+describe('Scenario 5', () => {
+  it('matches', () => {
     expect(testClaimStatus(ScenarioType.Scenario5)).toMatchSnapshot()
   })
-  it('renders for Scenario6', () => {
+})
+
+describe('Scenario 6', () => {
+  it('matches', () => {
     expect(testClaimStatus(ScenarioType.Scenario6)).toMatchSnapshot()
   })
 })

--- a/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
+++ b/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
@@ -1,6 +1,94 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ClaimStatus renders for Scenario1 1`] = `
+exports[`Scenario 1 matches when there are weeks to certify 1`] = `
+<div
+  className="claim-status claim-section"
+>
+  <h2>
+    Claim Status
+  </h2>
+  <div
+    className="pending-status claim-subsection"
+  >
+    <h3
+      className="header-line"
+    >
+      Pending Eligibility — Phone Interview Will Be Scheduled
+    </h3>
+  </div>
+  <div
+    className="summary"
+  >
+    We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      Your Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          Continue to 
+          <a
+            href="https://edd.ca.gov/Unemployment/certify.htm"
+          >
+            certify for benefits
+          </a>
+           while we determine your eligibility.
+        </li>
+        <li
+          className="next-step"
+        >
+          Confirm we have your current 
+          <a
+            href="https://edd.ca.gov/FAQ_-_Benefit_Programs_Online.htm"
+          >
+            phone number and mailing address
+          </a>
+          .
+        </li>
+        <li
+          className="next-step"
+        >
+          Check your mail for the 
+          &lt;em&gt;Notification of Unemployment Insurance Benefits Eligibility Interview&lt;/em&gt;
+           (DE 4800). It will explain the issue and help you prepare for the interview.
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      EDD Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          We will schedule a phone interview to determine your eligibility for benefits. This page will be updated with appointment details once your interview is scheduled.
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Scenario 1 matches when there aren't weeks to certify 1`] = `
 <div
   className="claim-status claim-section"
 >
@@ -77,7 +165,111 @@ exports[`ClaimStatus renders for Scenario1 1`] = `
 </div>
 `;
 
-exports[`ClaimStatus renders for Scenario4 1`] = `
+exports[`Scenario 4 matches when there are weeks to certify 1`] = `
+<div
+  className="claim-status claim-section"
+>
+  <h2>
+    Claim Status
+  </h2>
+  <div
+    className="pending-status claim-subsection"
+  >
+    <h3
+      className="header-line"
+    >
+      Review Required
+    </h3>
+  </div>
+  <div
+    className="summary"
+  >
+    We identified an issue and may need to determine your eligibility or verify your information.
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      Your Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          Continue to 
+          <a
+            href="https://edd.ca.gov/Unemployment/certify.htm"
+          >
+            certify for benefits
+          </a>
+           while we determine your eligibility.
+        </li>
+        <li
+          className="next-step"
+        >
+          Check your 
+          UI Online homepage
+           and inbox for the latest updates.
+        </li>
+        <li
+          className="next-step"
+        >
+          Check your mail. We may send requests for additional information. Make sure to respond as requested to avoid delays in processing your claim.
+        </li>
+        <li
+          className="next-step"
+        >
+          For more information, visit 
+          <a
+            href="https://www.edd.ca.gov/unemployment/claim-status.htm"
+          >
+            Claim Status: Pending Payment
+          </a>
+          .
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      EDD Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          We will contact you if we need more information to resolve the issue.
+        </li>
+        <li
+          className="next-step"
+        >
+          We will email you when you have weeks available to 
+          <a
+            href="https://edd.ca.gov/Unemployment/certify.htm"
+          >
+            certify for benefits
+          </a>
+          .
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Scenario 4 matches when there aren't weeks to certify 1`] = `
 <div
   className="claim-status claim-section"
 >
@@ -170,7 +362,7 @@ exports[`ClaimStatus renders for Scenario4 1`] = `
 </div>
 `;
 
-exports[`ClaimStatus renders for Scenario5 1`] = `
+exports[`Scenario 5 matches 1`] = `
 <div
   className="claim-status claim-section"
 >
@@ -256,7 +448,7 @@ exports[`ClaimStatus renders for Scenario5 1`] = `
 </div>
 `;
 
-exports[`ClaimStatus renders for Scenario6 1`] = `
+exports[`Scenario 6 matches 1`] = `
 <div
   className="claim-status claim-section"
 >

--- a/utils/apiGatewayStub.tsx
+++ b/utils/apiGatewayStub.tsx
@@ -10,7 +10,11 @@ import { Claim } from '../types/common'
 /**
  * Stub the API gateway response for a given scenario.
  */
-export default function apiGatewayStub(scenarioType: ScenarioType, programType = 'UI'): Claim {
+export default function apiGatewayStub(
+  scenarioType: ScenarioType,
+  hasCertificationWeeksAvailable = false,
+  programType = 'UI',
+): Claim {
   // Default empty response from the API gateway
   const claim: Claim = {
     uniqueNumber: null,
@@ -28,12 +32,16 @@ export default function apiGatewayStub(scenarioType: ScenarioType, programType =
   switch (scenarioType) {
     case ScenarioType.Scenario1:
       claim.pendingDetermination = [{ determinationStatus: null }]
+      claim.hasCertificationWeeksAvailable = hasCertificationWeeksAvailable
       break
 
     case ScenarioType.Scenario4:
       claim.hasPendingWeeks = true
+      claim.hasCertificationWeeksAvailable = hasCertificationWeeksAvailable
       break
 
+    // Note that Scenarios 5 & 6 explicitly differ based on whether hasCertificationWeeksAvailable
+    // is true or false, so we ignore the argument.
     case ScenarioType.Scenario5:
       claim.hasPendingWeeks = false
       claim.hasCertificationWeeksAvailable = false

--- a/utils/getClaimStatus.tsx
+++ b/utils/getClaimStatus.tsx
@@ -84,12 +84,21 @@ export function buildClaimStatusSummary(
 }
 
 /**
+ * Get conditional continue certifying next step.
+ */
+export function displayContinueCertifying(): TransLineProps {
+  const keys = ['conditional-next-steps', 'continue-certifying']
+  return buildTransLineProps(claimStatusJson['conditional-next-steps']['continue-certifying'], buildI18nKey(keys))
+}
+
+/**
  * Get next steps content for Claim Status.
  */
 export function buildNextSteps(
   scenarioObject: ClaimStatusScenarioJson,
   scenarioString: string,
   whichSteps: StepType,
+  continueCertifying = false,
 ): TransLineProps[] {
   const steps: TransLineProps[] = []
   const json = scenarioObject[whichSteps]
@@ -97,13 +106,18 @@ export function buildNextSteps(
     const keys = ['scenarios', scenarioString, whichSteps, index.toString()]
     steps.push(buildTransLineProps(value, buildI18nKey(keys)))
   }
+
+  // If we should display the "continue certifying" next step, then display it as the first step.
+  if (continueCertifying) {
+    steps.unshift(displayContinueCertifying())
+  }
   return steps
 }
 
 /**
  * Get combined Claim Status content.
  */
-export default function getClaimStatus(scenarioType: ScenarioType): ClaimStatusContent {
+export default function getClaimStatus(scenarioType: ScenarioType, continueCertifying: boolean): ClaimStatusContent {
   // Explicitly cast the scenario string (e.g. scenario1, scenario2) into the union of literal types
   // expected by Typescript. scenarioString must be one of the key names in claimStatusJson.scenarios
   // or this won't compile. For a very good explanation of `keyof typeof` Typescript's and union of
@@ -116,7 +130,7 @@ export default function getClaimStatus(scenarioType: ScenarioType): ClaimStatusC
   return {
     heading: buildClaimStatusHeading(scenarioType),
     summary: buildClaimStatusSummary(scenarioObject, scenarioString),
-    yourNextSteps: buildNextSteps(scenarioObject, scenarioString, 'your-next-steps'),
+    yourNextSteps: buildNextSteps(scenarioObject, scenarioString, 'your-next-steps', continueCertifying),
     eddNextSteps: buildNextSteps(scenarioObject, scenarioString, 'edd-next-steps'),
   }
 }

--- a/utils/getClaimStatus.tsx
+++ b/utils/getClaimStatus.tsx
@@ -101,16 +101,18 @@ export function buildNextSteps(
   continueCertifying = false,
 ): TransLineProps[] {
   const steps: TransLineProps[] = []
+
+  // If we should display the "continue certifying" next step, then display it as the first step.
+  if (continueCertifying) {
+    steps.push(displayContinueCertifying())
+  }
+
   const json = scenarioObject[whichSteps]
   for (const [index, value] of json.entries()) {
     const keys = ['scenarios', scenarioString, whichSteps, index.toString()]
     steps.push(buildTransLineProps(value, buildI18nKey(keys)))
   }
 
-  // If we should display the "continue certifying" next step, then display it as the first step.
-  if (continueCertifying) {
-    steps.unshift(displayContinueCertifying())
-  }
   return steps
 }
 

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -63,10 +63,8 @@ export function continueCertifying(scenarioType: ScenarioType, claimData: Claim)
   // If the Scenario is not scenario 5 or 6
   // AND hasCertificationWeeksAvailable is true
   // Then we should display the "continue certifying" content.
-  if (
-    ![ScenarioType.Scenario5, ScenarioType.Scenario6].includes(scenarioType) &&
-    claimData.hasCertificationWeeksAvailable
-  ) {
+  const isIgnoredScenario = [ScenarioType.Scenario5, ScenarioType.Scenario6].includes(scenarioType)
+  if (!isIgnoredScenario && claimData.hasCertificationWeeksAvailable) {
     return true
   }
   // Otherwise, we should not display the "continue certifying" content.

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -56,6 +56,25 @@ export function getScenario(claimData: Claim): ScenarioType {
   }
 }
 
+/**
+ * Return whether the Claim Status should display the "continue certifying" content.
+ */
+export function continueCertifying(scenarioType: ScenarioType, claimData: Claim): boolean {
+  // If the Scenario is not scenario 5 or 6
+  // AND hasCertificationWeeksAvailable is true
+  // Then we should display the "continue certifying" content.
+  if (
+    ![ScenarioType.Scenario5, ScenarioType.Scenario6].includes(scenarioType) &&
+    claimData.hasCertificationWeeksAvailable
+  ) {
+    return true
+  }
+  // Otherwise, we should not display the "continue certifying" content.
+  else {
+    return false
+  }
+}
+
 /*
  * Return scenario content.
  */
@@ -64,7 +83,7 @@ export default function getScenarioContent(claimData: Claim): ScenarioContent {
   const scenarioType = getScenario(claimData)
 
   // Construct claim status content.
-  const statusContent = getClaimStatus(scenarioType)
+  const statusContent = getClaimStatus(scenarioType, continueCertifying(scenarioType, claimData))
 
   // Construct claim details content.
   if (!claimData.claimDetails) {


### PR DESCRIPTION
## Ticket

Resolves #319 

## Changes

- Add conditional "continue to certify" next step as the first step if there are weeks left to certify
- Add a `hasCertificationWeeksAvailable` boolean control on the Page story

## Context

If `hasCertificationWeeksAvailable` is true for any scenarios other than Scenarios 5 & 6 (the two base state scenarios), then we should display the "continue to certify" next step as the first bullet in Your Next Steps.

## Testing

`yarn test`

PLUS

While #299 is not resolved, comment out the following lines, then run `yarn storybook`, and check that the "continue to certify" next step appears first in the bulleted list when you toggle the boolean for all scenarios other than 5 & 6: https://github.com/cagov/ui-claim-tracker/blob/32990f892c6b84017c30af5d273fdd94410649e7/pages/index.tsx#L95-L98


