### PR TITLE
Updates timeout handling to match requirements

### DIFF
--- a/components/TimeoutModal.tsx
+++ b/components/TimeoutModal.tsx
@@ -1,3 +1,12 @@
+/**
+ * Component to match EDD's session behavior
+ *
+ * In order to match EDD's session expiration policy, we redirect users back to EDD
+ * login page after REDIRECT_TIMER minutes. We also show this timeout modal
+ * WARNING_DURATION minutes prior to the redirect. X'ing out the modal or clicking
+ * outside it lets the user stay on the page until the redirect.
+ */
+
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'next-i18next'
 import Modal from 'react-bootstrap/Modal'
@@ -12,9 +21,8 @@ export interface TimeoutModalProps {
   timedOut: boolean
 }
 
-export const TimeoutModal: React.FC<TimeoutModalProps> = (props) => {
+export const TimeoutModal: React.FC<TimeoutModalProps> = ({ timedOut, userArrivedFromUioMobile }) => {
   const { t } = useTranslation()
-  const { timedOut, userArrivedFromUioMobile } = props
 
   // handy converter for Minutes -> Milliseconds
   const ONE_MINUTE_MS = 60 * 1000
@@ -37,7 +45,7 @@ export const TimeoutModal: React.FC<TimeoutModalProps> = (props) => {
     }
   })
 
-  function startTimer() {
+  function startTimers() {
     // Show the warning modal for a bit before navigating
     warningTimerId = setTimeout(() => {
       setShowWarningModal(true)
@@ -47,8 +55,8 @@ export const TimeoutModal: React.FC<TimeoutModalProps> = (props) => {
     // And at the end, send back to EDD
     setTimeout(() => {
       if (typeof window !== 'undefined') {
-        const eddLocation = getUrl('edd-log-in')?.concat(encodeURIComponent(window.location.toString()))
-        window.location.href = eddLocation || ''
+        const eddLoginLink = getUrl('edd-log-in')?.concat(encodeURIComponent(window.location.toString()))
+        window.location.href = eddLoginLink || ''
       }
     }, REDIRECT_TIMER * ONE_MINUTE_MS)
   }
@@ -69,7 +77,7 @@ export const TimeoutModal: React.FC<TimeoutModalProps> = (props) => {
 
   // If the warning modal hasn't shown, kickoff!
   if (!warned) {
-    startTimer()
+    startTimers()
   }
 
   return (

--- a/components/TimeoutModal.tsx
+++ b/components/TimeoutModal.tsx
@@ -8,20 +8,20 @@ import getUrl from '../utils/getUrl'
 let warningTimerId: NodeJS.Timeout | null = null
 
 export interface TimeoutModalProps {
-  action: string
+  userArrivedFromUioMobile: boolean
   timedOut: boolean
 }
 
 export const TimeoutModal: React.FC<TimeoutModalProps> = (props) => {
   const { t } = useTranslation()
-  const { timedOut } = props
+  const { timedOut, userArrivedFromUioMobile } = props
 
   // handy converter for Minutes -> Milliseconds
   const ONE_MINUTE_MS = 60 * 1000
 
   // keep times in human readable minutes
-  const REDIRECT_TIMER = 3
-  const WARNING_DURATION = 2
+  const REDIRECT_TIMER = 30
+  const WARNING_DURATION = 5
   const WARNING_TIMER = REDIRECT_TIMER - WARNING_DURATION
 
   const [numberOfMinutes, setNumberOfMinutes] = useState(WARNING_DURATION)
@@ -62,6 +62,11 @@ export const TimeoutModal: React.FC<TimeoutModalProps> = (props) => {
     }
   }
 
+  function redirectToUIHome() {
+    const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-home-url-mobile') : getUrl('uio-home-url-desktop')
+    window.location.href = uioHomeLink || ''
+  }
+
   // If the warning modal hasn't shown, kickoff!
   if (!warned) {
     startTimer()
@@ -74,9 +79,9 @@ export const TimeoutModal: React.FC<TimeoutModalProps> = (props) => {
           <strong>{t('timeout-modal.header')}</strong>
         </Modal.Title>
       </Modal.Header>
-      <Modal.Body>{t('timeout-modal.warning', { numberOfMinutes })}</Modal.Body>
+      <Modal.Body>{t('timeout-modal.warning', { count: numberOfMinutes })}</Modal.Body>
       <Modal.Footer className="border-0">
-        <Button onClick={closeWarningModal} label={t('timeout-modal.button')} />
+        <Button onClick={redirectToUIHome} label={t('timeout-modal.button')} />
       </Modal.Footer>
     </Modal>
   )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -77,7 +77,7 @@ export default function Home({
       </Head>
       <Header userArrivedFromUioMobile={userArrivedFromUioMobile} />
       {mainComponent}
-      <TimeoutModal action="startOrUpdate" timedOut={timedOut} />
+      <TimeoutModal userArrivedFromUioMobile={userArrivedFromUioMobile} timedOut={timedOut} />
       <Footer />
       {console.dir({ scenarioContent })} {/* @TODO: Remove. For development purposes only. */}
     </Container>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -36,7 +36,8 @@
   },
   "timeout-modal": {
     "header": "Your Session Will End Soon",
-    "warning": "To protect your information, you will be logged out in {{numberOfMinutes}} minutes if you do not continue.",
-    "button": "Stay Logged In"
+    "warning": "To protect your information, you will be logged out in {{count}} minute if you do not continue",
+    "warning_plural": "To protect your information, you will be logged out in {{count}} minutes if you do not continue",
+    "button": "Return to UI Home"
   }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -37,7 +37,7 @@
   "timeout-modal": {
     "header": "Your Session Will End Soon",
     "warning": "To protect your information, you will be logged out in {{count}} minute if you do not continue",
-    "warning_plural": "To protect your information, you will be logged out in {{count}} minutes if you do not continue",
+    "warning_plural": "To protect your information, you will be logged out in {{count}} minutes if you do not continue.",
     "button": "Return to UI Home"
   },
   "urls": {

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -37,7 +37,7 @@
   "timeout-modal": {
     "header": "Tu sesión terminará pronto",
     "warning": "Para proteger su información, se cerrará la sesión en {{count}} minuto si no continúa",
-    "warning_plural": "Para proteger su información, se cerrará la sesión en {{count}} minutos si no continúa",
+    "warning_plural": "Para proteger su información, se cerrará la sesión en {{count}} minutos si no continúa.",
     "button": "Volver a UI Casa"
   },
   "urls": {

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -36,7 +36,8 @@
   },
   "timeout-modal": {
     "header": "Tu sesión terminará pronto",
-    "warning": "Para proteger su información, se cerrará la sesión en {{numberOfMinutes}} minutos si no continúa.",
-    "button": "Sigue Trabajando"
+    "warning": "Para proteger su información, se cerrará la sesión en {{count}} minuto si no continúa",
+    "warning_plural": "Para proteger su información, se cerrará la sesión en {{count}} minutos si no continúa",
+    "button": "Volver a UI Casa"
   }
 }


### PR DESCRIPTION
<!-- Write a description below of the changes in this pull request. 

Include images/GIFs if relevant for reviewers. Try Firefox (right-click -> Take Screenshot) for full-page screenshots and LICEcap (macOS) or Peek (ubuntu) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items. -->

When the user has been on the site for ~25 minutes an alert appears letting them know they will be logged out in 5 minutes. Previously the user could acknowledge this alert and reset the timer. Now the user may navigate back to UI Home to refresh their session, or they can dismiss the modal to stay on the page, but will be redirected to login again regardless in 5 minutes.

===

Resolves #199 

- [x] Update modal timeout of 30m to be fixed instead of resetting
- [x] Match wording from the Content Document
- [x] Update the button to return the user to UI Home
- [ ] Changes are tested on Staging post-merge into `main`
