### PR TITLE
Fix pino-applicationinsights in storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const webpack = require('webpack')
 
 module.exports = {
   stories: ['../stories/**/*.stories.mdx', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -25,11 +26,15 @@ module.exports = {
     },
   ],
   webpackFinal: (config) => {
+    // applicationinsights is meant for node.js applications, storybook uses a browser environment.
+    // Use webpack's NormalModuleReplacementPlugin to mock the applicationinsights in storybook.
+    // See https://webpack.js.org/plugins/normal-module-replacement-plugin
+    config.plugins.push(new webpack.NormalModuleReplacementPlugin(/pino-applicationinsights/, 'node-noop'))
     return {
       ...config,
       node: {
         ...config.node,
-        fs: 'empty', //required to with with next-i18next
+        fs: 'empty', // required for next-i18next
       },
     }
   },

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "mockdate": "^3.0.5",
     "mocked-env": "^1.3.4",
     "next-i18next": "^8.1.2",
+    "node-noop": "^1.0.0",
     "pino-pretty": "^4.8.0",
     "prettier": "^2.2.1",
     "react-test-renderer": "^17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10549,6 +10549,11 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
+node-noop@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-noop/-/node-noop-1.0.0.tgz#47a3e7d80cffaa6458364bd22ed85cab3307be79"
+  integrity sha1-R6Pn2Az/qmRYNkvSLthcqzMHvnk=
+
 node-notifier@^8.0.0:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.2.tgz#f3167a38ef0d2c8a866a83e318c1ba0efeb702c5"


### PR DESCRIPTION
## Ticket

Resolves #299 

## Changes

- Mocks the `pino-applicationinsights` module in storybook
- Installs the [`node-noop`](https://github.com/euank/node-noop) package

## Context

When I added `pino-applicationinsights` to the repo to handle logging directly to Azure Application Insights, it broke Storybook builds (locally and on Chromatic). We were able to isolate that if we commented out the following lines, storybook builds would work successfully: https://github.com/cagov/ui-claim-tracker/blob/32990f892c6b84017c30af5d273fdd94410649e7/pages/index.tsx#L95-L98

The specific storybook build errors looked like this (for many many modules):

```sh
Module not found: Error: Can't resolve 'async_hooks' in '<snip>/ui-claim-tracker/node_modules/cls-hooked'
```

This is [apparently what the error looks like](https://github.com/elastic/apm-agent-nodejs/issues/1075#issuecomment-494587021) when "when trying to bundle Node.js code that uses non-browser-compatible code without explicitly telling webpack to allow it". An [extremely helpful](https://github.com/wallabyjs/public/issues/2525#issuecomment-700326595) comment in the wallabyjs github repo suggested using webpack's [NormalModuleReplacementPlugin](https://webpack.js.org/plugins/normal-module-replacement-plugin/) to replace the module with a mock. And the [wallaby docs](https://wallabyjs.com/docs/integration/webpack.html#normalmodulereplacement-plugin) suggested using the `node-noop` module:

```js
module.exports = function (wallaby) {
  var wallabyPostprocessor = wallabyWebpack({
    ...
      plugins: [
        new webpack.NormalModuleReplacementPlugin(/\.(gif|png|scss|css)$/, 'node-noop')
      ]
    ...
  });
};
```

## Testing

1. Checkout this branch
2. `yarn storybook`
3. Storybook should run with no errors