### PR TITLE
Implement pending determination scenario logic

### DIFF
--- a/components/ClaimStatus.tsx
+++ b/components/ClaimStatus.tsx
@@ -27,12 +27,16 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({
         <TextLine loading={loading} header text={t(heading)} />
       </div>
       <div className="summary">
-        <TransLine
-          loading={loading}
-          userArrivedFromUioMobile={userArrivedFromUioMobile}
-          i18nKey={summary.i18nKey}
-          links={summary.links}
-        />
+        {summary.map((paragraph, index) => (
+          <div key={index} className="">
+            <TransLine
+              loading={loading}
+              userArrivedFromUioMobile={userArrivedFromUioMobile}
+              i18nKey={paragraph.i18nKey}
+              links={paragraph.links}
+            />
+          </div>
+        ))}
       </div>
       <NextSteps
         loading={loading}

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "jest": "^26.6.3",
     "jest-fetch-mock": "^3.0.3",
     "lint-staged": "^10.5.4",
+    "mockdate": "^3.0.5",
     "mocked-env": "^1.3.4",
     "next-i18next": "^8.1.2",
     "pino-pretty": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/pino": "^6.3.8",
     "bootstrap": "^4.6.0",
     "date-fns": "^2.22.1",
+    "date-fns-tz": "^1.1.4",
     "next": "10.0.8",
     "pino": "^6.11.3",
     "pino-applicationinsights": "^2.1.0",

--- a/public/locales/en/claim-status.json
+++ b/public/locales/en/claim-status.json
@@ -2,9 +2,11 @@
   "scenarios": {
     "scenario1": {
       "heading": "Pending Eligibility — Phone Interview Will Be Scheduled",
-      "summary": {
-        "text": "We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview."
-      },
+      "summary": [
+        {
+          "text": "We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview."
+        }
+      ],
       "your-next-steps": [
         {
           "text": "Confirm we have your current phone number and mailing address. Go to the <0>UI Online homepage</0>, select <strong>Profile</strong> from the main menu, then select <strong>Contact Information</strong>.",
@@ -20,11 +22,82 @@
         }
       ]
     },
+    "scenario2": {
+      "heading": "Pending Eligibility — Phone Interview Scheduled",
+      "summary": [
+        {
+          "text": "We identified a potential issue that could make you ineligible for benefits. You have a phone interview scheduled for:"
+        },
+        {
+          "text": "<strong>Important</strong>: If you miss your phone interview, a decision will be made based on the available facts, which could result in your unemployment benefits being delayed or denied."
+        }
+      ],
+      "your-next-steps": [
+        {
+          "text": "Confirm we have your current phone number. Go to the <0>UI Online homepage</0>, select <strong>Profile</strong> from the main menu, then select <strong>Contact Information</strong>.",
+          "links": ["uio-home"]
+        },
+        {
+          "text": "Prepare for the interview. The <em>Notification of Unemployment Insurance Benefits Eligibility Interview</em> (DE 4800) includes the questions the interviewer is most likely to ask."
+        },
+        {
+          "text": "If you need to reschedule your interview, select <strong>Reschedule</strong> in the Appointments section on your <0>UI Online homepage</0>. You must reschedule at least one day before the interview.",
+          "links": ["uio-home"]
+        }
+      ],
+      "edd-next-steps": [
+        {
+          "text": "We will call you during your scheduled interview time. Your caller ID may show “St of CA EDD” or the UI Customer Service number 1-800-300-5616.",
+          "sub-bullets": [
+            {
+              "text": "If you do not receive a call from the EDD at your scheduled appointment time, we may have canceled your appointment because we confirmed your eligibility or resolved the issue before your interview."
+            },
+            {
+              "text": "If your appointment has been canceled, it will no longer display on your UI Online homepage."
+            }
+          ]
+        }
+      ]
+    },
+    "scenario3": {
+      "heading": "Pending Eligibility — Under Review",
+      "summary": [
+        {
+          "text": "Your phone interview time has passed and your eligibility for benefits is under review."
+        },
+        {
+          "text": "<strong>Important</strong>: If you missed your phone interview, a decision will be made based on the available facts, which could result in your unemployment benefits being delayed or denied."
+        }
+      ],
+      "your-next-steps": [
+        {
+          "text": "Allow up to 10 days for the EDD to make a decision."
+        }
+      ],
+      "edd-next-steps": [
+        {
+          "text": "We will determine your eligibility.",
+          "sub-bullets": [
+            {
+              "text": "If you are found eligible and no other issues are identified, we will pay you for all pending weeks."
+            },
+            {
+              "text": "If you are found not eligible, we will mail you a <em>Notice of Determination</em> (DE 1080CZ) with the reasons you were denied benefits and an <em>Appeal Form</em> (DE 1000M). If you disagree with the decision, you have the right to appeal. "
+            },
+            {
+              "text": "If you are paid benefits and are later found not eligible, we will also mail you a <em>Notice of Overpayment</em> (DE 1444) that explains why you were overpaid."
+            }
+          ]
+        }
+      ]
+    },
     "scenario4": {
       "heading": "Review Required",
-      "summary": {
-        "text": "We identified an issue and may need to determine your eligibility or verify your information."
-      },
+      "summary": [
+        {
+          "text": "We identified an issue and may need to determine your eligibility or verify your information."
+        }
+      ],
       "your-next-steps": [
         {
           "text": "Check your <0>UI Online homepage</0> and inbox for the latest updates.",
@@ -50,9 +123,11 @@
     },
     "scenario5": {
       "heading": "No Weeks Available to Certify",
-      "summary": {
-        "text": "You currently have no weeks available to certify for benefits."
-      },
+      "summary": [
+        {
+          "text": "You currently have no weeks available to certify for benefits."
+        }
+      ],
       "your-next-steps": [
         {
           "text": "Check your <0>UI Online homepage</0> and inbox for the latest updates.",
@@ -75,10 +150,12 @@
     },
     "scenario6": {
       "heading": "Weeks Available to Certify",
-      "summary": {
-        "text": "You have weeks available to <0>certify for benefits</0>.",
-        "links": ["urls.edd.ui-certify"]
-      },
+      "summary": [
+        {
+          "text": "You have weeks available to <0>certify for benefits</0>.",
+          "links": ["urls.edd.ui-certify"]
+        }
+      ],
       "your-next-steps": [
         {
           "text": "Select <strong>Certify for Benefits</strong> in the Notification section on your <0>UI Online homepage</0>.",

--- a/stories/ClaimStatus.stories.tsx
+++ b/stories/ClaimStatus.stories.tsx
@@ -12,9 +12,7 @@ const Template: Story<ClaimStatusProps> = (args) => <ClaimStatusComponent {...ar
 export const ClaimStatus = Template.bind({})
 ClaimStatus.args = {
   heading: 'claim-status:scenarios.scenario4.heading',
-  summary: {
-    i18nKey: 'claim-status:scenarios.scenario4.summary.text',
-  },
+  summary: [{ i18nKey: 'claim-status:scenarios.scenario4.summary.text' }],
   yourNextSteps: [{ i18nKey: 'claim-status:scenarios.scenario4.your-next-steps.0.text' }],
   eddNextSteps: [{ i18nKey: 'claim-status:scenarios.scenario4.edd-next-steps.0.text' }],
 }

--- a/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
+++ b/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
@@ -19,7 +19,11 @@ exports[`Scenario 1 matches when there are weeks to certify, on desktop 1`] = `
   <div
     className="summary"
   >
-    We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+    <div
+      className=""
+    >
+      We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+    </div>
   </div>
   <div
     className="next-steps claim-subsection"
@@ -115,7 +119,11 @@ exports[`Scenario 1 matches when there are weeks to certify, on mobile 1`] = `
   <div
     className="summary"
   >
-    We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+    <div
+      className=""
+    >
+      We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+    </div>
   </div>
   <div
     className="next-steps claim-subsection"
@@ -211,7 +219,11 @@ exports[`Scenario 1 matches when there aren't weeks to certify, on desktop 1`] =
   <div
     className="summary"
   >
-    We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+    <div
+      className=""
+    >
+      We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+    </div>
   </div>
   <div
     className="next-steps claim-subsection"
@@ -296,7 +308,11 @@ exports[`Scenario 1 matches when there aren't weeks to certify, on mobile 1`] = 
   <div
     className="summary"
   >
-    We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+    <div
+      className=""
+    >
+      We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+    </div>
   </div>
   <div
     className="next-steps claim-subsection"
@@ -381,7 +397,11 @@ exports[`Scenario 4 matches when there are weeks to certify, on desktop 1`] = `
   <div
     className="summary"
   >
-    We identified an issue and may need to determine your eligibility or verify your information.
+    <div
+      className=""
+    >
+      We identified an issue and may need to determine your eligibility or verify your information.
+    </div>
   </div>
   <div
     className="next-steps claim-subsection"
@@ -489,7 +509,11 @@ exports[`Scenario 4 matches when there are weeks to certify, on mobile 1`] = `
   <div
     className="summary"
   >
-    We identified an issue and may need to determine your eligibility or verify your information.
+    <div
+      className=""
+    >
+      We identified an issue and may need to determine your eligibility or verify your information.
+    </div>
   </div>
   <div
     className="next-steps claim-subsection"
@@ -597,7 +621,11 @@ exports[`Scenario 4 matches when there aren't weeks to certify, on desktop 1`] =
   <div
     className="summary"
   >
-    We identified an issue and may need to determine your eligibility or verify your information.
+    <div
+      className=""
+    >
+      We identified an issue and may need to determine your eligibility or verify your information.
+    </div>
   </div>
   <div
     className="next-steps claim-subsection"
@@ -694,7 +722,11 @@ exports[`Scenario 4 matches when there aren't weeks to certify, on mobile 1`] = 
   <div
     className="summary"
   >
-    We identified an issue and may need to determine your eligibility or verify your information.
+    <div
+      className=""
+    >
+      We identified an issue and may need to determine your eligibility or verify your information.
+    </div>
   </div>
   <div
     className="next-steps claim-subsection"
@@ -791,7 +823,11 @@ exports[`Scenario 5 matches, on desktop 1`] = `
   <div
     className="summary"
   >
-    You currently have no weeks available to certify for benefits.
+    <div
+      className=""
+    >
+      You currently have no weeks available to certify for benefits.
+    </div>
   </div>
   <div
     className="next-steps claim-subsection"
@@ -883,7 +919,11 @@ exports[`Scenario 5 matches, on mobile 1`] = `
   <div
     className="summary"
   >
-    You currently have no weeks available to certify for benefits.
+    <div
+      className=""
+    >
+      You currently have no weeks available to certify for benefits.
+    </div>
   </div>
   <div
     className="next-steps claim-subsection"
@@ -975,13 +1015,17 @@ exports[`Scenario 6 matches, on desktop 1`] = `
   <div
     className="summary"
   >
-    You have weeks available to 
-    <a
-      href="https://edd.ca.gov/Unemployment/certify.htm"
+    <div
+      className=""
     >
-      certify for benefits
-    </a>
-    .
+      You have weeks available to 
+      <a
+        href="https://edd.ca.gov/Unemployment/certify.htm"
+      >
+        certify for benefits
+      </a>
+      .
+    </div>
   </div>
   <div
     className="next-steps claim-subsection"
@@ -1065,13 +1109,17 @@ exports[`Scenario 6 matches, on mobile 1`] = `
   <div
     className="summary"
   >
-    You have weeks available to 
-    <a
-      href="https://edd.ca.gov/Unemployment/certify.htm"
+    <div
+      className=""
     >
-      certify for benefits
-    </a>
-    .
+      You have weeks available to 
+      <a
+        href="https://edd.ca.gov/Unemployment/certify.htm"
+      >
+        certify for benefits
+      </a>
+      .
+    </div>
   </div>
   <div
     className="next-steps claim-subsection"

--- a/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/tests/pages/__snapshots__/index.test.tsx.snap
@@ -184,7 +184,11 @@ exports[`Exemplar react-test-renderer Snapshot test renders homepage unchanged 1
           <div
             className="summary"
           >
-            We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+            <div
+              className=""
+            >
+              We identified an issue that could make you ineligible for benefits. We need to confirm your eligibility in a phone interview.
+            </div>
           </div>
           <div
             className="next-steps claim-subsection"

--- a/tests/utils/apiGatewayStub.test.tsx
+++ b/tests/utils/apiGatewayStub.test.tsx
@@ -1,4 +1,4 @@
-import { isDatePast, isValidDate, parseConvertDate } from '../../utils/formatDate'
+import { isDatePast, isValidDate, parseApiGatewayDate } from '../../utils/formatDate'
 import apiGatewayStub from '../../utils/apiGatewayStub'
 import { isDeterminationStatusPending, ScenarioType } from '../../utils/getScenarioContent'
 
@@ -21,7 +21,7 @@ describe('The API gateway stub response for the Determination Interview scenario
 
     expect(isValidDate(pendingDetermination.scheduleDate)).toBe(true)
 
-    const convertedDate = parseConvertDate(pendingDetermination.scheduleDate)
+    const convertedDate = parseApiGatewayDate(pendingDetermination.scheduleDate)
     expect(isDatePast(convertedDate)).toBe(false)
   })
 
@@ -34,7 +34,7 @@ describe('The API gateway stub response for the Determination Interview scenario
 
     expect(isValidDate(pendingDetermination.scheduleDate)).toBe(true)
 
-    const convertedDate = parseConvertDate(pendingDetermination.scheduleDate)
+    const convertedDate = parseApiGatewayDate(pendingDetermination.scheduleDate)
     expect(isDatePast(convertedDate)).toBe(true)
   })
 })

--- a/tests/utils/apiGatewayStub.test.tsx
+++ b/tests/utils/apiGatewayStub.test.tsx
@@ -1,10 +1,41 @@
+import { isDatePast, isValidDate, parseConvertDate } from '../../utils/formatDate'
 import apiGatewayStub from '../../utils/apiGatewayStub'
-import { ScenarioType } from '../../utils/getScenarioContent'
+import { isDeterminationStatusPending, ScenarioType } from '../../utils/getScenarioContent'
 
-describe('The API gateway stub response for the Pending Determination scenario', () => {
-  it('is correct', () => {
+describe('The API gateway stub response for the Determination Interview scenarios', () => {
+  it('is correct for Scenario 1', () => {
     const response = apiGatewayStub(ScenarioType.Scenario1)
-    expect(response.pendingDetermination.length).toBeGreaterThan(0)
+    expect(response.pendingDetermination.length).toBe(1)
+    const pendingDetermination = response.pendingDetermination
+    expect([null, false, undefined, '']).toContain(pendingDetermination.determinationStatus)
+    expect([null, false, undefined, '']).toContain(pendingDetermination.scheduleDate)
+    expect(pendingDetermination.requestDate).not.toBe('')
+  })
+
+  it('is correct for Scenario 2', () => {
+    const response = apiGatewayStub(ScenarioType.Scenario2)
+    expect(response.pendingDetermination.length).toBe(1)
+
+    const pendingDetermination = response.pendingDetermination[0]
+    expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
+
+    expect(isValidDate(pendingDetermination.scheduleDate)).toBe(true)
+
+    const convertedDate = parseConvertDate(pendingDetermination.scheduleDate)
+    expect(isDatePast(convertedDate)).toBe(false)
+  })
+
+  it('is correct for Scenario 3', () => {
+    const response = apiGatewayStub(ScenarioType.Scenario3)
+    expect(response.pendingDetermination.length).toBe(1)
+
+    const pendingDetermination = response.pendingDetermination[0]
+    expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
+
+    expect(isValidDate(pendingDetermination.scheduleDate)).toBe(true)
+
+    const convertedDate = parseConvertDate(pendingDetermination.scheduleDate)
+    expect(isDatePast(convertedDate)).toBe(true)
   })
 })
 

--- a/tests/utils/formatDate.test.ts
+++ b/tests/utils/formatDate.test.ts
@@ -1,4 +1,19 @@
-import formatDate from '../../utils/formatDate'
+import formatDate, { isValidDate } from '../../utils/formatDate'
+
+// Test isValidDate()
+describe('A date is', () => {
+  it('invalid if it is not a date', () => {
+    expect(isValidDate('nonsense')).toBe(false)
+  })
+
+  it('invalid if it is earlier than the minimum date', () => {
+    expect(isValidDate('0001-01-01T00:00:00')).toBe(false)
+  })
+
+  it('valid if it is later than the minimum date', () => {
+    expect(isValidDate('2013-01-01T00:00:00')).toBe(true)
+  })
+})
 
 // Test formatDate()
 describe('Formatting dates', () => {

--- a/tests/utils/formatDate.test.ts
+++ b/tests/utils/formatDate.test.ts
@@ -1,7 +1,7 @@
-import formatDate, { isValidDate } from '../../utils/formatDate'
+import formatDate, { isDatePast, isValidDate } from '../../utils/formatDate'
 
 // Test isValidDate()
-describe('A date is', () => {
+describe('Valid dates: A date is', () => {
   it('invalid if it is not a date', () => {
     expect(isValidDate('nonsense')).toBe(false)
   })
@@ -12,6 +12,26 @@ describe('A date is', () => {
 
   it('valid if it is later than the minimum date', () => {
     expect(isValidDate('2013-01-01T00:00:00')).toBe(true)
+  })
+})
+
+// Test isDatePast()
+describe('Past dates: A date is', () => {
+  it('correctly identified as being in the past', () => {
+    const today = new Date()
+    const yesterday = today.setDate(today.getDate() - 1)
+    expect(isDatePast(yesterday)).toBe(true)
+  })
+
+  it('correctly identified as not past if it is today', () => {
+    const today = new Date()
+    expect(isDatePast(today)).toBe(false)
+  })
+
+  it('correctly identified as not past if it is in the future', () => {
+    const today = new Date()
+    const tomorrow = today.setDate(today.getDate() + 1)
+    expect(isDatePast(tomorrow)).toBe(false)
   })
 })
 

--- a/tests/utils/formatDate.test.ts
+++ b/tests/utils/formatDate.test.ts
@@ -1,3 +1,5 @@
+import MockDate from 'mockdate'
+
 import formatDate, { isDatePast, isValidDate } from '../../utils/formatDate'
 
 // Test isValidDate()
@@ -17,10 +19,14 @@ describe('Valid dates: A date is', () => {
 
 // Test isDatePast()
 describe('Past dates: A date is', () => {
+  beforeAll(() => {
+    MockDate.set('2020-05-05T00:00:00')
+  })
+
   it('correctly identified as being in the past', () => {
-    const today = new Date()
-    const yesterday = today.setDate(today.getDate() - 1)
-    expect(isDatePast(yesterday)).toBe(true)
+    const date = new Date()
+    date.setDate(date.getDate() - 1)
+    expect(isDatePast(date)).toBe(true)
   })
 
   it('correctly identified as not past if it is today', () => {
@@ -29,9 +35,9 @@ describe('Past dates: A date is', () => {
   })
 
   it('correctly identified as not past if it is in the future', () => {
-    const today = new Date()
-    const tomorrow = today.setDate(today.getDate() + 1)
-    expect(isDatePast(tomorrow)).toBe(false)
+    const date = new Date()
+    date.setDate(date.getDate() + 1)
+    expect(isDatePast(date)).toBe(false)
   })
 })
 

--- a/tests/utils/formatDate.test.ts
+++ b/tests/utils/formatDate.test.ts
@@ -1,0 +1,10 @@
+import formatDate from '../../utils/formatDate'
+
+// Test formatDate()
+describe('Formatting dates', () => {
+  it('displays the expected date string', () => {
+    const notFormatted = '2013-09-27T00:00:00'
+    const formatted = formatDate(notFormatted)
+    expect(formatted).toEqual('9/27/2013')
+  })
+})

--- a/tests/utils/getClaimDetails.test.tsx
+++ b/tests/utils/getClaimDetails.test.tsx
@@ -1,7 +1,6 @@
 import getClaimDetails, {
   buildBenefitYear,
   formatCurrency,
-  formatDate,
   getProgramExtensionPair,
   programExtensionPairs,
   programExtensionPairType,
@@ -22,15 +21,6 @@ describe('Converting ProgramType to user-facing strings', () => {
     expect(() => {
       getProgramExtensionPair('unknown')
     }).toThrowError('Unknown Program Type')
-  })
-})
-
-// Test formatDate()
-describe('Formatting dates', () => {
-  it('displays the expected date string', () => {
-    const notFormatted = '2013-09-27T00:00:00'
-    const formatted = formatDate(notFormatted)
-    expect(formatted).toEqual('9/27/2013')
   })
 })
 

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -1,3 +1,5 @@
+import MockDate from 'mockdate'
+
 import { PendingDetermination } from '../../types/common'
 import apiGatewayStub from '../../utils/apiGatewayStub'
 import {
@@ -33,6 +35,13 @@ function getPendingDeterminationWithScheduleDate(offset = 1): PendingDeterminati
   pendingDetermination.scheduleDate = formatFromApiGateway(getDateWithOffset(offset))
   return pendingDetermination
 }
+
+/**
+ * Setup before all tests.
+ */
+beforeAll(() => {
+  MockDate.set('2020-05-05T00:00:00')
+})
 
 /**
  * Test getScenario()
@@ -195,11 +204,6 @@ describe('The determination interview is scheduled (scenario 2)', () => {
   it('scheduled (scenario 2) when the determination status is pending and there is one pending determination object with a schedule date of today', () => {
     // Mock a pending determination object with a schedule date that is now
     const pendingDetermination = getPendingDeterminationWithScheduleDate(0)
-
-    // Mock the result of Date.now() to today at midnight
-    const today = new Date()
-    Date.now = jest.fn(() => today.setUTCHours(0, 0, 0, 0))
-
     const result = identifyPendingDeterminationScenario([pendingDetermination])
     expect(result.scenarioType).toBe(ScenarioType.Scenario2)
   })

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -113,3 +113,6 @@ describe('Determination Status', () => {
     }
   })
 })
+
+// Test isScheduledStrictlyBefore()
+// Test identifyPendingDeterminationScenario()

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -1,76 +1,25 @@
+import { format } from 'date-fns'
+
 import { PendingDetermination } from '../../types/common'
+import apiGatewayStub from '../../utils/apiGatewayStub'
 import {
   getScenario,
+  identifyPendingDeterminationScenario,
   isDeterminationStatusPending,
   isScheduledStrictlyBefore,
   NonPendingDeterminationValues,
   ScenarioType,
 } from '../../utils/getScenarioContent'
-import apiGatewayStub from '../../utils/apiGatewayStub'
+import { datetimeInUtc } from '../../utils/formatDate'
 
 /**
- * Test getScenario()
- *
- * Refer to ScenarioType and ScenarioTypeNames for which scenario has which number.
+ * Test helpers.
  */
+function formatFromApiGateway(date: Date): string {
+  return format(date, "yyyy-MM-dd'T'HH:mm:ss")
+}
 
-// Scenario 1
-describe('Scenario 1', () => {
-  it('is returned when there is a pendingDetermination object', () => {
-    const pendingDeterminationScenario = apiGatewayStub(ScenarioType.Scenario1)
-    const scenarioType = getScenario(pendingDeterminationScenario)
-    expect(scenarioType).toBe(ScenarioType.Scenario1)
-  })
-
-  it('is returned when there is a pendingDetermination object regardless of other criteria', () => {
-    const pendingDeterminationScenarioWith = {
-      pendingDetermination: ['temporary text'],
-      hasPendingWeeks: true,
-    }
-    const scenarioTypeWith = getScenario(pendingDeterminationScenarioWith)
-    expect(scenarioTypeWith).toBe(ScenarioType.Scenario1)
-
-    const pendingDeterminationScenarioWithout = {
-      pendingDetermination: ['temporary text'],
-      hasPendingWeeks: false,
-    }
-    const scenarioTypeWithout = getScenario(pendingDeterminationScenarioWithout)
-    expect(scenarioTypeWithout).toBe(ScenarioType.Scenario1)
-  })
-
-  it('is not returned if pendingDetermination is null', () => {
-    const pendingDeterminationScenarioNull = { pendingDetermination: null }
-    const scenarioTypeNull = getScenario(pendingDeterminationScenarioNull)
-    expect(scenarioTypeNull).not.toBe(ScenarioType.Scenario1)
-  })
-
-  it('is not returned if pendingDetermination is an empty array', () => {
-    const pendingDeterminationScenarioEmpty = { pendingDetermination: [] }
-    const scenarioTypeEmpty = getScenario(pendingDeterminationScenarioEmpty)
-    expect(scenarioTypeEmpty).not.toBe(ScenarioType.Scenario1)
-  })
-})
-
-// Scenario 4
-describe('The Generic Pending scenario', () => {
-  it('is returned as expected', () => {
-    const scenarioType = ScenarioType.Scenario4
-    expect(getScenario(apiGatewayStub(scenarioType))).toBe(scenarioType)
-  })
-})
-
-// Scenarios 5 & 6
-describe('The Base State scenarios', () => {
-  it('are returned as expected', () => {
-    const baseScenarios = [ScenarioType.Scenario5, ScenarioType.Scenario6]
-    for (const scenarioType of baseScenarios) {
-      expect(getScenario(apiGatewayStub(scenarioType))).toBe(scenarioType)
-    }
-  })
-})
-
-// Test isDeterminationStatusPending()
-describe('Determination Status', () => {
+function getMockPendingDetermination(): PendingDetermination {
   // Shared mock data.
   const pendingDetermination: PendingDetermination = {
     pendingDate: '',
@@ -82,33 +31,348 @@ describe('Determination Status', () => {
     spokenLanguageCode: '',
     spokenLanguageDesc: '',
   }
+  return pendingDetermination
+}
 
+/**
+ * Test getScenario()
+ *
+ * Refer to ScenarioType and ScenarioTypeNames for which scenario has which number.
+ */
+
+// Scenarios 1, 2, 3
+describe('Scenarios 1, 2, 3', () => {
+  it('are not returned if pendingDetermination is null', () => {
+    const pendingDeterminationScenarioNull = { pendingDetermination: null }
+    const scenarioTypeNull = getScenario(pendingDeterminationScenarioNull)
+    expect(scenarioTypeNull).not.toBe(ScenarioType.Scenario1)
+    expect(scenarioTypeNull).not.toBe(ScenarioType.Scenario2)
+    expect(scenarioTypeNull).not.toBe(ScenarioType.Scenario3)
+  })
+
+  it('are not returned if pendingDetermination is an empty array', () => {
+    const pendingDeterminationScenarioEmpty = { pendingDetermination: [] }
+    const scenarioTypeEmpty = getScenario(pendingDeterminationScenarioEmpty)
+    expect(scenarioTypeEmpty).not.toBe(ScenarioType.Scenario1)
+    expect(scenarioTypeEmpty).not.toBe(ScenarioType.Scenario2)
+    expect(scenarioTypeEmpty).not.toBe(ScenarioType.Scenario3)
+  })
+})
+
+// Scenario 4
+describe('The Generic Pending scenario (scenario 4)', () => {
+  it('is returned as expected', () => {
+    const scenarioType = ScenarioType.Scenario4
+    expect(getScenario(apiGatewayStub(scenarioType))).toBe(scenarioType)
+  })
+})
+
+// Scenarios 5 & 6
+describe('The Base State scenarios (scenarios 5 & 6)', () => {
+  it('are returned as expected', () => {
+    const baseScenarios = [ScenarioType.Scenario5, ScenarioType.Scenario6]
+    for (const scenarioType of baseScenarios) {
+      expect(getScenario(apiGatewayStub(scenarioType))).toBe(scenarioType)
+    }
+  })
+})
+
+/**
+ * Test Test identifyPendingDeterminationScenario()
+ */
+
+// Scenario 1: Test various values of pendingDetermination.determinationStatus
+describe('The determination interview is not yet scheduled (scenario 1) when all other criteria are met and the determination status evaluates to', () => {
+  it('false (null)', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    pendingDetermination.determinationStatus = null
+    pendingDetermination.scheduleDate = null
+    pendingDetermination.requestDate = 'any non-null value'
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+  })
+
+  it('false (empty string)', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    pendingDetermination.determinationStatus = ''
+    pendingDetermination.scheduleDate = null
+    pendingDetermination.requestDate = 'any non-null value'
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+  })
+
+  it('false (undefined)', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    pendingDetermination.determinationStatus = undefined
+    pendingDetermination.scheduleDate = null
+    pendingDetermination.requestDate = 'any non-null value'
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+  })
+})
+
+// Scenario 1: Test various values of pendingDetermination.scheduleDate
+describe('The determination interview is not yet scheduled (scenario 1) when all other criteria are met and the schedule date evaluates to', () => {
+  it('false (null)', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    pendingDetermination.determinationStatus = null
+    pendingDetermination.scheduleDate = null
+    pendingDetermination.requestDate = 'any non-null value'
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+  })
+
+  it('false (empty string)', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    pendingDetermination.determinationStatus = null
+    pendingDetermination.scheduleDate = ''
+    pendingDetermination.requestDate = 'any non-null value'
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+  })
+
+  it('false (undefined)', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    pendingDetermination.determinationStatus = null
+    pendingDetermination.scheduleDate = undefined
+    pendingDetermination.requestDate = 'any non-null value'
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+  })
+})
+
+// Test various Scenario 1 invalid values
+describe('The determination interview is invalid if all other Scenario 1 critera are met, but', () => {
+  it('the determination status does not evaluate to false', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    pendingDetermination.determinationStatus = 'non-null value'
+    pendingDetermination.scheduleDate = ''
+    pendingDetermination.requestDate = 'any non-null value'
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result).toBe(null)
+  })
+
+  it('the schedule date does not evaluate to false', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    // Determination Status is one of NonPendingDeterminationValues values
+    pendingDetermination.determinationStatus = 'Complete'
+    pendingDetermination.scheduleDate = '2000-01-01T00:00:00'
+    pendingDetermination.requestDate = 'any non-null value'
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result).toBe(null)
+  })
+
+  it('the schedule date is an invalid datetime string', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    pendingDetermination.determinationStatus = ''
+    pendingDetermination.scheduleDate = 'non-null value'
+    pendingDetermination.requestDate = 'any non-null value'
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result).toBe(null)
+  })
+
+  it('the request date evaluates to false', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    pendingDetermination.determinationStatus = ''
+    pendingDetermination.scheduleDate = ''
+    pendingDetermination.requestDate = ''
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result).toBe(null)
+  })
+})
+
+// Scenario 2
+describe('The determination interview is scheduled (scenario 2)', () => {
+  it('when the determination status is pending and there is one pending determination object with a schedule date in the future', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    pendingDetermination.determinationStatus = 'Random string' // Can be anything other than one of NonPendingDeterminationValues
+
+    const today = new Date()
+    const tomorrow = today.setDate(today.getDate() + 1)
+    const tomorrowUtc = datetimeInUtc(tomorrow)
+
+    pendingDetermination.scheduleDate = formatFromApiGateway(tomorrowUtc)
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario2)
+  })
+
+  it('scheduled (scenario 2) when the determination status is pending and there is one pending determination object with a schedule date of today', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    pendingDetermination.determinationStatus = 'Random string' // Can be anything other than one of NonPendingDeterminationValues
+
+    const today = new Date()
+    const todayUtc = datetimeInUtc(today)
+
+    // Mock the result of Date.now() to today at midnight
+    Date.now = jest.fn(() => today.setUTCHours(0, 0, 0, 0))
+
+    pendingDetermination.scheduleDate = formatFromApiGateway(todayUtc)
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario2)
+  })
+})
+
+// Scenario 3
+describe('The determination interview is awating decision (scenario 3)', () => {
+  it('when the determination status is pending and there is one pending determination object with a schedule date in the past', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    pendingDetermination.determinationStatus = 'Random string' // Can be anything other than one of NonPendingDeterminationValues
+
+    const today = new Date()
+    const yesterday = today.setDate(today.getDate() - 1)
+    const yesterdayUtc = datetimeInUtc(yesterday)
+
+    pendingDetermination.scheduleDate = formatFromApiGateway(yesterdayUtc)
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario3)
+  })
+})
+
+// Test multiple pendingDetermination objects.
+describe('When there are multiple pendingDetermination objects, the determination interview is', () => {
+  // Multiple "not yet scheduled" pendingDetermination objects that evaluate
+  // to Scenario 1, return Scenario 1.
+  it('not yet scheduled (scenario 1) if all are not yet scheduled', () => {
+    const appt1 = getMockPendingDetermination()
+    appt1.pendingDetermination = ''
+    appt1.scheduleDate = ''
+    appt1.requestDate = 'not empty'
+
+    const appt2 = getMockPendingDetermination()
+    appt2.pendingDetermination = ''
+    appt2.scheduleDate = ''
+    appt2.requestDate = 'not empty'
+
+    const result = identifyPendingDeterminationScenario([appt1, appt2])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+  })
+
+  // Multiple "scheduled" pendingDetermination objects that evaluate
+  // to Scenario 2, returns the object with the earliest schedule date
+  it('scheduled (scenario 2) if all are scheduled', () => {
+    const appt1 = getMockPendingDetermination()
+    appt1.determinationStatus = 'Random string' // Can be anything other than one of NonPendingDeterminationValues
+    const now1 = new Date()
+    const tomorrow = now1.setDate(now1.getDate() + 1)
+    const tomorrowUtc = datetimeInUtc(tomorrow)
+    appt1.scheduleDate = formatFromApiGateway(tomorrowUtc)
+
+    const appt2 = getMockPendingDetermination()
+    appt2.determinationStatus = 'Random string' // Can be anything other than one of NonPendingDeterminationValues
+    const now2 = new Date()
+    const aWeekFromNow = now2.setDate(now2.getDate() + 7)
+    const aWeekFromNowUtc = datetimeInUtc(aWeekFromNow)
+    appt2.scheduleDate = formatFromApiGateway(aWeekFromNowUtc)
+
+    const result = identifyPendingDeterminationScenario([appt1, appt2])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario2)
+    expect(result.pendingDetermination).toBe(appt1)
+  })
+
+  // Multiple "awaiting decision" pendingDetermination objects that evaluate
+  // to Scenario 3, return Scenario 3.
+  it('awaiting decision (scenario 3) if all are awaiting decision', () => {
+    const appt1 = getMockPendingDetermination()
+    appt1.determinationStatus = 'Random string' // Can be anything other than one of NonPendingDeterminationValues
+    const now1 = new Date()
+    const yesterday = now1.setDate(now1.getDate() - 1)
+    const yesterdayUtc = datetimeInUtc(yesterday)
+    appt1.scheduleDate = formatFromApiGateway(yesterdayUtc)
+
+    const appt2 = getMockPendingDetermination()
+    appt2.determinationStatus = 'Random string' // Can be anything other than one of NonPendingDeterminationValues
+    const now2 = new Date()
+    const aWeekAgo = now2.setDate(now2.getDate() - 7)
+    const aWeekAgoUtc = datetimeInUtc(aWeekAgo)
+    appt2.scheduleDate = formatFromApiGateway(aWeekAgoUtc)
+
+    const result = identifyPendingDeterminationScenario([appt1, appt2])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario3)
+  })
+
+  // If all three types of scenarios are present, then scenario 2 takes priority.
+  it('scheduled (scenario 2) if there is a scheduled scenario, awaiting decision scenario, and not yet scheduled scenario', () => {
+    const scheduled = getMockPendingDetermination()
+    scheduled.determinationStatus = 'Random string' // Can be anything other than one of NonPendingDeterminationValues
+    const now1 = new Date()
+    const aWeekFromNow = now1.setDate(now1.getDate() + 7)
+    const aWeekFromNowUtc = datetimeInUtc(aWeekFromNow)
+    scheduled.scheduleDate = formatFromApiGateway(aWeekFromNowUtc)
+
+    const awaitingDecision = getMockPendingDetermination()
+    awaitingDecision.determinationStatus = 'Random string' // Can be anything other than one of NonPendingDeterminationValues
+    const now2 = new Date()
+    const aWeekAgo = now2.setDate(now2.getDate() - 7)
+    const aWeekAgoUtc = datetimeInUtc(aWeekAgo)
+    awaitingDecision.scheduleDate = formatFromApiGateway(aWeekAgoUtc)
+
+    const notYetScheduled = getMockPendingDetermination()
+    notYetScheduled.determinationStatus = ''
+    notYetScheduled.scheduleDate = ''
+    notYetScheduled.requestDate = 'not empty'
+
+    const result = identifyPendingDeterminationScenario([notYetScheduled, awaitingDecision, scheduled])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario2)
+    expect(result.pendingDetermination).toBe(scheduled)
+  })
+
+  // If scenarios 1 & 3 are present, then scenario 3 takes priority.
+  it('awaiting decision (scenario 3) if there is an awaiting decision scenario and not yet scheduled scenario', () => {
+    const awaitingDecision = getMockPendingDetermination()
+    awaitingDecision.determinationStatus = 'Random string' // Can be anything other than one of NonPendingDeterminationValues
+    const today = new Date()
+    const aWeekAgo = today.setDate(today.getDate() - 7)
+    const aWeekAgoUtc = datetimeInUtc(aWeekAgo)
+    awaitingDecision.scheduleDate = formatFromApiGateway(aWeekAgoUtc)
+
+    const notYetScheduled = getMockPendingDetermination()
+    notYetScheduled.determinationStatus = ''
+    notYetScheduled.scheduleDate = ''
+    notYetScheduled.requestDate = 'not empty'
+
+    const result = identifyPendingDeterminationScenario([notYetScheduled, awaitingDecision])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario3)
+  })
+})
+
+/**
+ * Other tests
+ */
+
+// Test isDeterminationStatusPending()
+describe('Determination Status', () => {
   it('is pending if it is an empty string', () => {
+    const pendingDetermination = getMockPendingDetermination()
     expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
   })
 
   it('is pending if it is null', () => {
+    const pendingDetermination = getMockPendingDetermination()
     pendingDetermination.determinationStatus = null
     expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
   })
 
   it('is pending if it is undefined', () => {
+    const pendingDetermination = getMockPendingDetermination()
     pendingDetermination.determinationStatus = undefined
     expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
   })
 
   it('is pending if is missing', () => {
+    const pendingDetermination = getMockPendingDetermination()
     delete pendingDetermination.determinationStatus
     expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
   })
 
   it('is pending if it is not one of the non-pending values', () => {
+    const pendingDetermination = getMockPendingDetermination()
     pendingDetermination.determinationStatus = 'foo'
     expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
   })
 
   it('is not pending if it is one of the non-pending values', () => {
     for (const value of NonPendingDeterminationValues) {
+      const pendingDetermination = getMockPendingDetermination()
       pendingDetermination.determinationStatus = value
       expect(isDeterminationStatusPending(pendingDetermination)).toBe(false)
     }
@@ -163,5 +427,3 @@ describe('Comparing pending determination objects', () => {
     expect(result).toBe(false)
   })
 })
-
-// Test identifyPendingDeterminationScenario()

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -1,5 +1,3 @@
-import { format } from 'date-fns'
-
 import { PendingDetermination } from '../../types/common'
 import apiGatewayStub from '../../utils/apiGatewayStub'
 import {
@@ -10,16 +8,11 @@ import {
   NonPendingDeterminationValues,
   ScenarioType,
 } from '../../utils/getScenarioContent'
-import { datetimeInUtc } from '../../utils/formatDate'
+import { formatFromApiGateway, getDateWithOffset } from '../../utils/formatDate'
 
 /**
- * Test helpers.
+ * Test helpers to create shared mock data.
  */
-function formatFromApiGateway(date: Date): string {
-  return format(date, "yyyy-MM-dd'T'HH:mm:ss")
-}
-
-// Shared mock data.
 function getMockPendingDetermination(): PendingDetermination {
   const pendingDetermination: PendingDetermination = {
     pendingDate: '',
@@ -37,16 +30,7 @@ function getMockPendingDetermination(): PendingDetermination {
 function getPendingDeterminationWithScheduleDate(offset = 1): PendingDetermination {
   const pendingDetermination = getMockPendingDetermination()
   pendingDetermination.determinationStatus = 'Random string' // Can be anything other than one of NonPendingDeterminationValues
-
-  const today = new Date()
-
-  // By default, this will mock a scheduled pendingDetermination object that has a
-  // schedule date that is tomorrow. Pass in an alternate offset to create different
-  // schedule dates
-  const sometime = today.setDate(today.getDate() + offset)
-  const sometimeUtc = datetimeInUtc(sometime)
-
-  pendingDetermination.scheduleDate = formatFromApiGateway(sometimeUtc)
+  pendingDetermination.scheduleDate = formatFromApiGateway(getDateWithOffset(offset))
   return pendingDetermination
 }
 

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -1,4 +1,10 @@
-import { getScenario, ScenarioType } from '../../utils/getScenarioContent'
+import { PendingDetermination } from '../../types/common'
+import {
+  getScenario,
+  isDeterminationStatusPending,
+  NonPendingDeterminationValues,
+  ScenarioType,
+} from '../../utils/getScenarioContent'
 import apiGatewayStub from '../../utils/apiGatewayStub'
 
 /**
@@ -58,6 +64,52 @@ describe('The Base State scenarios', () => {
     const baseScenarios = [ScenarioType.Scenario5, ScenarioType.Scenario6]
     for (const scenarioType of baseScenarios) {
       expect(getScenario(apiGatewayStub(scenarioType))).toBe(scenarioType)
+    }
+  })
+})
+
+// Test isDeterminationStatusPending()
+describe('Determination Status', () => {
+  // Shared mock data.
+  const pendingDetermination: PendingDetermination = {
+    pendingDate: '',
+    scheduleDate: '',
+    timeSlotDesc: '',
+    requestDate: '',
+    determinationStatus: '',
+    willCallIndicator: false,
+    spokenLanguageCode: '',
+    spokenLanguageDesc: '',
+  }
+
+  it('is pending if it is an empty string', () => {
+    expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
+  })
+
+  it('is pending if it is null', () => {
+    pendingDetermination.determinationStatus = null
+    expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
+  })
+
+  it('is pending if it is undefined', () => {
+    pendingDetermination.determinationStatus = undefined
+    expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
+  })
+
+  it('is pending if is missing', () => {
+    delete pendingDetermination.determinationStatus
+    expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
+  })
+
+  it('is pending if it is not one of the non-pending values', () => {
+    pendingDetermination.determinationStatus = 'foo'
+    expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
+  })
+
+  it('is not pending if it is one of the non-pending values', () => {
+    for (const value of NonPendingDeterminationValues) {
+      pendingDetermination.determinationStatus = value
+      expect(isDeterminationStatusPending(pendingDetermination)).toBe(false)
     }
   })
 })

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -2,6 +2,7 @@ import { PendingDetermination } from '../../types/common'
 import {
   getScenario,
   isDeterminationStatusPending,
+  isScheduledStrictlyBefore,
   NonPendingDeterminationValues,
   ScenarioType,
 } from '../../utils/getScenarioContent'
@@ -115,4 +116,52 @@ describe('Determination Status', () => {
 })
 
 // Test isScheduledStrictlyBefore()
+describe('Comparing pending determination objects', () => {
+  const earlier: PendingDetermination = {
+    pendingDate: '',
+    scheduleDate: '2021-01-01T00:00:00',
+    timeSlotDesc: '',
+    requestDate: '',
+    determinationStatus: '',
+    willCallIndicator: true,
+    spokenLanguageCode: '',
+    spokenLanguageDesc: '',
+  }
+  const laterTime: PendingDetermination = {
+    pendingDate: '',
+    scheduleDate: '2021-01-01T00:00:00',
+    timeSlotDesc: '',
+    requestDate: '',
+    determinationStatus: '',
+    willCallIndicator: true,
+    spokenLanguageCode: '',
+    spokenLanguageDesc: '',
+  }
+  const laterDate: PendingDetermination = {
+    pendingDate: '',
+    scheduleDate: '2021-01-02T00:00:00',
+    timeSlotDesc: '',
+    requestDate: '',
+    determinationStatus: '',
+    willCallIndicator: true,
+    spokenLanguageCode: '',
+    spokenLanguageDesc: '',
+  }
+
+  it('returns true if the first object has an earlier appointment date', () => {
+    const result = isScheduledStrictlyBefore(earlier, laterDate)
+    expect(result).toBe(true)
+  })
+
+  it('returns false if the second object has an earlier appointment date', () => {
+    const result = isScheduledStrictlyBefore(laterDate, earlier)
+    expect(result).toBe(false)
+  })
+
+  it('returns false if the both appointments are scheduled on the same date and neither have a valid time slot', () => {
+    const result = isScheduledStrictlyBefore(earlier, laterTime)
+    expect(result).toBe(false)
+  })
+})
+
 // Test identifyPendingDeterminationScenario()

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -49,7 +49,7 @@ beforeAll(() => {
  * Refer to ScenarioType and ScenarioTypeNames for which scenario has which number.
  */
 
-// Scenarios 1, 2, 3
+// Scenarios 1, 2, 3 negative identification tests
 describe('Scenarios 1, 2, 3', () => {
   it('are not returned if pendingDetermination is null', () => {
     const pendingDeterminationScenarioNull = { pendingDetermination: null }
@@ -89,7 +89,7 @@ describe('The Base State scenarios (scenarios 5 & 6)', () => {
 })
 
 /**
- * Test Test identifyPendingDeterminationScenario()
+ * Test identifyPendingDeterminationScenario()
  */
 
 // Scenario 1: Test various values of pendingDetermination.determinationStatus

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -63,7 +63,8 @@ describe('Scenarios 1, 2, 3', () => {
 describe('The Generic Pending scenario (scenario 4)', () => {
   it('is returned as expected', () => {
     const scenarioType = ScenarioType.Scenario4
-    expect(getScenario(apiGatewayStub(scenarioType))).toBe(scenarioType)
+    const scenarioObject = getScenario(apiGatewayStub(scenarioType))
+    expect(scenarioObject.scenarioType).toBe(scenarioType)
   })
 })
 
@@ -72,7 +73,8 @@ describe('The Base State scenarios (scenarios 5 & 6)', () => {
   it('are returned as expected', () => {
     const baseScenarios = [ScenarioType.Scenario5, ScenarioType.Scenario6]
     for (const scenarioType of baseScenarios) {
-      expect(getScenario(apiGatewayStub(scenarioType))).toBe(scenarioType)
+      const scenarioObject = getScenario(apiGatewayStub(scenarioType))
+      expect(scenarioObject.scenarioType).toBe(scenarioType)
     }
   })
 })

--- a/tests/utils/timeSlot.test.ts
+++ b/tests/utils/timeSlot.test.ts
@@ -14,7 +14,7 @@ describe('A time slot string is', () => {
 
   it('handled if it is improperly formatted', () => {
     const badTimeSlot = parseTimeSlot('not a time slot')
-    expect(badTimeSlot).toBe(undefined)
+    expect(badTimeSlot).toBe(null)
   })
 
   it('handled if the separator is an ndash', () => {
@@ -36,9 +36,9 @@ describe('Comparing time slots results in', () => {
   const earlier = '10-12'
   const later = '1-3'
 
-  it('undefined if both time slots are improperly formatted', () => {
+  it('null if both time slots are improperly formatted', () => {
     const result = isFirstTimeSlotEarlier(bad, bad)
-    expect(result).toBe(undefined)
+    expect(result).toBe(null)
   })
 
   it('the first time slot if only the second time slot is improperly formatted', () => {

--- a/tests/utils/timeSlot.test.ts
+++ b/tests/utils/timeSlot.test.ts
@@ -1,0 +1,68 @@
+import { isFirstTimeSlotEarlier, parseTimeSlot } from '../../utils/timeSlot'
+
+// Test parseTimeSlot()
+describe('A time slot string is', () => {
+  it('correctly parsed if it is properly formatted', () => {
+    const multipleDigits = parseTimeSlot('10-12')
+    expect(multipleDigits.rangeStart).toBe(10)
+    expect(multipleDigits.rangeEnd).toBe(12)
+
+    const singleDigits = parseTimeSlot('1-3')
+    expect(singleDigits.rangeStart).toBe(1)
+    expect(singleDigits.rangeEnd).toBe(3)
+  })
+
+  it('handled if it is improperly formatted', () => {
+    const badTimeSlot = parseTimeSlot('not a time slot')
+    expect(badTimeSlot).toBe(undefined)
+  })
+
+  it('handled if the separator is an ndash', () => {
+    const multipleDigits = parseTimeSlot('10–12')
+    expect(multipleDigits.rangeStart).toBe(10)
+    expect(multipleDigits.rangeEnd).toBe(12)
+  })
+
+  it('handled if the separator is an mdash', () => {
+    const multipleDigits = parseTimeSlot('10—12')
+    expect(multipleDigits.rangeStart).toBe(10)
+    expect(multipleDigits.rangeEnd).toBe(12)
+  })
+})
+
+// Test isFirstTimeSlotEarlier()
+describe('Comparing time slots results in', () => {
+  const bad = 'not a time slot'
+  const earlier = '10-12'
+  const later = '1-3'
+
+  it('undefined if both time slots are improperly formatted', () => {
+    const result = isFirstTimeSlotEarlier(bad, bad)
+    expect(result).toBe(undefined)
+  })
+
+  it('the first time slot if only the second time slot is improperly formatted', () => {
+    const result = isFirstTimeSlotEarlier(earlier, bad)
+    expect(result).toBe(true)
+  })
+
+  it('the second time slot if only the first time slot is improperly formatted', () => {
+    const result = isFirstTimeSlotEarlier(bad, earlier)
+    expect(result).toBe(false)
+  })
+
+  it('the first time slot if its start time is earlier', () => {
+    const result = isFirstTimeSlotEarlier(earlier, later)
+    expect(result).toBe(true)
+  })
+
+  it('the second time slot if its start time is earlier', () => {
+    const result = isFirstTimeSlotEarlier(later, earlier)
+    expect(result).toBe(false)
+  })
+
+  it('the second time slot if both start at the same time', () => {
+    const result = isFirstTimeSlotEarlier(earlier, earlier)
+    expect(result).toBe(false)
+  })
+})

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -54,7 +54,7 @@ export interface TimeSlot {
 
 export interface ClaimStatusContent {
   heading: I18nString
-  summary: TransLineContent
+  summary: TransLineContent[]
   yourNextSteps: TransLineContent[]
   eddNextSteps: TransLineContent[]
 }

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -1,5 +1,6 @@
 // Type aliases
 export type I18nString = string
+export type ApiGatewayDateString = string
 
 // Types for TransLine component
 export interface TransLineContent {

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -15,7 +15,14 @@ export interface TextOptionalLink {
 
 // Types for API gateway result
 export interface PendingDetermination {
-  determinationStatus?: null | undefined | string
+  pendingDate: string
+  scheduleDate: string
+  timeSlotDesc: string
+  requestDate: string
+  determinationStatus?: string | null | undefined
+  willCallIndicator: boolean
+  spokenLanguageCode: string
+  spokenLanguageDesc: string
 }
 
 export interface ClaimDetailsResult {
@@ -35,7 +42,7 @@ export interface Claim {
   claimDetails?: null | ClaimDetailsResult
   hasPendingWeeks?: null | undefined | boolean
   hasCertificationWeeksAvailable?: null | undefined | boolean
-  pendingDetermination?: null | [PendingDetermination]
+  pendingDetermination?: null | PendingDetermination[]
 }
 
 // Types for Claim Status and Claim Details

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -46,6 +46,11 @@ export interface Claim {
 }
 
 // Types for Claim Status and Claim Details
+export interface TimeSlot {
+  rangeStart: number
+  rangeEnd: number
+}
+
 export interface ClaimStatusContent {
   heading: I18nString
   summary: TransLineContent

--- a/utils/apiGatewayStub.tsx
+++ b/utils/apiGatewayStub.tsx
@@ -4,8 +4,9 @@
  * Provides stub responses for API gateway queries for Storybook and Jest testing.
  */
 
-import { ScenarioType } from '../utils/getScenarioContent'
 import { Claim, PendingDetermination } from '../types/common'
+import { ScenarioType } from '../utils/getScenarioContent'
+import { formatFromApiGateway, getDateWithOffset } from '../utils/formatDate'
 
 /**
  * Stub the API gateway response for a given scenario.
@@ -42,7 +43,23 @@ export default function apiGatewayStub(
 
   switch (scenarioType) {
     case ScenarioType.Scenario1:
-      pendingDetermination.determinationStatus = null
+      pendingDetermination.determinationStatus = ''
+      pendingDetermination.scheduleDate = ''
+      pendingDetermination.requestDate = 'not empty'
+      claim.pendingDetermination = [pendingDetermination]
+      claim.hasCertificationWeeksAvailable = hasCertificationWeeksAvailable
+      break
+
+    case ScenarioType.Scenario2:
+      pendingDetermination.determinationStatus = ''
+      pendingDetermination.scheduleDate = formatFromApiGateway(getDateWithOffset(7))
+      claim.pendingDetermination = [pendingDetermination]
+      claim.hasCertificationWeeksAvailable = hasCertificationWeeksAvailable
+      break
+
+    case ScenarioType.Scenario3:
+      pendingDetermination.determinationStatus = ''
+      pendingDetermination.scheduleDate = formatFromApiGateway(getDateWithOffset(-7))
       claim.pendingDetermination = [pendingDetermination]
       claim.hasCertificationWeeksAvailable = hasCertificationWeeksAvailable
       break

--- a/utils/apiGatewayStub.tsx
+++ b/utils/apiGatewayStub.tsx
@@ -5,7 +5,7 @@
  */
 
 import { ScenarioType } from '../utils/getScenarioContent'
-import { Claim } from '../types/common'
+import { Claim, PendingDetermination } from '../types/common'
 
 /**
  * Stub the API gateway response for a given scenario.
@@ -24,6 +24,17 @@ export default function apiGatewayStub(
     pendingDetermination: null,
   }
 
+  const pendingDetermination: PendingDetermination = {
+    pendingDate: '',
+    scheduleDate: '',
+    timeSlotDesc: '',
+    requestDate: '',
+    determinationStatus: '',
+    willCallIndicator: false,
+    spokenLanguageCode: '',
+    spokenLanguageDesc: '',
+  }
+
   // If this is a known scenarioType, set a uniqueNumber.
   if (scenarioType in ScenarioType) {
     claim.uniqueNumber = '12345'
@@ -31,7 +42,8 @@ export default function apiGatewayStub(
 
   switch (scenarioType) {
     case ScenarioType.Scenario1:
-      claim.pendingDetermination = [{ determinationStatus: null }]
+      pendingDetermination.determinationStatus = null
+      claim.pendingDetermination = [pendingDetermination]
       claim.hasCertificationWeeksAvailable = hasCertificationWeeksAvailable
       break
 

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -43,14 +43,6 @@ export function parseApiGatewayDate(dateString: ApiGatewayDateString): Date {
 }
 
 /**
- * Parse and convert an API gateway string to UTC.
- * @TODO: Delete
- */
-export function parseConvertDate(dateString: ApiGatewayDateString): Date {
-  return parseApiGatewayDate(dateString)
-}
-
-/**
  * Return a string that matches the API gateway format for datetimes.
  */
 export function formatFromApiGateway(date: Date): string {
@@ -75,7 +67,7 @@ export function isValidDate(dateString: ApiGatewayDateString): boolean {
 
   // If the date format is such that it can't be parsed, then it is definitely invalid.
   try {
-    date = parseConvertDate(dateString)
+    date = parseApiGatewayDate(dateString)
   } catch (error) {
     return false
   }
@@ -117,6 +109,6 @@ export function isDatePast(date: Date): boolean {
  * Does not care if the given dateString is a valid date.
  */
 export default function formatDate(dateString: ApiGatewayDateString): string {
-  const date = parseConvertDate(dateString)
+  const date = parseApiGatewayDate(dateString)
   return format(date, 'M/d/yyyy')
 }

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -1,11 +1,19 @@
 /**
  * Utility file to handle datetimes.
  *
+ * Some helpful context from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date:
+ * > A JavaScript date is fundamentally specified as the number of milliseconds that have
+ * > elapsed since midnight on January 1, 1970, UTC. ... It's important to keep in mind
+ * > that while the time value at the heart of a Date object is UTC, the basic methods to
+ * > fetch the date and time or its components all work in the local (i.e. host system)
+ * > time zone and offset.
+ *
  * Because this is a State of California application, we assume all times are
  * in Pacific Time if there is no timezone provided in the datetime string.
  */
-import { format, isValid, parse } from 'date-fns'
-import { zonedTimeToUtc } from 'date-fns-tz'
+
+import { format, isValid } from 'date-fns'
+import { toDate } from 'date-fns-tz'
 import { ApiGatewayDateString } from '../types/common'
 
 const pacificTimeZone = 'America/Los_Angeles'
@@ -13,24 +21,33 @@ const apiGatewayFormat = "yyyy-MM-dd'T'HH:mm:ss"
 
 /**
  * Parse a date string from the API gateway.
+ *
+ * By default, if a date time string has no time zone (which is how we expect
+ * the date times from the API gateway to be formatted), it is interpreted as a UTC time.
+ *
+ * From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse:
+ *
+ * > For example, "2011-10-10" (date-only form), "2011-10-10T14:48:00" (date-time form),
+ * > or "2011-10-10T14:48:00.000+09:00" (date-time form with milliseconds and time zone)
+ * > can be passed and will be parsed. When the time zone offset is absent, date-only forms
+ * > are interpreted as a UTC time and date-time forms are interpreted as local time.
+ *
+ * This function will interpret date time strings with no time zone as a Pacific Time Zone
+ * time. If the date string argument contains a time zone offset, the `timeZone` option
+ * is ignored.
+ *
+ * See: https://github.com/marnusw/date-fns-tz#todate
  */
 export function parseApiGatewayDate(dateString: ApiGatewayDateString): Date {
-  return parse(dateString, apiGatewayFormat, new Date())
-}
-
-/**
- * Assume input is in Pacific Time and convert to UTC.
- */
-export function datetimeInUtc(date: Date | number | string): Date {
-  return zonedTimeToUtc(date, pacificTimeZone)
+  return toDate(dateString, { timeZone: pacificTimeZone })
 }
 
 /**
  * Parse and convert an API gateway string to UTC.
+ * @TODO: Delete
  */
 export function parseConvertDate(dateString: ApiGatewayDateString): Date {
-  const parsedDate = parseApiGatewayDate(dateString)
-  return datetimeInUtc(parsedDate)
+  return parseApiGatewayDate(dateString)
 }
 
 /**
@@ -43,11 +60,11 @@ export function formatFromApiGateway(date: Date): string {
 /**
  * Create a Date object that is offset from today.
  */
-export function getDateWithOffset(offset = 1): Date {
+export function getDateWithOffset(daysOffset = 1): Date {
   const today = new Date()
-  const sometime = today.setDate(today.getDate() + offset)
-  const sometimeUtc = datetimeInUtc(sometime)
-  return sometimeUtc
+  today.setDate(today.getDate() + daysOffset)
+  today.setHours(0, 0, 0, 0)
+  return today
 }
 
 /**
@@ -56,8 +73,7 @@ export function getDateWithOffset(offset = 1): Date {
 export function isValidDate(dateString: ApiGatewayDateString): boolean {
   let date: Date
 
-  // If the date format is such that it can't be parsed and converted to UTC,
-  // then it is definitely invalid.
+  // If the date format is such that it can't be parsed, then it is definitely invalid.
   try {
     date = parseConvertDate(dateString)
   } catch (error) {
@@ -65,9 +81,8 @@ export function isValidDate(dateString: ApiGatewayDateString): boolean {
   }
 
   if (isValid(date)) {
-    // Set a min date because it's possible for the date
-    // to be '0001-01-01'.
-    const minDate = datetimeInUtc('1900-01-01')
+    // Set a min date because it's possible for the date to be '0001-01-01'.
+    const minDate = toDate('1900-01-01', { timeZone: pacificTimeZone })
     if (date <= minDate) {
       return false
     }
@@ -92,7 +107,7 @@ export function isValidDate(dateString: ApiGatewayDateString): boolean {
  * Assumes that the given date is a valid date.
  */
 export function isDatePast(date: Date): boolean {
-  const today = datetimeInUtc(Date.now())
+  const today = new Date()
   return date < today
 }
 

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -1,21 +1,30 @@
+/**
+ * Utility file to handle datetimes.
+ *
+ * Because this is a State of California application, we assume all times are
+ * in Pacific Time if there is no timezone provided in the datetime string.
+ */
 import { format, isValid, parse } from 'date-fns'
+import { zonedTimeToUtc } from 'date-fns-tz'
+
+const pacificTimeZone = 'America/Los_Angeles'
 
 /**
- * Parse dates formatted by the API gateway.
+ * Assume input is in Pacific Time and convert to UTC.
  */
-export function parseApiDate(dateString: string): Date {
-  return parse(dateString, "yyyy-MM-dd'T'HH:mm:ss", new Date())
+export function datetimeInUtc(date: string | Date): Date {
+  return zonedTimeToUtc(date, pacificTimeZone)
 }
 
 /**
  * Determine if the date string is valid.
  */
 export function isValidDate(dateString: string): boolean {
-  const date = parseApiDate(dateString)
+  const date = datetimeInUtc(dateString)
   if (isValid(date)) {
     // Set a min date because it's possible for the date
     // to be '0001-01-01'.
-    const minDate = new Date('1900-01-01')
+    const minDate = datetimeInUtc('1900-01-01')
     if (date <= minDate) {
       return false
     }
@@ -38,6 +47,6 @@ export function isValidDate(dateString: string): boolean {
  * Format dates for user-facing display.
  */
 export default function formatDate(dateString: string): string {
-  const parsedDate = parseApiDate(dateString)
+  const parsedDate = datetimeInUtc(dateString)
   return format(parsedDate, 'M/d/yyyy')
 }

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -17,6 +17,23 @@ export function datetimeInUtc(date: Date | number | string): Date {
 }
 
 /**
+ * Return a string that matches the API gateway format for datetimes.
+ */
+export function formatFromApiGateway(date: Date): string {
+  return format(date, "yyyy-MM-dd'T'HH:mm:ss")
+}
+
+/**
+ * Create a Date object that is offset from today.
+ */
+export function getDateWithOffset(offset = 1): Date {
+  const today = new Date()
+  const sometime = today.setDate(today.getDate() + offset)
+  const sometimeUtc = datetimeInUtc(sometime)
+  return sometimeUtc
+}
+
+/**
  * Determine if the date string is valid.
  */
 export function isValidDate(dateOrString: string | Date): boolean {

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -4,7 +4,7 @@
  * Because this is a State of California application, we assume all times are
  * in Pacific Time if there is no timezone provided in the datetime string.
  */
-import { format, isValid, parse } from 'date-fns'
+import { format, isValid } from 'date-fns'
 import { zonedTimeToUtc } from 'date-fns-tz'
 
 const pacificTimeZone = 'America/Los_Angeles'
@@ -42,6 +42,14 @@ export function isValidDate(dateString: string): boolean {
 
 // @TODO: add a function to check and log any dates that are earlier
 // than 2020 as these are anomolous dates that could indicate an error.
+
+/**
+ * Determine if the date is in the past.
+ */
+export function isDatePast(date: Date): boolean {
+  const today = datetimeInUtc(new Date())
+  return date < today
+}
 
 /**
  * Format dates for user-facing display.

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -100,6 +100,7 @@ export function isValidDate(dateString: ApiGatewayDateString): boolean {
  */
 export function isDatePast(date: Date): boolean {
   const today = new Date()
+  today.setHours(0, 0, 0, 0)
   return date < today
 }
 

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -12,15 +12,22 @@ const pacificTimeZone = 'America/Los_Angeles'
 /**
  * Assume input is in Pacific Time and convert to UTC.
  */
-export function datetimeInUtc(date: string | Date): Date {
+export function datetimeInUtc(date: Date | number | string): Date {
   return zonedTimeToUtc(date, pacificTimeZone)
 }
 
 /**
  * Determine if the date string is valid.
  */
-export function isValidDate(dateString: string): boolean {
-  const date = datetimeInUtc(dateString)
+export function isValidDate(dateOrString: string | Date): boolean {
+  let date: Date
+
+  if (typeof dateOrString === 'string') {
+    date = datetimeInUtc(dateOrString)
+  } else {
+    date = dateOrString
+  }
+
   if (isValid(date)) {
     // Set a min date because it's possible for the date
     // to be '0001-01-01'.
@@ -47,8 +54,12 @@ export function isValidDate(dateString: string): boolean {
  * Determine if the date is in the past.
  */
 export function isDatePast(date: Date): boolean {
-  const today = datetimeInUtc(new Date())
-  return date < today
+  const today = datetimeInUtc(Date.now())
+  if (isValidDate(today) && isValidDate(date)) {
+    return date < today
+  } else {
+    throw new Error('Invalid date')
+  }
 }
 
 /**

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -1,4 +1,4 @@
-import { format, parse } from 'date-fns'
+import { format, isValid, parse } from 'date-fns'
 
 /**
  * Parse dates formatted by the API gateway.
@@ -6,6 +6,33 @@ import { format, parse } from 'date-fns'
 export function parseApiDate(dateString: string): Date {
   return parse(dateString, "yyyy-MM-dd'T'HH:mm:ss", new Date())
 }
+
+/**
+ * Determine if the date string is valid.
+ */
+export function isValidDate(dateString: string): boolean {
+  const date = parseApiDate(dateString)
+  if (isValid(date)) {
+    // Set a min date because it's possible for the date
+    // to be '0001-01-01'.
+    const minDate = new Date('1900-01-01')
+    if (date <= minDate) {
+      return false
+    }
+    // date-fns says the date is valid
+    // AND the date is sooner than the min date.
+    else {
+      return true
+    }
+  }
+  // date-fns says the date is invalid
+  else {
+    return false
+  }
+}
+
+// @TODO: add a function to check and log any dates that are earlier
+// than 2020 as these are anomolous dates that could indicate an error.
 
 /**
  * Format dates for user-facing display.

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -1,0 +1,16 @@
+import { format, parse } from 'date-fns'
+
+/**
+ * Parse dates formatted by the API gateway.
+ */
+export function parseApiDate(dateString: string): Date {
+  return parse(dateString, "yyyy-MM-dd'T'HH:mm:ss", new Date())
+}
+
+/**
+ * Format dates for user-facing display.
+ */
+export default function formatDate(dateString: string): string {
+  const parsedDate = parseApiDate(dateString)
+  return format(parsedDate, 'M/d/yyyy')
+}

--- a/utils/getClaimDetails.tsx
+++ b/utils/getClaimDetails.tsx
@@ -5,8 +5,8 @@
  * shown in the Claim Tracker to the user.
  */
 
-import { format, parse } from 'date-fns'
 import { ClaimDetailsContent, ClaimDetailsResult, I18nString } from '../types/common'
+import formatDate from './formatDate'
 
 export interface ProgramType {
   [key: string]: string
@@ -86,14 +86,6 @@ export function getProgramExtensionPair(apiString: string): programExtensionPair
   }
   // If no known mapping is found, throw an error.
   throw new Error('Unknown Program Type')
-}
-
-/**
- * Format dates.
- */
-export function formatDate(dateString: string): string {
-  const parsedDate = parse(dateString, "yyyy-MM-dd'T'HH:mm:ss", new Date())
-  return format(parsedDate, 'M/d/yyyy')
 }
 
 /**

--- a/utils/getClaimStatus.tsx
+++ b/utils/getClaimStatus.tsx
@@ -10,7 +10,7 @@ type StepType = 'your-next-steps' | 'edd-next-steps'
 
 interface ClaimStatusScenarioJson {
   heading: string
-  summary: TextOptionalLink
+  summary: TextOptionalLink[]
   'your-next-steps': TextOptionalLink[]
   'edd-next-steps': TextOptionalLink[]
 }
@@ -64,9 +64,14 @@ function buildI18nKey(keys: string[]): I18nString {
 export function buildClaimStatusSummary(
   scenarioObject: ClaimStatusScenarioJson,
   scenarioString: string,
-): TransLineContent {
-  const keys = ['scenarios', scenarioString, 'summary']
-  return buildTransLineContent(scenarioObject.summary, buildI18nKey(keys))
+): TransLineContent[] {
+  const summaryParagraphs: TransLineContent[] = []
+  const json = scenarioObject.summary
+  for (const [index, value] of json.entries()) {
+    const keys = ['scenarios', scenarioString, 'summary', index.toString()]
+    summaryParagraphs.push(buildTransLineContent(value, buildI18nKey(keys)))
+  }
+  return summaryParagraphs
 }
 
 /**

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -10,7 +10,7 @@
 import { Claim, ClaimDetailsContent, PendingDetermination, ScenarioContent } from '../types/common'
 import getClaimDetails from './getClaimDetails'
 import getClaimStatus from './getClaimStatus'
-import { datetimeInUtc, isDatePast, isValidDate } from './formatDate'
+import { isDatePast, isValidDate, parseConvertDate } from './formatDate'
 import { isFirstTimeSlotEarlier } from './timeSlot'
 
 export enum ScenarioType {
@@ -57,10 +57,11 @@ export function isDeterminationStatusPending(pendingDetermination: PendingDeterm
  * Identify whether the first pendingDetermination object is scheduled before the second object.
  *
  * If both arguments are scheduled at the same time, this will return false.
+ * Assumes that dates have already been checked for validity.
  */
 export function isScheduledStrictlyBefore(first: PendingDetermination, second: PendingDetermination): boolean {
-  const firstScheduleDate = datetimeInUtc(first.scheduleDate)
-  const secondScheduleDate = datetimeInUtc(second.scheduleDate)
+  const firstScheduleDate = parseConvertDate(first.scheduleDate)
+  const secondScheduleDate = parseConvertDate(second.scheduleDate)
 
   // If the first appointment is scheduled before the second.
   if (firstScheduleDate < secondScheduleDate) {
@@ -105,7 +106,7 @@ export function identifyPendingDeterminationScenario(
       // Scenario 2:
       // If Determination Status is Pending
       // AND Schedule Date is today or in the future
-      if (!isDatePast(datetimeInUtc(pendingDetermination.scheduleDate))) {
+      if (!isDatePast(parseConvertDate(pendingDetermination.scheduleDate))) {
         // If we haven't found a pendingDetermination object that is scheduled yet
         // OR the current pendingDetermination object is earlier than the previous one found
         // Then update the earliest found scheduled pendingDetermination object

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -10,19 +10,29 @@
 import { Claim, ClaimDetailsContent, PendingDetermination, ScenarioContent } from '../types/common'
 import getClaimDetails from './getClaimDetails'
 import getClaimStatus from './getClaimStatus'
+import { datetimeInUtc, isDatePast } from './formatDate'
 
 export enum ScenarioType {
   Scenario1,
+  Scenario2,
+  Scenario3,
   Scenario4,
   Scenario5,
   Scenario6,
 }
 
 export const ScenarioTypeNames = {
-  [ScenarioType.Scenario1]: 'Pending determination scenario',
+  [ScenarioType.Scenario1]: 'Determination interview: not yet scheduled',
+  [ScenarioType.Scenario2]: 'Determination interview: scheduled',
+  [ScenarioType.Scenario3]: 'Determination interview: awaiting decision',
   [ScenarioType.Scenario4]: 'Generic pending state: pending weeks',
   [ScenarioType.Scenario5]: 'Base state: no pending weeks, no weeks to certify',
   [ScenarioType.Scenario6]: 'Base state: no pending weeks, weeks to certify',
+}
+
+interface PendingDeterminationScenario {
+  scenarioType: ScenarioType
+  pendingDetermination?: PendingDetermination
 }
 
 export const NonPendingDeterminationValues = ['Canceled', 'Complete', 'TRAN', 'INVL', 'IDNC', '1277', 'OTHR', 'ClmCX']
@@ -42,33 +52,109 @@ export function isDeterminationStatusPending(pendingDetermination: PendingDeterm
   )
 }
 
+export function isStrictlyBefore(first: PendingDetermination, second: PendingDetermination): boolean {
+  return true
+}
+
+/**
+ * Identify whether the scenario is one of the pending determination scenarios.
+ */
+export function identifyPendingDeterminationScenario(
+  pendingDeterminations: PendingDetermination[],
+): PendingDeterminationScenario | undefined {
+  let earliestScheduled: PendingDetermination | undefined
+
+  // Track whether any of the pendingDetermination objects meet the other scenario criteria.
+  let hasAwaitingDecision = false
+  let hasNotYetScheduled = false
+
+  // Loop through all the pendingDetermination objects.
+  for (const pendingDetermination of pendingDeterminations) {
+    if (isDeterminationStatusPending(pendingDetermination)) {
+      // Scenario 2:
+      // If Determination Status is Pending
+      // AND Schedule Date is today or in the future
+      if (!isDatePast(datetimeInUtc(pendingDetermination.scheduleDate))) {
+        // If we haven't found a pendingDetermination object that is scheduled yet
+        // OR the current pendingDetermination object is earlier than the previous one found
+        // Then update the earliest found scheduled pendingDetermination object
+        if (!earliestScheduled || isStrictlyBefore(pendingDetermination, earliestScheduled)) {
+          earliestScheduled = pendingDetermination
+        }
+      }
+      // Scenario 3:
+      // If Determination Status is Pending
+      // AND Schedule Date is in the past
+      else {
+        hasAwaitingDecision = true
+      }
+    }
+    // Scenario 1:
+    // If determinationStatus is empty/null/undefined/unset
+    // AND scheduleDate has no value
+    // AND requestDate has a value
+    else if (
+      !pendingDetermination.determinationStatus &&
+      !pendingDetermination.scheduleDate &&
+      pendingDetermination.requestDate
+    ) {
+      hasNotYetScheduled = true
+    }
+    // All other combinations are invalid!
+  }
+
+  // Scenarios 2 takes priority over Scenarios 1 & 3.
+  if (earliestScheduled) {
+    return {
+      scenarioType: ScenarioType.Scenario2,
+      pendingDetermination: earliestScheduled,
+    }
+  } else {
+    // Scenario 3 takes priority over Scenario 1.
+    if (hasAwaitingDecision) {
+      return { scenarioType: ScenarioType.Scenario3 }
+    } else if (hasNotYetScheduled) {
+      return { scenarioType: ScenarioType.Scenario1 }
+    }
+    // Otherwise, no valid pendingDetermination objects; return undefined.
+    else {
+      return undefined
+    }
+  }
+}
+
 /**
  * Identify the correct scenario to display.
  *
  * @TODO: Validating the API gateway response #150
  */
 export function getScenario(claimData: Claim): ScenarioType {
-  // The pending determination scenario: if claimData contains any pendingDetermination
-  // objects
-  // @TODO: refactor with more detailed pending determination scenarios #252
+  // If there are any pendingDetermination objects, the scenario MIGHT be one of the
+  // pending determination scenarios.
   if (claimData.pendingDetermination && claimData.pendingDetermination.length > 0) {
-    return ScenarioType.Scenario1
+    const pendingDeterminationScenario = identifyPendingDeterminationScenario(claimData.pendingDetermination)
+
+    // It's possible to have pending determination objects, but still not be a valid
+    // pending determination scenario, so check to see if the returned object is undefined.
+    if (pendingDeterminationScenario) {
+      return pendingDeterminationScenario.scenarioType
+    }
   }
 
-  // No pendingDetermination objects.
+  // If the scenario is not one of the Pending Determination scenarios,
+  // check to see if it one of the remaining scenarios.
+
+  // @TODO: Validate that hasPendingWeeks is a boolean
+  if (claimData.hasPendingWeeks === true) {
+    // @TODO: Validate that hasCertificationWeeks is a boolean
+    return ScenarioType.Scenario4
+  }
+  // hasPendingWeeks === false
   else {
-    // @TODO: Validate that hasPendingWeeks is a boolean
-    if (claimData.hasPendingWeeks === true) {
-      // @TODO: Validate that hasCertificationWeeks is a boolean
-      return ScenarioType.Scenario4
-    }
-    // hasPendingWeeks === false
-    else {
-      if (claimData.hasCertificationWeeksAvailable === false) {
-        return ScenarioType.Scenario5
-      } else {
-        return ScenarioType.Scenario6
-      }
+    if (claimData.hasCertificationWeeksAvailable === false) {
+      return ScenarioType.Scenario5
+    } else {
+      return ScenarioType.Scenario6
     }
   }
 }

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -78,7 +78,7 @@ export function isScheduledStrictlyBefore(first: PendingDetermination, second: P
     // It's possible for both time slots to be improperly formatted, in which case it doesn't
     // matter which appointment is said to be first, since they are on the same date.
     if (!isEarlier) {
-      return true
+      return false
     }
     // Otherwise, return the appointment with the earlier time slot start time.
     else {

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -10,7 +10,7 @@
 import { Claim, ClaimDetailsContent, PendingDetermination, ScenarioContent } from '../types/common'
 import getClaimDetails from './getClaimDetails'
 import getClaimStatus from './getClaimStatus'
-import { isDatePast, isValidDate, parseConvertDate } from './formatDate'
+import { isDatePast, isValidDate, parseApiGatewayDate } from './formatDate'
 import { isFirstTimeSlotEarlier } from './timeSlot'
 
 export enum ScenarioType {
@@ -60,8 +60,8 @@ export function isDeterminationStatusPending(pendingDetermination: PendingDeterm
  * Assumes that dates have already been checked for validity.
  */
 export function isScheduledStrictlyBefore(first: PendingDetermination, second: PendingDetermination): boolean {
-  const firstScheduleDate = parseConvertDate(first.scheduleDate)
-  const secondScheduleDate = parseConvertDate(second.scheduleDate)
+  const firstScheduleDate = parseApiGatewayDate(first.scheduleDate)
+  const secondScheduleDate = parseApiGatewayDate(second.scheduleDate)
 
   // If the first appointment is scheduled before the second.
   if (firstScheduleDate < secondScheduleDate) {
@@ -106,7 +106,7 @@ export function identifyPendingDeterminationScenario(
       // Scenario 2:
       // If Determination Status is Pending
       // AND Schedule Date is today or in the future
-      if (!isDatePast(parseConvertDate(pendingDetermination.scheduleDate))) {
+      if (!isDatePast(parseApiGatewayDate(pendingDetermination.scheduleDate))) {
         // If we haven't found a pendingDetermination object that is scheduled yet
         // OR the current pendingDetermination object is earlier than the previous one found
         // Then update the earliest found scheduled pendingDetermination object

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -10,7 +10,7 @@
 import { Claim, ClaimDetailsContent, PendingDetermination, ScenarioContent } from '../types/common'
 import getClaimDetails from './getClaimDetails'
 import getClaimStatus from './getClaimStatus'
-import { datetimeInUtc, isDatePast } from './formatDate'
+import { datetimeInUtc, isDatePast, isValidDate } from './formatDate'
 import { isFirstTimeSlotEarlier } from './timeSlot'
 
 export enum ScenarioType {
@@ -101,7 +101,7 @@ export function identifyPendingDeterminationScenario(
 
   // Loop through all the pendingDetermination objects.
   for (const pendingDetermination of pendingDeterminations) {
-    if (isDeterminationStatusPending(pendingDetermination)) {
+    if (isDeterminationStatusPending(pendingDetermination) && isValidDate(pendingDetermination.scheduleDate)) {
       // Scenario 2:
       // If Determination Status is Pending
       // AND Schedule Date is today or in the future

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -78,13 +78,8 @@ export function isScheduledStrictlyBefore(first: PendingDetermination, second: P
 
     // It's possible for both time slots to be improperly formatted, in which case it doesn't
     // matter which appointment is said to be first, since they are on the same date.
-    if (!isEarlier) {
-      return false
-    }
     // Otherwise, return the appointment with the earlier time slot start time.
-    else {
-      return isEarlier
-    }
+    return !!isEarlier
   }
 }
 

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -159,7 +159,7 @@ export function identifyPendingDeterminationScenario(
  *
  * @TODO: Validating the API gateway response #150
  */
-export function getScenario(claimData: Claim): ScenarioType {
+export function getScenario(claimData: Claim): PendingDeterminationScenario {
   // If there are any pendingDetermination objects, the scenario MIGHT be one of the
   // pending determination scenarios.
   if (claimData.pendingDetermination && claimData.pendingDetermination.length > 0) {
@@ -168,7 +168,7 @@ export function getScenario(claimData: Claim): ScenarioType {
     // It's possible to have pending determination objects, but still not be a valid
     // pending determination scenario, so check to see if the returned object is null.
     if (pendingDeterminationScenario) {
-      return pendingDeterminationScenario.scenarioType
+      return pendingDeterminationScenario
     }
   }
 
@@ -178,14 +178,14 @@ export function getScenario(claimData: Claim): ScenarioType {
   // @TODO: Validate that hasPendingWeeks is a boolean
   if (claimData.hasPendingWeeks === true) {
     // @TODO: Validate that hasCertificationWeeks is a boolean
-    return ScenarioType.Scenario4
+    return { scenarioType: ScenarioType.Scenario4 }
   }
   // hasPendingWeeks === false
   else {
     if (claimData.hasCertificationWeeksAvailable === false) {
-      return ScenarioType.Scenario5
+      return { scenarioType: ScenarioType.Scenario5 }
     } else {
-      return ScenarioType.Scenario6
+      return { scenarioType: ScenarioType.Scenario6 }
     }
   }
 }
@@ -212,7 +212,8 @@ export function continueCertifying(scenarioType: ScenarioType, claimData: Claim)
  */
 export default function getScenarioContent(claimData: Claim): ScenarioContent {
   // Get the scenario type.
-  const scenarioType = getScenario(claimData)
+  const scenarioTypeObject = getScenario(claimData)
+  const scenarioType = scenarioTypeObject.scenarioType
 
   // Construct claim status content.
   const statusContent = getClaimStatus(scenarioType, continueCertifying(scenarioType, claimData))

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -78,8 +78,13 @@ export function isScheduledStrictlyBefore(first: PendingDetermination, second: P
 
     // It's possible for both time slots to be improperly formatted, in which case it doesn't
     // matter which appointment is said to be first, since they are on the same date.
+    if (!isEarlier) {
+      return false
+    }
     // Otherwise, return the appointment with the earlier time slot start time.
-    return !!isEarlier
+    else {
+      return isEarlier
+    }
   }
 }
 

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -7,7 +7,7 @@
  * description in ScenarioTypeNames for easy(ish) reference.
  */
 
-import { Claim, ClaimDetailsContent, ScenarioContent } from '../types/common'
+import { Claim, ClaimDetailsContent, PendingDetermination, ScenarioContent } from '../types/common'
 import getClaimDetails from './getClaimDetails'
 import getClaimStatus from './getClaimStatus'
 
@@ -23,6 +23,23 @@ export const ScenarioTypeNames = {
   [ScenarioType.Scenario4]: 'Generic pending state: pending weeks',
   [ScenarioType.Scenario5]: 'Base state: no pending weeks, no weeks to certify',
   [ScenarioType.Scenario6]: 'Base state: no pending weeks, weeks to certify',
+}
+
+export const NonPendingDeterminationValues = ['Canceled', 'Complete', 'TRAN', 'INVL', 'IDNC', '1277', 'OTHR', 'ClmCX']
+
+/**
+ * Determine whether the Determination Status is pending.
+ *
+ * Determination Status is considered pending if:
+ * either DeterminationStatus is blank (NULL)
+ * OR DeterminationStatus is neither "Canceled" nor "Complete" nor "TRAN" nor
+ *   "INVL" nor "IDNC" nor "1277" nor "OTHR" nor "ClmCX"
+ */
+export function isDeterminationStatusPending(pendingDetermination: PendingDetermination): boolean {
+  return (
+    !pendingDetermination.determinationStatus ||
+    !NonPendingDeterminationValues.includes(pendingDetermination.determinationStatus)
+  )
 }
 
 /**

--- a/utils/timeSlot.ts
+++ b/utils/timeSlot.ts
@@ -1,0 +1,76 @@
+/**
+ * Utility file to handle time slots for scheduled appointments.
+ */
+
+import { TimeSlot } from '../types/common'
+
+/**
+ * Parse a time slot from the API gateway.
+ */
+export function parseTimeSlot(timeSlot: string): TimeSlot | null {
+  // Time slots are expected to be in the format 10-12.
+  const match = /(\d+)[-–—](\d+)/.exec(timeSlot)
+  if (match) {
+    const formattedTimeSlot: TimeSlot = {
+      rangeStart: parseInt(match[1]),
+      rangeEnd: parseInt(match[2]),
+    }
+    return formattedTimeSlot
+  }
+  // If the arg does not match the regex, return null.
+  else {
+    return null
+  }
+}
+
+/**
+ * Convert 12 hour time into 24 hour time.
+ *
+ * Assume that any time earlier than 8 is actually PM.
+ */
+function convertTo24H(time: number): number {
+  if (time < 8) {
+    return time + 12
+  } else {
+    return time
+  }
+}
+
+/**
+ * Determine whether the first time slot starts earlier than the second time slot.
+ */
+export function isFirstTimeSlotEarlier(first: string, second: string): boolean | null {
+  const firstTimeSlot = parseTimeSlot(first)
+  const secondTimeSlot = parseTimeSlot(second)
+
+  // If neither arg matches the expected format, return null.
+  if (!firstTimeSlot && !secondTimeSlot) {
+    return null
+  }
+  // If the first arg is properly formatted and the second one is not,
+  // then we say the first one is earlier because we prefer showing more granularity.
+  else if (firstTimeSlot && !secondTimeSlot) {
+    return true
+  }
+  // If the first arg is not properly formatted and the second one is,
+  // then we say the second one is earlier for the same reason as above.
+  else if (!firstTimeSlot && secondTimeSlot) {
+    return false
+  }
+  // If both args are properly formatted...
+  // Note: this is an "else if" instead of an "else" because typescript says that
+  // firstTimeSlot and secondTimeSlot could be null at this point.
+  else if (firstTimeSlot && secondTimeSlot) {
+    // ...then we can actually compare them against each other.
+    if (convertTo24H(firstTimeSlot.rangeStart) < convertTo24H(secondTimeSlot.rangeStart)) {
+      return true
+    } else {
+      return false
+    }
+  }
+  // This is required due to a weird typescript issue.
+  // In practice, this should be unreachable code.
+  else {
+    return null
+  }
+}

--- a/utils/timeSlot.ts
+++ b/utils/timeSlot.ts
@@ -1,5 +1,10 @@
 /**
  * Utility file to handle time slots for scheduled appointments.
+ *
+ * Time slots are expected to be in this format:
+ * - "10-12"
+ * - "1-3"
+ * - etc
  */
 
 import { TimeSlot } from '../types/common'
@@ -8,7 +13,8 @@ import { TimeSlot } from '../types/common'
  * Parse a time slot from the API gateway.
  */
 export function parseTimeSlot(timeSlot: string): TimeSlot | null {
-  // Time slots are expected to be in the format 10-12.
+  // Time slots are expected to be in the format 10-12,
+  // where the dash can either be a hyphen (-) or an ndash (–) or an mdash (—).
   const match = /(\d+)[-–—](\d+)/.exec(timeSlot)
   if (match) {
     const formattedTimeSlot: TimeSlot = {
@@ -27,10 +33,6 @@ export function parseTimeSlot(timeSlot: string): TimeSlot | null {
  * Convert 12 hour time into 24 hour time.
  *
  * Assume that any time earlier than 8 is actually PM.
- * Time slots are expected to be in this format:
- * - "10-12"
- * - "1-3"
- * - etc
  */
 function convertTo24H(time: number): number {
   if (time < 8) {

--- a/utils/timeSlot.ts
+++ b/utils/timeSlot.ts
@@ -27,6 +27,10 @@ export function parseTimeSlot(timeSlot: string): TimeSlot | null {
  * Convert 12 hour time into 24 hour time.
  *
  * Assume that any time earlier than 8 is actually PM.
+ * Time slots are expected to be in this format:
+ * - "10-12"
+ * - "1-3"
+ * - etc
  */
 function convertTo24H(time: number): number {
   if (time < 8) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10054,6 +10054,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mockdate@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
+  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
+
 mocked-env@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mocked-env/-/mocked-env-1.3.4.tgz#271cc15074a9b1db20330133a03766e41e528489"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5673,6 +5673,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns-tz@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.1.4.tgz#38282c2bfab08946a4e9bb89d733451e5525048b"
+  integrity sha512-lQ+FF7xUxxRuRqIY7H/lagnT3PhhSnnvtGHzjE5WZKwRyLU7glJfLys05SZ7zHlEr6RXWiqkmgWq4nCkcElR+g==
+
 date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"


### PR DESCRIPTION
## Ticket

Resolves #252 

## Changes

- Add business logic for Scenarios 1–3, including:
  - Identifying whether the Determination Status is pending
  - Comparing dates and times between `pendingDetermination` objects
  - Handling multiple `pendingDetermination` objects
- Add [`date-fns-tz`](https://github.com/marnusw/date-fns-tz) as a dependency to handle time zones
- Add date parsing and formatting utility (moved out of `getClaimDetails.tsx`)
- Add time slot utility
- Add support for Claim Status summary to have multiple paragraphs
- Add latest English language scenario content
- Update `apiGatewayStub` to support Scenarios 1–3
- Add [`mockdate`](https://github.com/boblauer/MockDate) package for more robust mocking of `Date.now()`

## Context

This PR adds a lot of functionality to support the 3 pending determination/determination interview scenarios. The logic is bit complicated, so I'm happy to walk you through it. The highlights are:

- If there are multiple `pendingDetermination` objects, Scenario 2 takes priority, then Scenario 3, then Scenario 1.
- If there are multiple objects that fit Scenario 2, show the one that has the soonest appointment.
- It's possible for there to be invalid `pendingDetermination` objects, in which case, fall through to the logic for Scenarios 4–6.

The content turned out to actually be of a slightly different format from the Generic Pending and Base State scenarios, so I've split out 2 additional tickets:
- #341 
- #342 

## Testing

`yarn test`

PLUS

While #299 is not resolved, comment out the following lines, then run `yarn storybook`, and verify that the links the 3 pending determination scenarios display the latest content (with the exceptions of the upcoming appointment date and the nested bullets): https://github.com/cagov/ui-claim-tracker/blob/32990f892c6b84017c30af5d273fdd94410649e7/pages/index.tsx#L95-L98