### PR TITLE
Hide fields in the Claim Details section if the field returns null

### DIFF
--- a/components/ClaimDetails.tsx
+++ b/components/ClaimDetails.tsx
@@ -17,6 +17,25 @@ export const ClaimDetails: React.FC<ClaimDetailsProps> = ({
 }) => {
   const { t } = useTranslation(['common', 'claim-details'])
 
+  let claimBalanceField: JSX.Element | null = null
+  if (claimBalance) {
+    claimBalanceField = <InfoField loading={loading} label={t('claim-details.claim-balance')} text={claimBalance} />
+  }
+
+  let weeklyBenefitAmountField: JSX.Element | null = null
+  if (weeklyBenefitAmount) {
+    weeklyBenefitAmountField = (
+      <InfoField loading={loading} label={t('claim-details.weekly-benefit-amount')} text={weeklyBenefitAmount} />
+    )
+  }
+
+  let lastPaymentIssuedField: JSX.Element | null = null
+  if (lastPaymentIssued) {
+    lastPaymentIssuedField = (
+      <InfoField loading={loading} label={t('claim-details.last-payment-issued')} text={lastPaymentIssued} />
+    )
+  }
+
   let extension: JSX.Element | null = null
   if (extensionType) {
     extension = (
@@ -38,11 +57,11 @@ export const ClaimDetails: React.FC<ClaimDetailsProps> = ({
 
             <InfoField loading={loading} label={t('claim-details.benefit-year')} text={benefitYear} />
 
-            <InfoField loading={loading} label={t('claim-details.claim-balance')} text={claimBalance} />
+            {claimBalanceField}
 
-            <InfoField loading={loading} label={t('claim-details.weekly-benefit-amount')} text={weeklyBenefitAmount} />
+            {weeklyBenefitAmountField}
 
-            <InfoField loading={loading} label={t('claim-details.last-payment-issued')} text={lastPaymentIssued} />
+            {lastPaymentIssuedField}
           </div>
           {extension}
         </div>

--- a/components/ClaimDetails.tsx
+++ b/components/ClaimDetails.tsx
@@ -36,9 +36,9 @@ export const ClaimDetails: React.FC<ClaimDetailsProps> = ({
     )
   }
 
-  let extension: JSX.Element | null = null
+  let extensionField: JSX.Element | null = null
   if (extensionType) {
-    extension = (
+    extensionField = (
       <div className="col-6">
         <div />
         <InfoField loading={loading} label={t('claim-details.extension-type')} text={t(extensionType)} />
@@ -63,7 +63,7 @@ export const ClaimDetails: React.FC<ClaimDetailsProps> = ({
 
             {lastPaymentIssuedField}
           </div>
-          {extension}
+          {extensionField}
         </div>
       </div>
     </div>

--- a/stories/ClaimDetails.stories.tsx
+++ b/stories/ClaimDetails.stories.tsx
@@ -49,6 +49,6 @@ ClaimDetails.args = {
   benefitYear: '3/21/2020 - 3/20/2021',
   claimBalance: '$508.00',
   weeklyBenefitAmount: '$120.00',
-  lastPaymentIssued: '4/29/2021',
+  lastPaymentIssued: '$120.00 on 4/29/21',
   extensionType: 'Tier 2 Extension',
 }

--- a/stories/ClaimDetails.stories.tsx
+++ b/stories/ClaimDetails.stories.tsx
@@ -7,6 +7,38 @@ export default {
   title: 'Component/Page Section/Claim Details',
   component: ClaimDetailsComponent,
   decorators: [withNextRouter],
+  argTypes: {
+    programType: {
+      control: {
+        type: 'text',
+      },
+    },
+    benefitYear: {
+      control: {
+        type: 'text',
+      },
+    },
+    claimBalance: {
+      control: {
+        type: 'text',
+      },
+    },
+    weeklyBenefitAmount: {
+      control: {
+        type: 'text',
+      },
+    },
+    lastPaymentIssued: {
+      control: {
+        type: 'text',
+      },
+    },
+    extensionType: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
 } as Meta
 
 const Template: Story<ClaimDetailsProps> = (args) => <ClaimDetailsComponent {...args} />

--- a/tests/components/ClaimDetails.test.tsx
+++ b/tests/components/ClaimDetails.test.tsx
@@ -1,8 +1,4 @@
-import renderer from 'react-test-renderer'
 import { render, screen } from '@testing-library/react'
-import getScenarioContent, { ScenarioType } from '../../utils/getScenarioContent'
-import apiGatewayStub from '../../utils/apiGatewayStub'
-import { ScenarioContent, ClaimDetailsContent } from '../../types/common'
 
 import { useRouter } from 'next/router'
 

--- a/tests/components/ClaimDetails.test.tsx
+++ b/tests/components/ClaimDetails.test.tsx
@@ -1,0 +1,105 @@
+import renderer from 'react-test-renderer'
+import { render, screen } from '@testing-library/react'
+import getScenarioContent, { ScenarioType } from '../../utils/getScenarioContent'
+import apiGatewayStub from '../../utils/apiGatewayStub'
+import { ScenarioContent, ClaimDetailsContent } from '../../types/common'
+
+import { useRouter } from 'next/router'
+
+import { ClaimDetails } from '../../components/ClaimDetails'
+
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: jest.fn(),
+}))
+
+describe('ClaimDetails with all nonnull fields', () => {
+  it('shows all the fields', () => {
+    const mockRouter = {
+      locale: 'en',
+    }
+    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+
+    render(
+      <ClaimDetails
+        loading={false}
+        programType="Test Program Type"
+        benefitYear="Test Benefit Year"
+        claimBalance="Test Claim Balance"
+        weeklyBenefitAmount="Test Weekly Benefit Amount"
+        lastPaymentIssued="Test Last Payment Issued"
+        extensionType="Test Extension Type"
+      />,
+    )
+
+    expect(screen.queryByText('Claim Details')).toBeInTheDocument()
+    expect(screen.queryByText('Program Type')).toBeInTheDocument()
+    expect(screen.queryByText('Benefit Year')).toBeInTheDocument()
+    expect(screen.queryByText('Claim Balance')).toBeInTheDocument()
+    expect(screen.queryByText('Weekly Benefit Amount')).toBeInTheDocument()
+    expect(screen.queryByText('Last Payment Issued')).toBeInTheDocument()
+  })
+})
+
+describe('ClaimDetails with nullable fields', () => {
+  it('Null Claim Balance hides the field', () => {
+    const mockRouter = {
+      locale: 'en',
+    }
+    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+
+    render(
+      <ClaimDetails
+        loading={false}
+        programType="Test Program Type"
+        benefitYear="Test Benefit Year"
+        claimBalance={null}
+        weeklyBenefitAmount="Test Weekly Benefit Amount"
+        lastPaymentIssued="Test Last Payment Issued"
+        extensionType="Test Extension Type"
+      />,
+    )
+
+    expect(screen.queryByText('Claim Balance')).not.toBeInTheDocument()
+  })
+  it('Null Weekly Benefit Amount hides the field', () => {
+    const mockRouter = {
+      locale: 'en',
+    }
+    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+
+    render(
+      <ClaimDetails
+        loading={false}
+        programType="Test Program Type"
+        benefitYear="Test Benefit Year"
+        claimBalance="Test Claim Balance"
+        weeklyBenefitAmount={null}
+        lastPaymentIssued="Test Last Payment Issued"
+        extensionType="Test Extension Type"
+      />,
+    )
+
+    expect(screen.queryByText('Weekly Benefit Amount')).not.toBeInTheDocument()
+  })
+  it('Null Last Payment Issued hides the field', () => {
+    const mockRouter = {
+      locale: 'en',
+    }
+    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+
+    render(
+      <ClaimDetails
+        loading={false}
+        programType="Test Program Type"
+        benefitYear="Test Benefit Year"
+        claimBalance="Test Claim Balance"
+        weeklyBenefitAmount="Test Weekly Benefit Amount"
+        lastPaymentIssued={null}
+        extensionType="Test Extension Type"
+      />,
+    )
+
+    expect(screen.queryByText('Last Payment Issued')).not.toBeInTheDocument()
+  })
+})

--- a/tests/utils/getClaimDetails.test.tsx
+++ b/tests/utils/getClaimDetails.test.tsx
@@ -68,4 +68,82 @@ describe('Constructing the Claim Details object', () => {
     const claimDetails = getClaimDetails(rawDetails)
     expect(claimDetails).toStrictEqual(expected)
   })
+
+  it('null values pass through properly', () => {
+    // Mock ClaimDetailsResults
+    const rawDetails = {
+      programType: 'UI',
+      benefitYearStartDate: '2021-05-21T00:00:00',
+      benefitYearEndDate: '2022-05-20T00:00:00',
+      claimBalance: null,
+      weeklyBenefitAmount: null,
+      lastPaymentIssued: null,
+      lastPaymentAmount: null,
+      monetaryStatus: 'active',
+    }
+
+    // Expected results
+    const expected = {
+      programType: 'claim-details:program-type.ui',
+      benefitYear: '5/21/2021–5/20/2022',
+      claimBalance: null,
+      weeklyBenefitAmount: null,
+      lastPaymentIssued: null,
+      extensionType: '',
+    }
+    const claimDetails = getClaimDetails(rawDetails)
+    expect(claimDetails).toStrictEqual(expected)
+  })
+
+  it('null lastPaymentIssued date makes the final lastPaymentIssued null', () => {
+    // Mock ClaimDetailsResults
+    const rawDetails = {
+      programType: 'UI',
+      benefitYearStartDate: '2021-05-21T00:00:00',
+      benefitYearEndDate: '2022-05-20T00:00:00',
+      claimBalance: 100,
+      weeklyBenefitAmount: 25,
+      lastPaymentIssued: null,
+      lastPaymentAmount: 10,
+      monetaryStatus: 'active',
+    }
+
+    // Expected results
+    const expected = {
+      programType: 'claim-details:program-type.ui',
+      benefitYear: '5/21/2021–5/20/2022',
+      claimBalance: '$100.00',
+      weeklyBenefitAmount: '$25.00',
+      lastPaymentIssued: null,
+      extensionType: '',
+    }
+    const claimDetails = getClaimDetails(rawDetails)
+    expect(claimDetails).toStrictEqual(expected)
+  })
+
+  it('null lastPaymentAmount makes the final lastPaymentIssued null', () => {
+    // Mock ClaimDetailsResults
+    const rawDetails = {
+      programType: 'UI',
+      benefitYearStartDate: '2021-05-21T00:00:00',
+      benefitYearEndDate: '2022-05-20T00:00:00',
+      claimBalance: 100,
+      weeklyBenefitAmount: 25,
+      lastPaymentIssued: '2021-03-12T00:00:00',
+      lastPaymentAmount: null,
+      monetaryStatus: 'active',
+    }
+
+    // Expected results
+    const expected = {
+      programType: 'claim-details:program-type.ui',
+      benefitYear: '5/21/2021–5/20/2022',
+      claimBalance: '$100.00',
+      weeklyBenefitAmount: '$25.00',
+      lastPaymentIssued: null,
+      extensionType: '',
+    }
+    const claimDetails = getClaimDetails(rawDetails)
+    expect(claimDetails).toStrictEqual(expected)
+  })
 })

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -74,9 +74,9 @@ export interface ClaimStatusContent {
 export interface ClaimDetailsContent {
   programType: string
   benefitYear: string
-  claimBalance: string
-  weeklyBenefitAmount: string
-  lastPaymentIssued: string
+  claimBalance: string | null
+  weeklyBenefitAmount: string | null
+  lastPaymentIssued: string | null
   extensionType: string
 }
 

--- a/types/common.tsx
+++ b/types/common.tsx
@@ -44,7 +44,6 @@ export interface Claim {
   claimDetails?: null | ClaimDetailsResult
   hasPendingWeeks?: null | undefined | boolean
   hasCertificationWeeksAvailable?: null | undefined | boolean
-  hasClaimDetails?: null | undefined | boolean
   pendingDetermination?: null | PendingDetermination[]
 }
 

--- a/utils/getClaimDetails.tsx
+++ b/utils/getClaimDetails.tsx
@@ -137,14 +137,22 @@ export function formatCurrency(amount: number): string {
 export default function getClaimDetails(rawDetails: ClaimDetailsResult): ClaimDetailsContent {
   // Get programType and extensionType.
   const pair: programExtensionPairType = getProgramExtensionPair(rawDetails.programType)
+
+  // construct our fields
   const benefitYear = buildBenefitYear(rawDetails.benefitYearStartDate, rawDetails.benefitYearEndDate)
+  const claimBalance = rawDetails.claimBalance ? formatCurrency(rawDetails.claimBalance) : null
+  const weeklyBenefitAmount = rawDetails.weeklyBenefitAmount ? formatCurrency(rawDetails.weeklyBenefitAmount) : null
+  const lastPaymentIssued =
+    rawDetails.lastPaymentAmount && rawDetails.lastPaymentIssued
+      ? `${formatCurrency(rawDetails.lastPaymentAmount)} on ${formatDate(rawDetails.lastPaymentIssued)}`
+      : null
 
   return {
     programType: pair.programType,
     benefitYear: benefitYear,
-    claimBalance: formatCurrency(rawDetails.claimBalance),
-    weeklyBenefitAmount: formatCurrency(rawDetails.weeklyBenefitAmount),
-    lastPaymentIssued: `${formatCurrency(rawDetails.lastPaymentAmount)} on ${formatDate(rawDetails.lastPaymentIssued)}`,
+    claimBalance: claimBalance,
+    weeklyBenefitAmount: weeklyBenefitAmount,
+    lastPaymentIssued: lastPaymentIssued,
     extensionType: pair.extensionType,
   }
 }


### PR DESCRIPTION
<!-- Write a description below of the changes in this pull request. 

Include images/GIFs if relevant for reviewers. Try Firefox (right-click -> Take Screenshot) for full-page screenshots and LICEcap (macOS) or Peek (ubuntu) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items. -->

  - Makes the three fields indicated in #365 safely nullable
  - Hides the entire field when their value is null
  - Basic tests for the API parsing and the Component display
  - Storybook tweaks
  - Removes an extraneous type change (see https://github.com/cagov/ui-claim-tracker/pull/371#discussion_r687879970)

Testing:
 - Load storybook and look at the ClaimDetails component - delete the string and observe that the field disappears
 - `yarn test`

===

Resolves #365

- [x] If `Claim Balance`, `Weekly Benefit Amount`, `Payment Issued`, `Last Payment Amount` in the claimDetails object returns null, the corresponding display field in the Claim Details section is hidden
- [ ] Changes are tested on Staging post-merge into `main`
