### PR TITLE
Add ability to have language-dependent urls

### DIFF
--- a/components/ClaimSection.tsx
+++ b/components/ClaimSection.tsx
@@ -4,13 +4,20 @@ import { ScenarioContent } from '../types/common'
 
 export interface ClaimSectionProps extends ScenarioContent {
   loading: boolean
+  userArrivedFromUioMobile: boolean
 }
 
-export const ClaimSection: React.FC<ClaimSectionProps> = ({ loading = false, statusContent, detailsContent }) => {
+export const ClaimSection: React.FC<ClaimSectionProps> = ({
+  loading = false,
+  userArrivedFromUioMobile = false,
+  statusContent,
+  detailsContent,
+}) => {
   return (
     <div className="claim-section">
       <ClaimStatus
         loading={loading}
+        userArrivedFromUioMobile={userArrivedFromUioMobile}
         heading={statusContent.heading}
         summary={statusContent.summary}
         yourNextSteps={statusContent.yourNextSteps}

--- a/components/ClaimStatus.tsx
+++ b/components/ClaimStatus.tsx
@@ -7,10 +7,12 @@ import { ClaimStatusContent } from '../types/common'
 
 export interface ClaimStatusProps extends ClaimStatusContent {
   loading: boolean
+  userArrivedFromUioMobile: boolean
 }
 
 export const ClaimStatus: React.FC<ClaimStatusProps> = ({
   loading = false,
+  userArrivedFromUioMobile = false,
   heading,
   summary,
   yourNextSteps,
@@ -25,10 +27,25 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({
         <TextLine loading={loading} header text={t(heading)} />
       </div>
       <div className="summary">
-        <TransLine loading={loading} i18nKey={summary.i18nKey} links={summary.links} />
+        <TransLine
+          loading={loading}
+          userArrivedFromUioMobile={userArrivedFromUioMobile}
+          i18nKey={summary.i18nKey}
+          links={summary.links}
+        />
       </div>
-      <NextSteps loading={loading} header={t('claim-status.your-next-steps')} nextSteps={yourNextSteps} />
-      <NextSteps loading={loading} header={t('claim-status.edd-next-steps')} nextSteps={eddNextSteps} />
+      <NextSteps
+        loading={loading}
+        userArrivedFromUioMobile={userArrivedFromUioMobile}
+        header={t('claim-status.your-next-steps')}
+        nextSteps={yourNextSteps}
+      />
+      <NextSteps
+        loading={loading}
+        userArrivedFromUioMobile={userArrivedFromUioMobile}
+        header={t('claim-status.edd-next-steps')}
+        nextSteps={eddNextSteps}
+      />
     </div>
   )
 }

--- a/components/NextSteps.tsx
+++ b/components/NextSteps.tsx
@@ -1,14 +1,20 @@
 import { Shimmer } from './Shimmer'
 import { TransLine } from './TransLine'
-import { TransLineProps } from '../types/common'
+import { TransLineContent } from '../types/common'
 
 export interface NextStepsProps {
   loading: boolean
+  userArrivedFromUioMobile: boolean
   header: string[]
-  nextSteps: TransLineProps[]
+  nextSteps: TransLineContent[]
 }
 
-export const NextSteps: React.FC<NextStepsProps> = ({ loading = false, header, nextSteps }) => {
+export const NextSteps: React.FC<NextStepsProps> = ({
+  loading = false,
+  userArrivedFromUioMobile = false,
+  header,
+  nextSteps,
+}) => {
   let loadableContent: JSX.Element
   if (loading) {
     loadableContent = <Shimmer width="100%" height={50} baseColor="#B6B2B2" shimColor="#656565" borderRadius={3} />
@@ -18,7 +24,12 @@ export const NextSteps: React.FC<NextStepsProps> = ({ loading = false, header, n
         <ul>
           {nextSteps.map((nextStep, index) => (
             <li key={index} className="next-step">
-              <TransLine i18nKey={nextStep.i18nKey} links={nextStep.links} />
+              <TransLine
+                loading={loading}
+                userArrivedFromUioMobile={userArrivedFromUioMobile}
+                i18nKey={nextStep.i18nKey}
+                links={nextStep.links}
+              />
             </li>
           ))}
         </ul>

--- a/components/TransLine.tsx
+++ b/components/TransLine.tsx
@@ -1,7 +1,6 @@
 import { Trans, useTranslation } from 'react-i18next'
 import React from 'react'
 import { Shimmer } from './Shimmer'
-import { useRouter } from 'next/router'
 import { TransLineContent } from '../types/common'
 import getUrl from '../utils/getUrl'
 

--- a/components/TransLine.tsx
+++ b/components/TransLine.tsx
@@ -1,12 +1,31 @@
 import { Trans, useTranslation } from 'react-i18next'
 import React from 'react'
 import { Shimmer } from './Shimmer'
-import { TransLineContent } from '../types/common'
+import { I18nString, TransLineContent } from '../types/common'
 import getUrl from '../utils/getUrl'
 
 export interface TransLineProps extends TransLineContent {
   loading: boolean
   userArrivedFromUioMobile: boolean
+}
+
+/**
+ * Handle url resolution.
+ */
+function resolveUrl(link: I18nString, userArrivedFromUioMobile: boolean) {
+  // Special case for UIO homepage links.
+  if (link === 'uio-home') {
+    const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-home-url-mobile') : getUrl('uio-home-url-desktop')
+    if (uioHomeLink) {
+      // If the link is for UIO homepage, do a direct getUrl() lookup.
+      // Do not pass the looked up url through t() because t() will mangle the url.
+      return uioHomeLink
+    }
+  }
+
+  // Otherwise, use t() to lookup the correct language-dependent url.
+  const { t } = useTranslation(['common', 'claim-details', 'claim-status'])
+  return t(link)
 }
 
 export const TransLine: React.FC<TransLineProps> = ({
@@ -19,25 +38,10 @@ export const TransLine: React.FC<TransLineProps> = ({
     return <Shimmer width={120} height={15} baseColor="#B6B2B2" shimColor="#656565" borderRadius={3} />
   }
 
-  const { t } = useTranslation(['common', 'claim-details', 'claim-status'])
-
   const linkComponents: JSX.Element[] = []
   if (links && links.length > 0) {
     for (const link of links) {
-      // Special case for UIO homepage links.
-      let href = ''
-      if (link === 'uio-home') {
-        const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-home-url-mobile') : getUrl('uio-home-url-desktop')
-        if (uioHomeLink) {
-          // If the link is for UIO homepage, do a direct getUrl() lookup.
-          // Do not pass the looked up url through t() because t() will mangle the url.
-          href = uioHomeLink
-        }
-      }
-      // Otherwise, use t() to lookup the correct language-dependent url.
-      else {
-        href = t(link)
-      }
+      const href = resolveUrl(link, userArrivedFromUioMobile)
       // Disabling some linting rules for this line. The anchor <a> element will
       // be interpolated by <Trans>.
       /* eslint-disable jsx-a11y/anchor-has-content */

--- a/components/TransLine.tsx
+++ b/components/TransLine.tsx
@@ -1,4 +1,4 @@
-import { Trans } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import React from 'react'
 import { Shimmer } from './Shimmer'
 import { TransLineProps } from '../types/common'
@@ -8,13 +8,15 @@ export const TransLine: React.FC<TransLineProps> = ({ loading, i18nKey, links = 
     return <Shimmer width={120} height={15} baseColor="#B6B2B2" shimColor="#656565" borderRadius={3} />
   }
 
+  const { t } = useTranslation(['common', 'claim-details', 'claim-status'])
+
   let linkComponents: JSX.Element[] = []
   if (links && links.length > 0) {
     // Disabling some linting rules for this line. The anchor <a> element will
     // be interporlated by <Trans>.
     /* eslint-disable jsx-a11y/anchor-has-content */
     /* eslint-disable react/self-closing-comp */
-    linkComponents = links.map((link) => <a href={link} key={link}></a>)
+    linkComponents = links.map((link) => <a href={t(link)} key={link}></a>)
     /* eslint-enable jsx-a11y/anchor-has-content */
     /* eslint-enable react/self-closing-comp */
   }

--- a/components/TransLine.tsx
+++ b/components/TransLine.tsx
@@ -23,22 +23,25 @@ export const TransLine: React.FC<TransLineProps> = ({
 
   const linkComponents: JSX.Element[] = []
   if (links && links.length > 0) {
-    for (let link of links) {
+    for (const link of links) {
       // Special case for UIO homepage links.
+      let href = ''
       if (link === 'uio-home') {
-        const router = useRouter()
-        const userArrivedFromUioMobile = router.query?.from === 'uiom'
         const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-home-url-mobile') : getUrl('uio-home-url-desktop')
         if (uioHomeLink) {
-          link = uioHomeLink
+          // If the link is for UIO homepage, do a direct getUrl() lookup.
+          href = uioHomeLink
         }
       }
-
+      // Otherwise, use t() to lookup the correct language-dependent url.
+      else {
+        href = t(link)
+      }
       // Disabling some linting rules for this line. The anchor <a> element will
       // be interporlated by <Trans>.
       /* eslint-disable jsx-a11y/anchor-has-content */
       /* eslint-disable react/self-closing-comp */
-      linkComponents.push(<a href={t(link)} key={link}></a>)
+      linkComponents.push(<a href={href} key={link}></a>)
       /* eslint-enable jsx-a11y/anchor-has-content */
       /* eslint-enable react/self-closing-comp */
     }

--- a/components/TransLine.tsx
+++ b/components/TransLine.tsx
@@ -2,10 +2,20 @@ import { Trans, useTranslation } from 'react-i18next'
 import React from 'react'
 import { Shimmer } from './Shimmer'
 import { useRouter } from 'next/router'
-import { TransLineProps } from '../types/common'
+import { TransLineContent } from '../types/common'
 import getUrl from '../utils/getUrl'
 
-export const TransLine: React.FC<TransLineProps> = ({ loading, i18nKey, links = [] }) => {
+export interface TransLineProps extends TransLineContent {
+  loading: boolean
+  userArrivedFromUioMobile: boolean
+}
+
+export const TransLine: React.FC<TransLineProps> = ({
+  loading = false,
+  userArrivedFromUioMobile = false,
+  i18nKey,
+  links = [],
+}) => {
   if (loading) {
     return <Shimmer width={120} height={15} baseColor="#B6B2B2" shimColor="#656565" borderRadius={3} />
   }

--- a/components/TransLine.tsx
+++ b/components/TransLine.tsx
@@ -1,7 +1,9 @@
 import { Trans, useTranslation } from 'react-i18next'
 import React from 'react'
 import { Shimmer } from './Shimmer'
+import { useRouter } from 'next/router'
 import { TransLineProps } from '../types/common'
+import getUrl from '../utils/getUrl'
 
 export const TransLine: React.FC<TransLineProps> = ({ loading, i18nKey, links = [] }) => {
   if (loading) {
@@ -10,15 +12,27 @@ export const TransLine: React.FC<TransLineProps> = ({ loading, i18nKey, links = 
 
   const { t } = useTranslation(['common', 'claim-details', 'claim-status'])
 
-  let linkComponents: JSX.Element[] = []
+  const linkComponents: JSX.Element[] = []
   if (links && links.length > 0) {
-    // Disabling some linting rules for this line. The anchor <a> element will
-    // be interporlated by <Trans>.
-    /* eslint-disable jsx-a11y/anchor-has-content */
-    /* eslint-disable react/self-closing-comp */
-    linkComponents = links.map((link) => <a href={t(link)} key={link}></a>)
-    /* eslint-enable jsx-a11y/anchor-has-content */
-    /* eslint-enable react/self-closing-comp */
+    for (let link of links) {
+      // Special case for UIO homepage links.
+      if (link === 'uio-home') {
+        const router = useRouter()
+        const userArrivedFromUioMobile = router.query?.from === 'uiom'
+        const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-home-url-mobile') : getUrl('uio-home-url-desktop')
+        if (uioHomeLink) {
+          link = uioHomeLink
+        }
+      }
+
+      // Disabling some linting rules for this line. The anchor <a> element will
+      // be interporlated by <Trans>.
+      /* eslint-disable jsx-a11y/anchor-has-content */
+      /* eslint-disable react/self-closing-comp */
+      linkComponents.push(<a href={t(link)} key={link}></a>)
+      /* eslint-enable jsx-a11y/anchor-has-content */
+      /* eslint-enable react/self-closing-comp */
+    }
   }
   return <Trans i18nKey={i18nKey}>{linkComponents}</Trans>
 }

--- a/components/TransLine.tsx
+++ b/components/TransLine.tsx
@@ -30,6 +30,7 @@ export const TransLine: React.FC<TransLineProps> = ({
         const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-home-url-mobile') : getUrl('uio-home-url-desktop')
         if (uioHomeLink) {
           // If the link is for UIO homepage, do a direct getUrl() lookup.
+          // Do not pass the looked up url through t() because t() will mangle the url.
           href = uioHomeLink
         }
       }
@@ -38,7 +39,7 @@ export const TransLine: React.FC<TransLineProps> = ({
         href = t(link)
       }
       // Disabling some linting rules for this line. The anchor <a> element will
-      // be interporlated by <Trans>.
+      // be interpolated by <Trans>.
       /* eslint-disable jsx-a11y/anchor-has-content */
       /* eslint-disable react/self-closing-comp */
       linkComponents.push(<a href={href} key={link}></a>)

--- a/public/locales/en/claim-status.json
+++ b/public/locales/en/claim-status.json
@@ -7,8 +7,8 @@
       },
       "your-next-steps": [
         {
-          "text": "Confirm we have your current <0>phone number and mailing address</0>.",
-          "links": ["edd-faq-bpo"]
+          "text": "Confirm we have your current phone number and mailing address. Go to the <0>UI Online homepage</0>, select <strong>Profile</strong> from the main menu, then select <strong>Contact Information</strong>.",
+          "links": ["urls:uio.home"]
         },
         {
           "text": "Check your mail for the <em>Notification of Unemployment Insurance Benefits Eligibility Interview</em> (DE 4800). It will explain the issue and help you prepare for the interview."
@@ -27,14 +27,15 @@
       },
       "your-next-steps": [
         {
-          "text": "Check your <0>UI Online homepage</0> and inbox for the latest updates."
+          "text": "Check your <0>UI Online homepage</0> and inbox for the latest updates.",
+          "links": ["urls:uio.home"]
         },
         {
           "text": "Check your mail. We may send requests for additional information. Make sure to respond as requested to avoid delays in processing your claim."
         },
         {
           "text": "For more information, visit <0>Claim Status: Pending Payment</0>.",
-          "links": ["edd-ui-claim-status"]
+          "links": ["claim-status:urls.edd-ui-claim-status"]
         }
       ],
       "edd-next-steps": [
@@ -43,7 +44,7 @@
         },
         {
           "text": "We will email you when you have weeks available to <0>certify for benefits</0>.",
-          "links": ["edd-ui-certify"]
+          "links": ["claim-status:urls.edd-ui-certify"]
         }
       ]
     },
@@ -54,20 +55,21 @@
       },
       "your-next-steps": [
         {
-          "text": "Check your UI Online homepage and inbox for the latest updates."
+          "text": "Check your <0>UI Online homepage</0> and inbox for the latest updates.",
+          "links": ["urls:uio.home"]
         },
         {
           "text": "Check your mail. We may send requests for additional information. Make sure to respond as requested to avoid delays in processing your claim."
         },
         {
           "text": "If it’s been more than 30 days since you last certified for benefits, you must <0>reopen your claim</0> before you can certify.",
-          "links": ["edd-ui-reopen"]
+          "links": ["claim-status:urls.edd-ui-reopen"]
         }
       ],
       "edd-next-steps": [
         {
           "text": "We will email you when you have weeks available to <0>certify for benefits</0>.",
-          "links": ["edd-ui-certify"]
+          "links": ["claim-status:urls.edd-ui-certify"]
         }
       ]
     },
@@ -75,16 +77,18 @@
       "heading": "Weeks Available to Certify",
       "summary": {
         "text": "You have weeks available to <0>certify for benefits</0>.",
-        "links": ["edd-ui-certify"]
+        "links": ["claim-status:urls.edd-ui-certify"]
       },
       "your-next-steps": [
         {
-          "text": "Select <strong>Certify for Benefits</strong> in the Notification section on your UI Online homepage."
+          "text": "Select <strong>Certify for Benefits</strong> in the Notification section on your <0>UI Online homepage</0>.",
+          "links": ["urls:uio.home"]
         }
       ],
       "edd-next-steps": [
         {
-          "text": "When we process your certification, we will update the payment status on your Claim History."
+          "text": "When we process your certification, we will update the payment status. Go to the <0>UI Online homepage</0> and select <strong>History</strong> from the main menu.",
+          "links": ["urls:uio.home"]
         }
       ]
     }
@@ -92,7 +96,12 @@
   "conditional-next-steps": {
     "continue-certifying": {
       "text": "Continue to <0>certify for benefits</0> while we determine your eligibility.",
-      "links": ["edd-ui-certify"]
+      "links": ["claim-status:urls.edd-ui-certify"]
     }
+  },
+  "urls": {
+    "edd-ui-claim-status": "https://www.edd.ca.gov/unemployment/claim-status.htm",
+    "edd-ui-certify": "https://edd.ca.gov/Unemployment/certify.htm",
+    "edd-ui-reopen": "https://edd.ca.gov/Unemployment/Reopen-A-Claim.htm"
   }
 }

--- a/public/locales/en/claim-status.json
+++ b/public/locales/en/claim-status.json
@@ -8,7 +8,7 @@
       "your-next-steps": [
         {
           "text": "Confirm we have your current phone number and mailing address. Go to the <0>UI Online homepage</0>, select <strong>Profile</strong> from the main menu, then select <strong>Contact Information</strong>.",
-          "links": ["urls:uio.home"]
+          "links": ["uio-home"]
         },
         {
           "text": "Check your mail for the <em>Notification of Unemployment Insurance Benefits Eligibility Interview</em> (DE 4800). It will explain the issue and help you prepare for the interview."
@@ -28,14 +28,14 @@
       "your-next-steps": [
         {
           "text": "Check your <0>UI Online homepage</0> and inbox for the latest updates.",
-          "links": ["urls:uio.home"]
+          "links": ["uio-home"]
         },
         {
           "text": "Check your mail. We may send requests for additional information. Make sure to respond as requested to avoid delays in processing your claim."
         },
         {
           "text": "For more information, visit <0>Claim Status: Pending Payment</0>.",
-          "links": ["claim-status:urls.edd-ui-claim-status"]
+          "links": ["urls.edd.ui-claim-status"]
         }
       ],
       "edd-next-steps": [
@@ -44,7 +44,7 @@
         },
         {
           "text": "We will email you when you have weeks available to <0>certify for benefits</0>.",
-          "links": ["claim-status:urls.edd-ui-certify"]
+          "links": ["urls.edd.ui-certify"]
         }
       ]
     },
@@ -56,20 +56,20 @@
       "your-next-steps": [
         {
           "text": "Check your <0>UI Online homepage</0> and inbox for the latest updates.",
-          "links": ["urls:uio.home"]
+          "links": ["uio-home"]
         },
         {
           "text": "Check your mail. We may send requests for additional information. Make sure to respond as requested to avoid delays in processing your claim."
         },
         {
           "text": "If it’s been more than 30 days since you last certified for benefits, you must <0>reopen your claim</0> before you can certify.",
-          "links": ["claim-status:urls.edd-ui-reopen"]
+          "links": ["urls.edd.ui-reopen"]
         }
       ],
       "edd-next-steps": [
         {
           "text": "We will email you when you have weeks available to <0>certify for benefits</0>.",
-          "links": ["claim-status:urls.edd-ui-certify"]
+          "links": ["urls.edd.ui-certify"]
         }
       ]
     },
@@ -77,18 +77,18 @@
       "heading": "Weeks Available to Certify",
       "summary": {
         "text": "You have weeks available to <0>certify for benefits</0>.",
-        "links": ["claim-status:urls.edd-ui-certify"]
+        "links": ["urls.edd.ui-certify"]
       },
       "your-next-steps": [
         {
           "text": "Select <strong>Certify for Benefits</strong> in the Notification section on your <0>UI Online homepage</0>.",
-          "links": ["urls:uio.home"]
+          "links": ["uio-home"]
         }
       ],
       "edd-next-steps": [
         {
           "text": "When we process your certification, we will update the payment status. Go to the <0>UI Online homepage</0> and select <strong>History</strong> from the main menu.",
-          "links": ["urls:uio.home"]
+          "links": ["uio-home"]
         }
       ]
     }
@@ -96,12 +96,7 @@
   "conditional-next-steps": {
     "continue-certifying": {
       "text": "Continue to <0>certify for benefits</0> while we determine your eligibility.",
-      "links": ["claim-status:urls.edd-ui-certify"]
+      "links": ["urls.edd.ui-certify"]
     }
-  },
-  "urls": {
-    "edd-ui-claim-status": "https://www.edd.ca.gov/unemployment/claim-status.htm",
-    "edd-ui-certify": "https://edd.ca.gov/Unemployment/certify.htm",
-    "edd-ui-reopen": "https://edd.ca.gov/Unemployment/Reopen-A-Claim.htm"
   }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -38,5 +38,12 @@
     "header": "Your Session Will End Soon",
     "warning": "To protect your information, you will be logged out in {{numberOfMinutes}} minutes if you do not continue.",
     "button": "Stay Logged In"
+  },
+  "urls": {
+    "edd": {
+      "ui-certify": "https://edd.ca.gov/Unemployment/certify.htm",
+      "ui-claim-status": "https://www.edd.ca.gov/unemployment/claim-status.htm",
+      "ui-reopen": "https://edd.ca.gov/Unemployment/Reopen-A-Claim.htm"
+    }
   }
 }

--- a/public/locales/es/claim-status.json
+++ b/public/locales/es/claim-status.json
@@ -87,12 +87,5 @@
     "continue-certifying": {
       "text": "Continúe <0>certificando los beneficios</0> mientras determinamos su elegibilidad."
     }
-  },
-  "urls": {
-    "edd": {
-      "ui-claim-status": "https://www.edd.ca.gov/unemployment/claim-status-espanol.htm",
-      "ui-certify": "https://edd.ca.gov/Unemployment/certify-espanol.htm",
-      "ui-reopen": "https://edd.ca.gov/Unemployment/Reopen-A-Claim-Espanol.htm"
-    }
   }
 }

--- a/public/locales/es/claim-status.json
+++ b/public/locales/es/claim-status.json
@@ -7,7 +7,7 @@
       },
       "your-next-steps": [
         {
-          "text": "Confirme que tenemos su <0>número de teléfono y dirección postal</0> actuales."
+          "text": "Confirme que tenemos su número de teléfono y dirección postal actuales. Vaya a la <0>página de inicio de UI Online</0>, seleccione <strong>Perfil</strong> en el menú principal y luego seleccione <strong>Información de contacto</strong>."
         },
         {
           "text": "Consulte su correo para obtener la <em>Notificación de la entrevista de elegibilidad para los beneficios del seguro de desempleo</em> (DE 4800). Le explicará el problema y le ayudará a prepararse para la entrevista."
@@ -78,7 +78,7 @@
       ],
       "edd-next-steps": [
         {
-          "text": "Cuando procesemos su certificación, actualizaremos el estado de pago en su Historial de reclamos."
+          "text": "Cuando procesemos su certificación, actualizaremos el estado del pago. Vaya a la <0>página de inicio de UI Online</0> y seleccione <strong>Historial</strong> en el menú principal."
         }
       ]
     }
@@ -86,6 +86,13 @@
   "conditional-next-steps": {
     "continue-certifying": {
       "text": "Continúe <0>certificando los beneficios</0> mientras determinamos su elegibilidad."
+    }
+  },
+  "urls": {
+    "edd": {
+      "ui-claim-status": "https://www.edd.ca.gov/unemployment/claim-status-espanol.htm",
+      "ui-certify": "https://edd.ca.gov/Unemployment/certify-espanol.htm",
+      "ui-reopen": "https://edd.ca.gov/Unemployment/Reopen-A-Claim-Espanol.htm"
     }
   }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -38,5 +38,12 @@
     "header": "Tu sesión terminará pronto",
     "warning": "Para proteger su información, se cerrará la sesión en {{numberOfMinutes}} minutos si no continúa.",
     "button": "Sigue Trabajando"
+  },
+  "urls": {
+    "edd": {
+      "ui-certify": "https://edd.ca.gov/Unemployment/certify-espanol.htm",
+      "ui-claim-status": "https://www.edd.ca.gov/unemployment/claim-status-espanol.htm",
+      "ui-reopen": "https://edd.ca.gov/Unemployment/Reopen-A-Claim-Espanol.htm"
+    }
   }
 }

--- a/public/urls.json
+++ b/public/urls.json
@@ -5,14 +5,9 @@
   "edd-about-contact": "https://www.edd.ca.gov/About_EDD/Contact_EDD.htm",
   "edd-about-privacy-policy": "https://www.edd.ca.gov/About_EDD/Privacy_Policy.htm",
   "edd-ca-gov": "https://edd.ca.gov",
-  "edd-faq-bpo": "https://edd.ca.gov/FAQ_-_Benefit_Programs_Online.htm",
   "edd-help-new-claim": "https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=en-US/Public/NewClaim/UIOnlineNewClaimLandingPage.htm",
   "edd-log-in": "https://portal.edd.ca.gov/WebApp/Login?resource_url=",
   "edd-log-out": "https://portal.edd.ca.gov/WebApp/Logout",
-  "edd-ui-certify": "https://edd.ca.gov/Unemployment/certify.htm",
-  "edd-ui-claim-status": "https://www.edd.ca.gov/unemployment/claim-status.htm",
-  "edd-ui-eligibility": "https://edd.ca.gov/Unemployment/Eligibility.htm",
-  "edd-ui-reopen": "https://edd.ca.gov/Unemployment/Reopen-A-Claim.htm",
   "uio-home-url-desktop": "https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx",
   "uio-home-url-mobile": "https://uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
 }

--- a/setupTests.tsx
+++ b/setupTests.tsx
@@ -32,6 +32,10 @@ i18n.use(initReactI18next).init({
           styledStringOneLink: 'first <strong>second</strong> <0>third</0>',
           styledLink: 'first <strong><0>second</0></strong>',
         },
+        urls: {
+          alpha: 'https://example.com/alpha',
+          beta: 'https://example.com/beta',
+        },
       },
     },
   },

--- a/stories/Page.stories.tsx
+++ b/stories/Page.stories.tsx
@@ -34,6 +34,11 @@ export default {
         type: 'boolean',
       },
     },
+    userArrivedFromUioMobile: {
+      control: {
+        type: 'boolean',
+      },
+    },
     errorCode: {
       control: {
         type: 'text',

--- a/stories/TransLine.stories.tsx
+++ b/stories/TransLine.stories.tsx
@@ -1,6 +1,5 @@
 import { Story, Meta } from '@storybook/react'
-import { TransLine as TransLineComponent } from '../components/TransLine'
-import { TransLineProps } from '../types/common'
+import { TransLine as TransLineComponent, TransLineProps } from '../components/TransLine'
 
 export default {
   title: 'Component/Atoms/Trans Line',

--- a/tests/components/ClaimStatus.test.tsx
+++ b/tests/components/ClaimStatus.test.tsx
@@ -4,30 +4,12 @@ import getScenarioContent, { ScenarioType } from '../../utils/getScenarioContent
 import apiGatewayStub from '../../utils/apiGatewayStub'
 import { ClaimStatusContent } from '../../types/common'
 
-import { useRouter } from 'next/router'
-
-jest.mock('next/router', () => ({
-  __esModule: true,
-  useRouter: jest.fn(),
-}))
-
-function mockTheRouter(fromUiom: false) {
-  const mockRouter = {
-    locale: 'en',
-  }
-  if (fromUiom) {
-    mockRouter.query = {
-      from: 'uiom',
-    }
-  }
-  ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
-}
-
-function renderClaimStatusComponent(statusContent: ClaimStatusContent): string {
+function renderClaimStatusComponent(statusContent: ClaimStatusContent, userArrivedFromUioMobile: boolean): string {
   return renderer
     .create(
       <ClaimStatus
         loading={false}
+        userArrivedFromUioMobile={userArrivedFromUioMobile}
         heading={statusContent.heading}
         summary={statusContent.summary}
         yourNextSteps={statusContent.yourNextSteps}
@@ -40,11 +22,10 @@ function renderClaimStatusComponent(statusContent: ClaimStatusContent): string {
 function testClaimStatus(
   scenarioType: ScenarioType,
   hasCertificationWeeksAvailable: boolean,
-  fromUiom: boolean,
+  userArrivedFromUioMobile: boolean,
 ): string {
-  mockTheRouter(fromUiom)
   const scenarioContent = getScenarioContent(apiGatewayStub(scenarioType, hasCertificationWeeksAvailable))
-  return renderClaimStatusComponent(scenarioContent.statusContent)
+  return renderClaimStatusComponent(scenarioContent.statusContent, userArrivedFromUioMobile)
 }
 
 describe('Scenario 1', () => {

--- a/tests/components/ClaimStatus.test.tsx
+++ b/tests/components/ClaimStatus.test.tsx
@@ -4,6 +4,25 @@ import getScenarioContent, { ScenarioType } from '../../utils/getScenarioContent
 import apiGatewayStub from '../../utils/apiGatewayStub'
 import { ClaimStatusContent } from '../../types/common'
 
+import { useRouter } from 'next/router'
+
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: jest.fn(),
+}))
+
+function mockTheRouter(fromUiom: false) {
+  const mockRouter = {
+    locale: 'en',
+  }
+  if (fromUiom) {
+    mockRouter.query = {
+      from: 'uiom',
+    }
+  }
+  ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+}
+
 function renderClaimStatusComponent(statusContent: ClaimStatusContent): string {
   return renderer
     .create(
@@ -18,39 +37,64 @@ function renderClaimStatusComponent(statusContent: ClaimStatusContent): string {
     .toJSON()
 }
 
-function testClaimStatus(scenarioType: ScenarioType, hasCertificationWeeksAvailable: boolean): string {
+function testClaimStatus(
+  scenarioType: ScenarioType,
+  hasCertificationWeeksAvailable: boolean,
+  fromUiom: boolean,
+): string {
+  mockTheRouter(fromUiom)
   const scenarioContent = getScenarioContent(apiGatewayStub(scenarioType, hasCertificationWeeksAvailable))
   return renderClaimStatusComponent(scenarioContent.statusContent)
 }
 
 describe('Scenario 1', () => {
-  it('matches when there are weeks to certify', () => {
+  it('matches when there are weeks to certify, on desktop', () => {
     expect(testClaimStatus(ScenarioType.Scenario1, true)).toMatchSnapshot()
   })
-  it("matches when there aren't weeks to certify", () => {
+  it('matches when there are weeks to certify, on mobile', () => {
+    expect(testClaimStatus(ScenarioType.Scenario1, true, true)).toMatchSnapshot()
+  })
+
+  it("matches when there aren't weeks to certify, on desktop", () => {
     expect(testClaimStatus(ScenarioType.Scenario1, false)).toMatchSnapshot()
+  })
+  it("matches when there aren't weeks to certify, on mobile", () => {
+    expect(testClaimStatus(ScenarioType.Scenario1, false, true)).toMatchSnapshot()
   })
 })
 
 describe('Scenario 4', () => {
-  it('matches when there are weeks to certify', () => {
+  it('matches when there are weeks to certify, on desktop', () => {
     expect(testClaimStatus(ScenarioType.Scenario4, true)).toMatchSnapshot()
   })
-  it("matches when there aren't weeks to certify", () => {
+  it('matches when there are weeks to certify, on mobile', () => {
+    expect(testClaimStatus(ScenarioType.Scenario4, true, true)).toMatchSnapshot()
+  })
+
+  it("matches when there aren't weeks to certify, on desktop", () => {
     expect(testClaimStatus(ScenarioType.Scenario4, false)).toMatchSnapshot()
+  })
+  it("matches when there aren't weeks to certify, on mobile", () => {
+    expect(testClaimStatus(ScenarioType.Scenario4, false, true)).toMatchSnapshot()
   })
 })
 
 // Note that Scenarios 5 & 6 explicitly differ based on whether hasCertificationWeeksAvailable
 // is true or false, so it doesn't make sense to test again.
 describe('Scenario 5', () => {
-  it('matches', () => {
+  it('matches, on desktop', () => {
     expect(testClaimStatus(ScenarioType.Scenario5)).toMatchSnapshot()
+  })
+  it('matches, on mobile', () => {
+    expect(testClaimStatus(ScenarioType.Scenario5, true, true)).toMatchSnapshot()
   })
 })
 
 describe('Scenario 6', () => {
-  it('matches', () => {
+  it('matches, on desktop', () => {
     expect(testClaimStatus(ScenarioType.Scenario6)).toMatchSnapshot()
+  })
+  it('matches, on mobile', () => {
+    expect(testClaimStatus(ScenarioType.Scenario6, true, true)).toMatchSnapshot()
   })
 })

--- a/tests/components/TransLine.test.tsx
+++ b/tests/components/TransLine.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/react'
 import { TransLine } from '../../components/TransLine'
 
+const alpha = 'https://example.com/alpha'
+const beta = 'https://example.com/beta'
+
 describe('TransLine component loads', () => {
   it('a string with no links or styles', () => {
     render(<TransLine i18nKey="test:transLine.plainString" />)
@@ -8,25 +11,25 @@ describe('TransLine component loads', () => {
   })
 
   it('a string with one link and no styles', () => {
-    const links = ['https://example.com']
+    const links = ['test:urls.alpha']
     render(<TransLine i18nKey="test:transLine.plainStringOneLink" links={links} />)
-    expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', links[0])
+    expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', alpha)
   })
 
   it('a string with multiple links and no styles', () => {
-    const links = ['https://example.com/alpha', 'https://example.com/beta']
+    const links = ['test:urls.alpha', 'test:urls.beta']
     render(<TransLine i18nKey="test:transLine.plainStringLinks" links={links} />)
-    expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', links[0])
-    expect(screen.getByRole('link', { name: 'third' })).toHaveAttribute('href', links[1])
+    expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', alpha)
+    expect(screen.getByRole('link', { name: 'third' })).toHaveAttribute('href', beta)
   })
 
   it('a string with multiple links reused links and out of order', () => {
-    const links = ['https://example.com/alpha', 'https://example.com/beta']
+    const links = ['test:urls.alpha', 'test:urls.beta']
     render(<TransLine i18nKey="test:transLine.plainStringLinksComplicated" links={links} />)
-    expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', links[0])
-    expect(screen.getByRole('link', { name: 'fourth' })).toHaveAttribute('href', links[0])
-    expect(screen.getByRole('link', { name: 'first' })).toHaveAttribute('href', links[1])
-    expect(screen.getByRole('link', { name: 'fifth' })).toHaveAttribute('href', links[1])
+    expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', alpha)
+    expect(screen.getByRole('link', { name: 'fourth' })).toHaveAttribute('href', alpha)
+    expect(screen.getByRole('link', { name: 'first' })).toHaveAttribute('href', beta)
+    expect(screen.getByRole('link', { name: 'fifth' })).toHaveAttribute('href', beta)
   })
 
   it('a string with no links, but with styles', () => {
@@ -39,22 +42,22 @@ describe('TransLine component loads', () => {
   })
 
   it('a string with one link and styles', () => {
-    const links = ['https://example.com/alpha']
+    const links = ['test:urls.alpha']
     render(<TransLine i18nKey="test:transLine.styledStringOneLink" links={links} />)
     expect(screen.getByText('first', { exact: false })).toBeInTheDocument()
     screen.getByText((content, element) => {
       return element.tagName.toLowerCase() === 'strong' && content.startsWith('second')
     })
-    expect(screen.getByRole('link', { name: 'third' })).toHaveAttribute('href', links[0])
+    expect(screen.getByRole('link', { name: 'third' })).toHaveAttribute('href', alpha)
   })
 
   it('a string with a styled link', () => {
-    const links = ['https://example.com/alpha']
+    const links = ['test:urls.alpha']
     render(<TransLine i18nKey="test:transLine.styledLink" links={links} />)
     expect(screen.getByText('first', { exact: false })).toBeInTheDocument()
     screen.getByText((content, element) => {
       return element.tagName.toLowerCase() === 'strong'
     })
-    expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', links[0])
+    expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', alpha)
   })
 })

--- a/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
+++ b/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`Scenario 1 matches when there are weeks to certify, on desktop 1`] = `
         >
           Confirm we have your current phone number and mailing address. Go to the 
           <a
-            href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
+            href="https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
           >
             UI Online homepage
           </a>
@@ -145,7 +145,7 @@ exports[`Scenario 1 matches when there are weeks to certify, on mobile 1`] = `
         >
           Confirm we have your current phone number and mailing address. Go to the 
           <a
-            href="//uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+            href="https://uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
           >
             UI Online homepage
           </a>
@@ -230,7 +230,7 @@ exports[`Scenario 1 matches when there aren't weeks to certify, on desktop 1`] =
         >
           Confirm we have your current phone number and mailing address. Go to the 
           <a
-            href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
+            href="https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
           >
             UI Online homepage
           </a>
@@ -277,7 +277,7 @@ exports[`Scenario 1 matches when there aren't weeks to certify, on desktop 1`] =
 </div>
 `;
 
-exports[`Scenario 1 matches when there aren't weeks to certify, on desktop 2`] = `
+exports[`Scenario 1 matches when there aren't weeks to certify, on mobile 1`] = `
 <div
   className="claim-status claim-section"
 >
@@ -315,7 +315,7 @@ exports[`Scenario 1 matches when there aren't weeks to certify, on desktop 2`] =
         >
           Confirm we have your current phone number and mailing address. Go to the 
           <a
-            href="//uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+            href="https://uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
           >
             UI Online homepage
           </a>
@@ -411,7 +411,7 @@ exports[`Scenario 4 matches when there are weeks to certify, on desktop 1`] = `
         >
           Check your 
           <a
-            href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
+            href="https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
           >
             UI Online homepage
           </a>
@@ -519,7 +519,7 @@ exports[`Scenario 4 matches when there are weeks to certify, on mobile 1`] = `
         >
           Check your 
           <a
-            href="//uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+            href="https://uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
           >
             UI Online homepage
           </a>
@@ -616,7 +616,7 @@ exports[`Scenario 4 matches when there aren't weeks to certify, on desktop 1`] =
         >
           Check your 
           <a
-            href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
+            href="https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
           >
             UI Online homepage
           </a>
@@ -713,7 +713,7 @@ exports[`Scenario 4 matches when there aren't weeks to certify, on mobile 1`] = 
         >
           Check your 
           <a
-            href="//uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+            href="https://uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
           >
             UI Online homepage
           </a>
@@ -810,7 +810,7 @@ exports[`Scenario 5 matches, on desktop 1`] = `
         >
           Check your 
           <a
-            href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
+            href="https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
           >
             UI Online homepage
           </a>
@@ -902,7 +902,7 @@ exports[`Scenario 5 matches, on mobile 1`] = `
         >
           Check your 
           <a
-            href="//uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+            href="https://uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
           >
             UI Online homepage
           </a>
@@ -1004,7 +1004,7 @@ exports[`Scenario 6 matches, on desktop 1`] = `
           </strong>
            in the Notification section on your 
           <a
-            href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
+            href="https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
           >
             UI Online homepage
           </a>
@@ -1030,7 +1030,7 @@ exports[`Scenario 6 matches, on desktop 1`] = `
         >
           When we process your certification, we will update the payment status. Go to the 
           <a
-            href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
+            href="https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
           >
             UI Online homepage
           </a>
@@ -1094,7 +1094,7 @@ exports[`Scenario 6 matches, on mobile 1`] = `
           </strong>
            in the Notification section on your 
           <a
-            href="//uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+            href="https://uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
           >
             UI Online homepage
           </a>
@@ -1120,7 +1120,7 @@ exports[`Scenario 6 matches, on mobile 1`] = `
         >
           When we process your certification, we will update the payment status. Go to the 
           <a
-            href="//uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+            href="https://uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
           >
             UI Online homepage
           </a>

--- a/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
+++ b/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Scenario 1 matches when there are weeks to certify 1`] = `
+exports[`Scenario 1 matches when there are weeks to certify, on desktop 1`] = `
 <div
   className="claim-status claim-section"
 >
@@ -47,12 +47,20 @@ exports[`Scenario 1 matches when there are weeks to certify 1`] = `
         <li
           className="next-step"
         >
-          Confirm we have your current 
+          Confirm we have your current phone number and mailing address. Go to the 
           <a
-            href="https://edd.ca.gov/FAQ_-_Benefit_Programs_Online.htm"
+            href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
           >
-            phone number and mailing address
+            UI Online homepage
           </a>
+          , select 
+          <strong>
+            Profile
+          </strong>
+           from the main menu, then select 
+          <strong>
+            Contact Information
+          </strong>
           .
         </li>
         <li
@@ -88,7 +96,7 @@ exports[`Scenario 1 matches when there are weeks to certify 1`] = `
 </div>
 `;
 
-exports[`Scenario 1 matches when there aren't weeks to certify 1`] = `
+exports[`Scenario 1 matches when there are weeks to certify, on mobile 1`] = `
 <div
   className="claim-status claim-section"
 >
@@ -124,12 +132,31 @@ exports[`Scenario 1 matches when there aren't weeks to certify 1`] = `
         <li
           className="next-step"
         >
-          Confirm we have your current 
+          Continue to 
           <a
-            href="https://edd.ca.gov/FAQ_-_Benefit_Programs_Online.htm"
+            href="https://edd.ca.gov/Unemployment/certify.htm"
           >
-            phone number and mailing address
+            certify for benefits
           </a>
+           while we determine your eligibility.
+        </li>
+        <li
+          className="next-step"
+        >
+          Confirm we have your current phone number and mailing address. Go to the 
+          <a
+            href="//uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+          >
+            UI Online homepage
+          </a>
+          , select 
+          <strong>
+            Profile
+          </strong>
+           from the main menu, then select 
+          <strong>
+            Contact Information
+          </strong>
           .
         </li>
         <li
@@ -165,7 +192,177 @@ exports[`Scenario 1 matches when there aren't weeks to certify 1`] = `
 </div>
 `;
 
-exports[`Scenario 4 matches when there are weeks to certify 1`] = `
+exports[`Scenario 1 matches when there aren't weeks to certify, on desktop 1`] = `
+<div
+  className="claim-status claim-section"
+>
+  <h2>
+    Claim Status
+  </h2>
+  <div
+    className="pending-status claim-subsection"
+  >
+    <h3
+      className="header-line"
+    >
+      Pending Eligibility — Phone Interview Will Be Scheduled
+    </h3>
+  </div>
+  <div
+    className="summary"
+  >
+    We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      Your Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          Confirm we have your current phone number and mailing address. Go to the 
+          <a
+            href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
+          >
+            UI Online homepage
+          </a>
+          , select 
+          <strong>
+            Profile
+          </strong>
+           from the main menu, then select 
+          <strong>
+            Contact Information
+          </strong>
+          .
+        </li>
+        <li
+          className="next-step"
+        >
+          Check your mail for the 
+          &lt;em&gt;Notification of Unemployment Insurance Benefits Eligibility Interview&lt;/em&gt;
+           (DE 4800). It will explain the issue and help you prepare for the interview.
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      EDD Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          We will schedule a phone interview to determine your eligibility for benefits. This page will be updated with appointment details once your interview is scheduled.
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Scenario 1 matches when there aren't weeks to certify, on desktop 2`] = `
+<div
+  className="claim-status claim-section"
+>
+  <h2>
+    Claim Status
+  </h2>
+  <div
+    className="pending-status claim-subsection"
+  >
+    <h3
+      className="header-line"
+    >
+      Pending Eligibility — Phone Interview Will Be Scheduled
+    </h3>
+  </div>
+  <div
+    className="summary"
+  >
+    We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      Your Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          Confirm we have your current phone number and mailing address. Go to the 
+          <a
+            href="//uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+          >
+            UI Online homepage
+          </a>
+          , select 
+          <strong>
+            Profile
+          </strong>
+           from the main menu, then select 
+          <strong>
+            Contact Information
+          </strong>
+          .
+        </li>
+        <li
+          className="next-step"
+        >
+          Check your mail for the 
+          &lt;em&gt;Notification of Unemployment Insurance Benefits Eligibility Interview&lt;/em&gt;
+           (DE 4800). It will explain the issue and help you prepare for the interview.
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      EDD Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          We will schedule a phone interview to determine your eligibility for benefits. This page will be updated with appointment details once your interview is scheduled.
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Scenario 4 matches when there are weeks to certify, on desktop 1`] = `
 <div
   className="claim-status claim-section"
 >
@@ -213,7 +410,11 @@ exports[`Scenario 4 matches when there are weeks to certify 1`] = `
           className="next-step"
         >
           Check your 
-          UI Online homepage
+          <a
+            href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
+          >
+            UI Online homepage
+          </a>
            and inbox for the latest updates.
         </li>
         <li
@@ -269,7 +470,7 @@ exports[`Scenario 4 matches when there are weeks to certify 1`] = `
 </div>
 `;
 
-exports[`Scenario 4 matches when there aren't weeks to certify 1`] = `
+exports[`Scenario 4 matches when there are weeks to certify, on mobile 1`] = `
 <div
   className="claim-status claim-section"
 >
@@ -305,8 +506,23 @@ exports[`Scenario 4 matches when there aren't weeks to certify 1`] = `
         <li
           className="next-step"
         >
+          Continue to 
+          <a
+            href="https://edd.ca.gov/Unemployment/certify.htm"
+          >
+            certify for benefits
+          </a>
+           while we determine your eligibility.
+        </li>
+        <li
+          className="next-step"
+        >
           Check your 
-          UI Online homepage
+          <a
+            href="//uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+          >
+            UI Online homepage
+          </a>
            and inbox for the latest updates.
         </li>
         <li
@@ -362,7 +578,201 @@ exports[`Scenario 4 matches when there aren't weeks to certify 1`] = `
 </div>
 `;
 
-exports[`Scenario 5 matches 1`] = `
+exports[`Scenario 4 matches when there aren't weeks to certify, on desktop 1`] = `
+<div
+  className="claim-status claim-section"
+>
+  <h2>
+    Claim Status
+  </h2>
+  <div
+    className="pending-status claim-subsection"
+  >
+    <h3
+      className="header-line"
+    >
+      Review Required
+    </h3>
+  </div>
+  <div
+    className="summary"
+  >
+    We identified an issue and may need to determine your eligibility or verify your information.
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      Your Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          Check your 
+          <a
+            href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
+          >
+            UI Online homepage
+          </a>
+           and inbox for the latest updates.
+        </li>
+        <li
+          className="next-step"
+        >
+          Check your mail. We may send requests for additional information. Make sure to respond as requested to avoid delays in processing your claim.
+        </li>
+        <li
+          className="next-step"
+        >
+          For more information, visit 
+          <a
+            href="https://www.edd.ca.gov/unemployment/claim-status.htm"
+          >
+            Claim Status: Pending Payment
+          </a>
+          .
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      EDD Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          We will contact you if we need more information to resolve the issue.
+        </li>
+        <li
+          className="next-step"
+        >
+          We will email you when you have weeks available to 
+          <a
+            href="https://edd.ca.gov/Unemployment/certify.htm"
+          >
+            certify for benefits
+          </a>
+          .
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Scenario 4 matches when there aren't weeks to certify, on mobile 1`] = `
+<div
+  className="claim-status claim-section"
+>
+  <h2>
+    Claim Status
+  </h2>
+  <div
+    className="pending-status claim-subsection"
+  >
+    <h3
+      className="header-line"
+    >
+      Review Required
+    </h3>
+  </div>
+  <div
+    className="summary"
+  >
+    We identified an issue and may need to determine your eligibility or verify your information.
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      Your Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          Check your 
+          <a
+            href="//uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+          >
+            UI Online homepage
+          </a>
+           and inbox for the latest updates.
+        </li>
+        <li
+          className="next-step"
+        >
+          Check your mail. We may send requests for additional information. Make sure to respond as requested to avoid delays in processing your claim.
+        </li>
+        <li
+          className="next-step"
+        >
+          For more information, visit 
+          <a
+            href="https://www.edd.ca.gov/unemployment/claim-status.htm"
+          >
+            Claim Status: Pending Payment
+          </a>
+          .
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      EDD Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          We will contact you if we need more information to resolve the issue.
+        </li>
+        <li
+          className="next-step"
+        >
+          We will email you when you have weeks available to 
+          <a
+            href="https://edd.ca.gov/Unemployment/certify.htm"
+          >
+            certify for benefits
+          </a>
+          .
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Scenario 5 matches, on desktop 1`] = `
 <div
   className="claim-status claim-section"
 >
@@ -398,7 +808,13 @@ exports[`Scenario 5 matches 1`] = `
         <li
           className="next-step"
         >
-          Check your UI Online homepage and inbox for the latest updates.
+          Check your 
+          <a
+            href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
+          >
+            UI Online homepage
+          </a>
+           and inbox for the latest updates.
         </li>
         <li
           className="next-step"
@@ -448,7 +864,99 @@ exports[`Scenario 5 matches 1`] = `
 </div>
 `;
 
-exports[`Scenario 6 matches 1`] = `
+exports[`Scenario 5 matches, on mobile 1`] = `
+<div
+  className="claim-status claim-section"
+>
+  <h2>
+    Claim Status
+  </h2>
+  <div
+    className="pending-status claim-subsection"
+  >
+    <h3
+      className="header-line"
+    >
+      No Weeks Available to Certify
+    </h3>
+  </div>
+  <div
+    className="summary"
+  >
+    You currently have no weeks available to certify for benefits.
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      Your Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          Check your 
+          <a
+            href="//uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+          >
+            UI Online homepage
+          </a>
+           and inbox for the latest updates.
+        </li>
+        <li
+          className="next-step"
+        >
+          Check your mail. We may send requests for additional information. Make sure to respond as requested to avoid delays in processing your claim.
+        </li>
+        <li
+          className="next-step"
+        >
+          If it’s been more than 30 days since you last certified for benefits, you must 
+          <a
+            href="https://edd.ca.gov/Unemployment/Reopen-A-Claim.htm"
+          >
+            reopen your claim
+          </a>
+           before you can certify.
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      EDD Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          We will email you when you have weeks available to 
+          <a
+            href="https://edd.ca.gov/Unemployment/certify.htm"
+          >
+            certify for benefits
+          </a>
+          .
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Scenario 6 matches, on desktop 1`] = `
 <div
   className="claim-status claim-section"
 >
@@ -494,7 +1002,13 @@ exports[`Scenario 6 matches 1`] = `
           <strong>
             Certify for Benefits
           </strong>
-           in the Notification section on your UI Online homepage.
+           in the Notification section on your 
+          <a
+            href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
+          >
+            UI Online homepage
+          </a>
+          .
         </li>
       </ul>
     </div>
@@ -514,7 +1028,107 @@ exports[`Scenario 6 matches 1`] = `
         <li
           className="next-step"
         >
-          When we process your certification, we will update the payment status on your Claim History.
+          When we process your certification, we will update the payment status. Go to the 
+          <a
+            href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
+          >
+            UI Online homepage
+          </a>
+           and select 
+          <strong>
+            History
+          </strong>
+           from the main menu.
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Scenario 6 matches, on mobile 1`] = `
+<div
+  className="claim-status claim-section"
+>
+  <h2>
+    Claim Status
+  </h2>
+  <div
+    className="pending-status claim-subsection"
+  >
+    <h3
+      className="header-line"
+    >
+      Weeks Available to Certify
+    </h3>
+  </div>
+  <div
+    className="summary"
+  >
+    You have weeks available to 
+    <a
+      href="https://edd.ca.gov/Unemployment/certify.htm"
+    >
+      certify for benefits
+    </a>
+    .
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      Your Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          Select 
+          <strong>
+            Certify for Benefits
+          </strong>
+           in the Notification section on your 
+          <a
+            href="//uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+          >
+            UI Online homepage
+          </a>
+          .
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div
+    className="next-steps claim-subsection"
+  >
+    <h3
+      className="next-steps-header"
+    >
+      EDD Next Steps
+    </h3>
+    <div
+      className="next-step-explanation"
+    >
+      <ul>
+        <li
+          className="next-step"
+        >
+          When we process your certification, we will update the payment status. Go to the 
+          <a
+            href="//uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+          >
+            UI Online homepage
+          </a>
+           and select 
+          <strong>
+            History
+          </strong>
+           from the main menu.
         </li>
       </ul>
     </div>

--- a/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/tests/pages/__snapshots__/index.test.tsx.snap
@@ -201,12 +201,20 @@ exports[`Exemplar react-test-renderer Snapshot test renders homepage unchanged 1
                 <li
                   className="next-step"
                 >
-                  Confirm we have your current 
+                  Confirm we have your current phone number and mailing address. Go to the 
                   <a
-                    href="https://edd.ca.gov/FAQ_-_Benefit_Programs_Online.htm"
+                    href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
                   >
-                    phone number and mailing address
+                    UI Online homepage
                   </a>
+                  , select 
+                  <strong>
+                    Profile
+                  </strong>
+                   from the main menu, then select 
+                  <strong>
+                    Contact Information
+                  </strong>
                   .
                 </li>
                 <li

--- a/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/tests/pages/__snapshots__/index.test.tsx.snap
@@ -203,7 +203,7 @@ exports[`Exemplar react-test-renderer Snapshot test renders homepage unchanged 1
                 >
                   Confirm we have your current phone number and mailing address. Go to the 
                   <a
-                    href="//uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
+                    href="https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx"
                   >
                     UI Online homepage
                   </a>

--- a/tests/utils/getUrl.test.tsx
+++ b/tests/utils/getUrl.test.tsx
@@ -3,7 +3,7 @@ import getUrl from '../../utils/getUrl'
 describe('Retrieving urls', () => {
   // Note: This tests against real content
   it('works for real keys', () => {
-    expect(getUrl('edd-ui-claim-status')).toBe('https://www.edd.ca.gov/unemployment/claim-status.htm')
+    expect(getUrl('ca-gov')).toBe('https://www.ca.gov/')
   })
 
   it('returns undefined for unknown keys', () => {

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -5,7 +5,7 @@ export type I18nString = string
 export interface TransLineProps {
   loading?: boolean
   i18nKey: I18nString
-  links?: string[]
+  links?: I18nString[]
 }
 
 // Types for translation file JSON

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -2,8 +2,7 @@
 export type I18nString = string
 
 // Types for TransLine component
-export interface TransLineProps {
-  loading?: boolean
+export interface TransLineContent {
   i18nKey: I18nString
   links?: I18nString[]
 }
@@ -42,9 +41,9 @@ export interface Claim {
 // Types for Claim Status and Claim Details
 export interface ClaimStatusContent {
   heading: I18nString
-  summary: TransLineProps
-  yourNextSteps: TransLineProps[]
-  eddNextSteps: TransLineProps[]
+  summary: TransLineContent
+  yourNextSteps: TransLineContent[]
+  eddNextSteps: TransLineContent[]
 }
 
 export interface ClaimDetailsContent {

--- a/utils/getClaimStatus.tsx
+++ b/utils/getClaimStatus.tsx
@@ -3,7 +3,7 @@
  */
 
 import claimStatusJson from '../public/locales/en/claim-status.json'
-import { ClaimStatusContent, I18nString, TextOptionalLink, TransLineProps } from '../types/common'
+import { ClaimStatusContent, I18nString, TextOptionalLink, TransLineContent } from '../types/common'
 import { ScenarioType } from './getScenarioContent'
 
 type StepType = 'your-next-steps' | 'edd-next-steps'
@@ -59,17 +59,17 @@ function buildI18nKey(keys: string[]): I18nString {
 export function buildClaimStatusSummary(
   scenarioObject: ClaimStatusScenarioJson,
   scenarioString: string,
-): TransLineProps {
+): TransLineContent {
   const keys = ['scenarios', scenarioString, 'summary']
-  return buildTransLineProps(scenarioObject.summary, buildI18nKey(keys))
+  return buildTransLineContent(scenarioObject.summary, buildI18nKey(keys))
 }
 
 /**
  * Get conditional continue certifying next step.
  */
-export function displayContinueCertifying(): TransLineProps {
+export function displayContinueCertifying(): TransLineContent {
   const keys = ['conditional-next-steps', 'continue-certifying']
-  return buildTransLineProps(claimStatusJson['conditional-next-steps']['continue-certifying'], buildI18nKey(keys))
+  return buildTransLineContent(claimStatusJson['conditional-next-steps']['continue-certifying'], buildI18nKey(keys))
 }
 
 /**
@@ -80,12 +80,12 @@ export function buildNextSteps(
   scenarioString: string,
   whichSteps: StepType,
   continueCertifying = false,
-): TransLineProps[] {
-  const steps: TransLineProps[] = []
+): TransLineContent[] {
+  const steps: TransLineContent[] = []
   const json = scenarioObject[whichSteps]
   for (const [index, value] of json.entries()) {
     const keys = ['scenarios', scenarioString, whichSteps, index.toString()]
-    steps.push(buildTransLineProps(value, buildI18nKey(keys)))
+    steps.push(buildTransLineContent(value, buildI18nKey(keys)))
   }
 
   // If we should display the "continue certifying" next step, then display it as the first step.

--- a/utils/getClaimStatus.tsx
+++ b/utils/getClaimStatus.tsx
@@ -5,7 +5,6 @@
 import claimStatusJson from '../public/locales/en/claim-status.json'
 import { ClaimStatusContent, I18nString, TextOptionalLink, TransLineProps } from '../types/common'
 import { ScenarioType } from './getScenarioContent'
-import getUrl from './getUrl'
 
 type StepType = 'your-next-steps' | 'edd-next-steps'
 
@@ -35,24 +34,6 @@ function buildTranslationPrefix(scenarioType: ScenarioType): I18nString {
  */
 export function buildClaimStatusHeading(scenarioType: ScenarioType): I18nString {
   return buildTranslationPrefix(scenarioType) + '.heading'
-}
-
-/**
- * Build a list of urls from keys in the json translation files.
- */
-export function buildTransLineLinks(linkKeys: string[] | undefined): string[] {
-  const links: string[] = []
-  if (linkKeys) {
-    for (const linkKey of linkKeys) {
-      const url = getUrl(linkKey)
-      if (url) {
-        links.push(url)
-      }
-      // @TODO: else log that we attempted to get a url using a key that
-      // doesn't exist.
-    }
-  }
-  return links
 }
 
 /**

--- a/utils/getClaimStatus.tsx
+++ b/utils/getClaimStatus.tsx
@@ -61,7 +61,7 @@ export function buildTransLineLinks(linkKeys: string[] | undefined): string[] {
 export function buildTransLineProps(json: TextOptionalLink, i18nKey: I18nString): TransLineProps {
   return {
     i18nKey: i18nKey,
-    links: buildTransLineLinks(json.links),
+    links: json.links,
   }
 }
 

--- a/utils/getClaimStatus.tsx
+++ b/utils/getClaimStatus.tsx
@@ -39,11 +39,16 @@ export function buildClaimStatusHeading(scenarioType: ScenarioType): I18nString 
 /**
  * Build props to pass to the TransLine react component.
  */
-export function buildTransLineProps(json: TextOptionalLink, i18nKey: I18nString): TransLineProps {
-  return {
+export function buildTransLineContent(json: TextOptionalLink, i18nKey: I18nString): TransLineContent {
+  const props: TransLineContent = {
     i18nKey: i18nKey,
-    links: json.links,
   }
+
+  if (json.links) {
+    props.links = json.links
+  }
+
+  return props
 }
 
 /**


### PR DESCRIPTION
## Ticket

Resolves #324 

## Changes

- Move language-dependent urls into `common.json`
- Move url resolution logic from `getClaimStatus` to `<TransLine>`
- Update scenario content to latest content from UIB
- Move logic to determine whether the user came from UIO Mobile from the `<Home>` component to `getServerSideProps()`
- Add `userArrivedFromUioMobile` argument to many components
- Split `TransLineContent` type from `TransLineProps` type to better mirror other types in `common`
- Add `userArrivedFromUioMobile` boolean control to the Page story

## Context

This PR has a lot of changes, but they can be loosely organized into three buckets:

1. Changes to support language-dependent url resolution
2. Changes to support mobile vs non-mobile url resolution
3. Renaming types

## Testing

`yarn test`

PLUS

While #299 is not resolved, comment out the following lines, then run `yarn storybook`, and verify that the links to UIO mobile work when the toggle is set to `true`: https://github.com/cagov/ui-claim-tracker/blob/32990f892c6b84017c30af5d273fdd94410649e7/pages/index.tsx#L95-L98

PLUS

1. Run `yarn dev`
2. Load localhost:3000
3. Click "En español"
4. Make sure the links change to their `-espanol` version 

