### PR TITLE
Add additional Spanish translation strings.

### DIFF
--- a/public/locales/es/claim-details.json
+++ b/public/locales/es/claim-details.json
@@ -3,8 +3,8 @@
     "ui": "Seguro de Desempleo (UI)",
     "dua": "Asistencia de Desempleo por Desastre (DUA)",
     "pua": "Asistencia de Desempleo por la Pandemia (PUA)",
-    "interstate": "Interstate Unemployment Insurance",
-    "nafta": "NAFTA Transitional Assistance"
+    "interstate": "Interestatal del Seguro de Desempleo",
+    "nafta": "Asistencia de transición del TLCAN"
   },
   "extension-type": {
     "euc": "Compensación de Desempleo de Emergencia (EUC) – Nivel 1",
@@ -13,8 +13,8 @@
     "euw": "Compensación de Desempleo de Emergencia (EUC) – Nivel 3",
     "euz": "Compensación de Desempleo de Emergencia (EUC) – Nivel 4",
     "fed-ed": "Duración de la Extensión Federal-Estatal de Beneficios (FED-ED)",
-    "cal-ed": "California Extended Duration (CAL-ED)",
-    "tra": "Extensión básica de la Asignación por Reajuste Comercial ",
+    "cal-ed": "Duración de la Extensión de California (CAL-ED)",
+    "tra": "Extensión básica de la Asignación por Reajuste Comercial",
     "tra-additional": "Extensión adicional de la Asistencia por Ajuste Ccomercial",
     "te": "Extensión de entrenamiento laboral (TE)"
   }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -12,8 +12,8 @@
   "change-locale": "In English",
   "claim-status": {
     "title": "Estatus de solicitud",
-    "your-next-steps": "Próximos pasos del usted",
-    "edd-next-steps": "Próximos pasos del EDD"
+    "your-next-steps": "Sus próximos pasos",
+    "edd-next-steps": "Próximos pasos de EDD"
   },
   "claim-details": {
     "title": "Detalles de la solicitud",


### PR DESCRIPTION
## Ticket

Resolves #346 

## Changes

- [x] All remaining Spanish translation strings have been added:
  - [x] "Your Next Steps" — `Sus próximos pasos`
  - [x] "EDD Next Steps" — `Próximos pasos de EDD`
  - [x] Confirm all "EU#" extension types — see [doc](https://docs.google.com/document/d/18ZIc1y8kq9AGxdNCVIyGKWMk5aanBz0p5SaPj2prGPc/edit#)
  - [x] "California Extended Duration (CAL-ED)" — `Duración de la Extensión de California (CAL-ED)`
  - [x] "Interstate Unemployment Insurance" — `Interestatal del Seguro de Desempleo`
  - [x] "NAFTA Transitional Assistance" —`Asistencia de transición del TLCAN`

## Testing

Follow the testing instructions in #345 and check each scenario (English & Spanish) and each program type (English & Spanish).