### PR TITLE
Add support for indented bullets in Next Steps

### DIFF
--- a/components/NextSteps.tsx
+++ b/components/NextSteps.tsx
@@ -6,7 +6,7 @@ export interface NextStepsProps {
   loading: boolean
   userArrivedFromUioMobile: boolean
   header: string[]
-  nextSteps: TransLineContent[]
+  nextSteps: Array<TransLineContent | TransLineContent[]>
 }
 
 export const NextSteps: React.FC<NextStepsProps> = ({
@@ -22,16 +22,39 @@ export const NextSteps: React.FC<NextStepsProps> = ({
     loadableContent = (
       <div className="next-step-explanation">
         <ul>
-          {nextSteps.map((nextStep, index) => (
-            <li key={index} className="next-step">
-              <TransLine
-                loading={loading}
-                userArrivedFromUioMobile={userArrivedFromUioMobile}
-                i18nKey={nextStep.i18nKey}
-                links={nextStep.links}
-              />
-            </li>
-          ))}
+          {nextSteps.map((nextStep, index) => {
+            // Use the only element, or the first element if an array, as the main bullet
+            // Include remaining elements in an array as sub-bullets
+            const thisStep = Array.isArray(nextStep) ? nextStep[0] : nextStep
+
+            return (
+              <li key={index} className="next-step">
+                <TransLine
+                  loading={loading}
+                  userArrivedFromUioMobile={userArrivedFromUioMobile}
+                  i18nKey={thisStep.i18nKey}
+                  links={thisStep.links}
+                />
+                {Array.isArray(nextStep) ? (
+                  <ul>
+                    {
+                      // Include sub-bullets; ignore first element since it was already included as a main bullet above
+                      nextStep.slice(1).map((subStep, index2) => (
+                        <li key={index2} className="next-step">
+                          <TransLine
+                            loading={loading}
+                            userArrivedFromUioMobile={userArrivedFromUioMobile}
+                            i18nKey={subStep.i18nKey}
+                            links={subStep.links}
+                          />
+                        </li>
+                      ))
+                    }
+                  </ul>
+                ) : null}
+              </li>
+            )
+          })}
         </ul>
       </div>
     )

--- a/public/locales/en/claim-status.json
+++ b/public/locales/en/claim-status.json
@@ -48,7 +48,7 @@
       "edd-next-steps": [
         {
           "text": "We will call you during your scheduled interview time. Your caller ID may show “St of CA EDD” or the UI Customer Service number 1-800-300-5616.",
-          "sub-bullets": [
+          "subBullets": [
             {
               "text": "If you do not receive a call from the EDD at your scheduled appointment time, we may have canceled your appointment because we confirmed your eligibility or resolved the issue before your interview."
             },
@@ -77,7 +77,7 @@
       "edd-next-steps": [
         {
           "text": "We will determine your eligibility.",
-          "sub-bullets": [
+          "subBullets": [
             {
               "text": "If you are found eligible and no other issues are identified, we will pay you for all pending weeks."
             },

--- a/tests/components/ClaimStatus.test.tsx
+++ b/tests/components/ClaimStatus.test.tsx
@@ -21,8 +21,8 @@ function renderClaimStatusComponent(statusContent: ClaimStatusContent, userArriv
 
 function testClaimStatus(
   scenarioType: ScenarioType,
-  hasCertificationWeeksAvailable: boolean,
-  userArrivedFromUioMobile: boolean,
+  hasCertificationWeeksAvailable = false,
+  userArrivedFromUioMobile = false,
 ): string {
   const scenarioContent = getScenarioContent(apiGatewayStub(scenarioType, hasCertificationWeeksAvailable))
   return renderClaimStatusComponent(scenarioContent.statusContent, userArrivedFromUioMobile)

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -12,6 +12,7 @@ export interface TransLineContent {
 export interface TextOptionalLink {
   text: string
   links?: string[]
+  subBullets?: TextOptionalLink[]
 }
 
 // Types for API gateway result
@@ -55,8 +56,8 @@ export interface TimeSlot {
 export interface ClaimStatusContent {
   heading: I18nString
   summary: TransLineContent[]
-  yourNextSteps: TransLineContent[]
-  eddNextSteps: TransLineContent[]
+  yourNextSteps: Array<TransLineContent | TransLineContent[]>
+  eddNextSteps: Array<TransLineContent | TransLineContent[]>
 }
 
 export interface ClaimDetailsContent {

--- a/utils/getClaimStatus.tsx
+++ b/utils/getClaimStatus.tsx
@@ -90,8 +90,8 @@ export function buildNextSteps(
   scenarioString: string,
   whichSteps: StepType,
   continueCertifying = false,
-): TransLineContent[] {
-  const steps: TransLineContent[] = []
+): Array<TransLineContent | TransLineContent[]> {
+  const steps: Array<TransLineContent | TransLineContent[]> = []
 
   // If we should display the "continue certifying" next step, then display it as the first step.
   if (continueCertifying) {
@@ -101,9 +101,18 @@ export function buildNextSteps(
   const json = scenarioObject[whichSteps]
   for (const [index, value] of json.entries()) {
     const keys = ['scenarios', scenarioString, whichSteps, index.toString()]
-    steps.push(buildTransLineContent(value, buildI18nKey(keys)))
+    if (Array.isArray(value.subBullets)) {
+      const nestedSteps = []
+      nestedSteps.push(buildTransLineContent(value, buildI18nKey(keys)))
+      for (const [index2, subBullet] of value.subBullets.entries()) {
+        const keys = ['scenarios', scenarioString, whichSteps, index.toString(), 'subBullets', index2.toString()]
+        nestedSteps.push(buildTransLineContent(subBullet, buildI18nKey(keys)))
+      }
+      steps.push(nestedSteps)
+    } else {
+      steps.push(buildTransLineContent(value, buildI18nKey(keys)))
+    }
   }
-
   return steps
 }
 


### PR DESCRIPTION
Adds support for indented bullets in Next Steps. When the "sub-bullets" property exists under edd-next-steps or your-next-steps in claim-status.json, its array members will be displayed as sub-bullets. Line spacing / formatting will be added in a subsequent PR.

Example from Scenario 2:
![image](https://user-images.githubusercontent.com/82277/127663676-34e93240-fd74-46c5-9e8d-479dbc7985aa.png)

===

Resolves #342 

- [ ] Relevent Documentation (e.g. READMEs, Technical Foundation) updated
- [ ] Issue AC are copied to this PR & are met
- [ ] Changes are tested on Staging post-merge into `main`
