### PR TITLE
Scenario 1: Handle invalid schedule date and invalid request date

### DIFF
--- a/tests/utils/formatDate.test.ts
+++ b/tests/utils/formatDate.test.ts
@@ -1,7 +1,7 @@
 import MockDate from 'mockdate'
 import { toDate } from 'date-fns-tz'
 
-import formatDate, { formatAppointmentDate, isDatePast, isValidDate } from '../../utils/formatDate'
+import formatDate, { formatAppointmentDate, isDatePast, isNullDateString, isValidDate } from '../../utils/formatDate'
 
 // Test isValidDate()
 describe('Valid dates: A date is', () => {
@@ -10,11 +10,23 @@ describe('Valid dates: A date is', () => {
   })
 
   it('invalid if it is earlier than the minimum date', () => {
-    expect(isValidDate('0001-01-01T00:00:00')).toBe(false)
+    expect(isValidDate('1831-01-01T00:00:00')).toBe(false)
   })
 
   it('valid if it is later than the minimum date', () => {
     expect(isValidDate('2013-01-01T00:00:00')).toBe(true)
+  })
+})
+
+// Test isNullDateString()
+describe('Null dates: A date is', () => {
+  it('null if it is Jan 1, 0001', () => {
+    expect(isNullDateString('0001-01-01T00:00:00')).toBe(true)
+  })
+
+  it('not null if it is any string', () => {
+    expect(isNullDateString('2001-01-01T00:00:00')).toBe(false)
+    expect(isNullDateString('something else')).toBe(false)
   })
 })
 

--- a/tests/utils/formatDate.test.ts
+++ b/tests/utils/formatDate.test.ts
@@ -1,7 +1,7 @@
 import MockDate from 'mockdate'
 import { toDate } from 'date-fns-tz'
 
-import formatDate, { formatAppointmentDate, isDatePast, isNullDateString, isValidDate } from '../../utils/formatDate'
+import formatDate, { formatAppointmentDate, isDatePast, isDateStringFalsy, isValidDate } from '../../utils/formatDate'
 
 // Test isValidDate()
 describe('Valid dates: A date is', () => {
@@ -18,15 +18,30 @@ describe('Valid dates: A date is', () => {
   })
 })
 
-// Test isNullDateString()
-describe('Null dates: A date is', () => {
-  it('null if it is Jan 1, 0001', () => {
-    expect(isNullDateString('0001-01-01T00:00:00')).toBe(true)
+// Test isDateStringFalsy()
+describe('Falsy date strings: A date string is', () => {
+  it('falsy if it is Jan 1, 0001', () => {
+    expect(isDateStringFalsy('0001-01-01T00:00:00')).toBe(true)
   })
 
-  it('not null if it is any string', () => {
-    expect(isNullDateString('2001-01-01T00:00:00')).toBe(false)
-    expect(isNullDateString('something else')).toBe(false)
+  it('falsy if it is null', () => {
+    expect(isDateStringFalsy(null)).toBe(true)
+  })
+
+  it('falsy if it is an empty string', () => {
+    expect(isDateStringFalsy('')).toBe(true)
+  })
+
+  it('falsy if it is undefined', () => {
+    expect(isDateStringFalsy(undefined)).toBe(true)
+  })
+
+  it('not falsy if it is any valid date', () => {
+    expect(isDateStringFalsy('2001-01-01T00:00:00')).toBe(false)
+  })
+
+  it('not falsy if it is any valid string', () => {
+    expect(isDateStringFalsy('something else')).toBe(false)
   })
 })
 

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -3,6 +3,7 @@ import MockDate from 'mockdate'
 import { getMockPendingDetermination, getPendingDeterminationWithScheduleDate } from '../testHelpers'
 import { PendingDetermination } from '../../types/common'
 import apiGatewayStub from '../../utils/apiGatewayStub'
+import { formatFromApiGateway } from '../../utils/formatDate'
 import {
   getScenario,
   identifyPendingDeterminationScenario,
@@ -74,7 +75,7 @@ describe('The determination interview is not yet scheduled (scenario 1) when all
     const pendingDetermination = getMockPendingDetermination()
     pendingDetermination.determinationStatus = null
     pendingDetermination.scheduleDate = null
-    pendingDetermination.requestDate = 'any non-null value'
+    pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
     expect(result.scenarioType).toBe(ScenarioType.Scenario1)
   })
@@ -83,7 +84,7 @@ describe('The determination interview is not yet scheduled (scenario 1) when all
     const pendingDetermination = getMockPendingDetermination()
     pendingDetermination.determinationStatus = ''
     pendingDetermination.scheduleDate = null
-    pendingDetermination.requestDate = 'any non-null value'
+    pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
     expect(result.scenarioType).toBe(ScenarioType.Scenario1)
   })
@@ -92,37 +93,46 @@ describe('The determination interview is not yet scheduled (scenario 1) when all
     const pendingDetermination = getMockPendingDetermination()
     pendingDetermination.determinationStatus = undefined
     pendingDetermination.scheduleDate = null
-    pendingDetermination.requestDate = 'any non-null value'
+    pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
     expect(result.scenarioType).toBe(ScenarioType.Scenario1)
   })
 })
 
 // Scenario 1: Test various values of pendingDetermination.scheduleDate
-describe('The determination interview is not yet scheduled (scenario 1) when all other criteria are met and the schedule date evaluates to', () => {
-  it('false (null)', () => {
+describe('The determination interview is not yet scheduled (scenario 1) when all other criteria are met and the schedule date', () => {
+  it('evaluates to false (null)', () => {
     const pendingDetermination = getMockPendingDetermination()
     pendingDetermination.determinationStatus = null
     pendingDetermination.scheduleDate = null
-    pendingDetermination.requestDate = 'any non-null value'
+    pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
     expect(result.scenarioType).toBe(ScenarioType.Scenario1)
   })
 
-  it('false (empty string)', () => {
+  it('evaluates to false (empty string)', () => {
     const pendingDetermination = getMockPendingDetermination()
     pendingDetermination.determinationStatus = null
     pendingDetermination.scheduleDate = ''
-    pendingDetermination.requestDate = 'any non-null value'
+    pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
     expect(result.scenarioType).toBe(ScenarioType.Scenario1)
   })
 
-  it('false (undefined)', () => {
+  it('evaluates to false (undefined)', () => {
     const pendingDetermination = getMockPendingDetermination()
     pendingDetermination.determinationStatus = null
     pendingDetermination.scheduleDate = undefined
-    pendingDetermination.requestDate = 'any non-null value'
+    pendingDetermination.requestDate = formatFromApiGateway(-30)
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+  })
+
+  it('is 0001-01-01T00:00:00', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    pendingDetermination.determinationStatus = null
+    pendingDetermination.scheduleDate = '0001-01-01T00:00:00'
+    pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
     expect(result.scenarioType).toBe(ScenarioType.Scenario1)
   })
@@ -134,7 +144,7 @@ describe('The determination interview is invalid if all other Scenario 1 critera
     const pendingDetermination = getMockPendingDetermination()
     pendingDetermination.determinationStatus = 'non-null value'
     pendingDetermination.scheduleDate = ''
-    pendingDetermination.requestDate = 'any non-null value'
+    pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
     expect(result).toBe(null)
   })
@@ -144,7 +154,7 @@ describe('The determination interview is invalid if all other Scenario 1 critera
     // Determination Status is one of NonPendingDeterminationValues values
     pendingDetermination.determinationStatus = 'Complete'
     pendingDetermination.scheduleDate = '2000-01-01T00:00:00'
-    pendingDetermination.requestDate = 'any non-null value'
+    pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
     expect(result).toBe(null)
   })
@@ -153,7 +163,7 @@ describe('The determination interview is invalid if all other Scenario 1 critera
     const pendingDetermination = getMockPendingDetermination()
     pendingDetermination.determinationStatus = ''
     pendingDetermination.scheduleDate = 'non-null value'
-    pendingDetermination.requestDate = 'any non-null value'
+    pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
     expect(result).toBe(null)
   })
@@ -163,6 +173,15 @@ describe('The determination interview is invalid if all other Scenario 1 critera
     pendingDetermination.determinationStatus = ''
     pendingDetermination.scheduleDate = ''
     pendingDetermination.requestDate = ''
+    const result = identifyPendingDeterminationScenario([pendingDetermination])
+    expect(result).toBe(null)
+  })
+
+  it('the request date is an invalid date', () => {
+    const pendingDetermination = getMockPendingDetermination()
+    pendingDetermination.determinationStatus = ''
+    pendingDetermination.scheduleDate = ''
+    pendingDetermination.requestDate = '0001-01-01T00:00:00'
     const result = identifyPendingDeterminationScenario([pendingDetermination])
     expect(result).toBe(null)
   })
@@ -203,12 +222,12 @@ describe('When there are multiple pendingDetermination objects, the determinatio
     const appt1 = getMockPendingDetermination()
     appt1.pendingDetermination = ''
     appt1.scheduleDate = ''
-    appt1.requestDate = 'not empty'
+    appt1.requestDate = formatFromApiGateway(-30)
 
     const appt2 = getMockPendingDetermination()
     appt2.pendingDetermination = ''
     appt2.scheduleDate = ''
-    appt2.requestDate = 'not empty'
+    appt2.requestDate = formatFromApiGateway(-30)
 
     const result = identifyPendingDeterminationScenario([appt1, appt2])
     expect(result.scenarioType).toBe(ScenarioType.Scenario1)

--- a/tests/utils/getScenarioContent.test.tsx
+++ b/tests/utils/getScenarioContent.test.tsx
@@ -159,10 +159,10 @@ describe('The determination interview is invalid if all other Scenario 1 critera
     expect(result).toBe(null)
   })
 
-  it('the schedule date is an invalid datetime string', () => {
+  it('the schedule date is a non-empty string', () => {
     const pendingDetermination = getMockPendingDetermination()
     pendingDetermination.determinationStatus = ''
-    pendingDetermination.scheduleDate = 'non-null value'
+    pendingDetermination.scheduleDate = 'non-empty string'
     pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
     expect(result).toBe(null)

--- a/utils/apiGatewayStub.tsx
+++ b/utils/apiGatewayStub.tsx
@@ -46,7 +46,7 @@ export default function apiGatewayStub(
     case ScenarioType.Scenario1:
       pendingDetermination.determinationStatus = ''
       pendingDetermination.scheduleDate = ''
-      pendingDetermination.requestDate = 'not empty'
+      pendingDetermination.requestDate = formatFromApiGateway(-30)
       claim.pendingDetermination = [pendingDetermination]
       claim.hasCertificationWeeksAvailable = hasCertificationWeeksAvailable
       break

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -91,6 +91,13 @@ export function isValidDate(dateString: ApiGatewayDateString): boolean {
   }
 }
 
+/**
+ * Returns true if the dateString is Jan 1, year 1.
+ */
+export function isNullDateString(dateString: ApiGatewayDateString): boolean {
+  return dateString === '0001-01-01T00:00:00'
+}
+
 // @TODO: add a function to check and log any dates that are earlier
 // than 2020 as these are anomolous dates that could indicate an error.
 

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -94,7 +94,7 @@ export function isValidDate(dateString: ApiGatewayDateString): boolean {
 /**
  * Returns true if the dateString is falsy.
  *
- * We are defining falsy here to mean: null, empty string, undefined, or 0001-01-01T00:00:00.
+ * We are defining falsy here to mean: standard JS falsy (null, empty string, undefined, etc) or 0001-01-01T00:00:00.
  */
 export function isDateStringFalsy(dateString: ApiGatewayDateString): boolean {
   return !dateString || dateString === '0001-01-01T00:00:00'

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -92,10 +92,12 @@ export function isValidDate(dateString: ApiGatewayDateString): boolean {
 }
 
 /**
- * Returns true if the dateString is Jan 1, year 1.
+ * Returns true if the dateString is falsy.
+ *
+ * We are defining falsy here to mean: null, empty string, undefined, or 0001-01-01T00:00:00.
  */
-export function isNullDateString(dateString: ApiGatewayDateString): boolean {
-  return dateString === '0001-01-01T00:00:00'
+export function isDateStringFalsy(dateString: ApiGatewayDateString): boolean {
+  return !dateString || dateString === '0001-01-01T00:00:00'
 }
 
 // @TODO: add a function to check and log any dates that are earlier

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -10,7 +10,7 @@
 import { Claim, ClaimDetailsContent, PendingDetermination, ScenarioContent } from '../types/common'
 import getClaimDetails from './getClaimDetails'
 import getClaimStatus from './getClaimStatus'
-import { isDatePast, isNullDateString, isValidDate, parseApiGatewayDate } from './formatDate'
+import { isDatePast, isDateStringFalsy, isValidDate, parseApiGatewayDate } from './formatDate'
 import { isFirstTimeSlotEarlier } from './timeSlot'
 
 export enum ScenarioType {
@@ -117,13 +117,13 @@ export function identifyPendingDeterminationScenario(
       }
     }
     // Scenario 1:
-    // If determinationStatus is empty/null/undefined/unset
-    // AND scheduleDate has no value
-    // AND requestDate has a value
+    // If determinationStatus is empty/null/undefined
+    // AND scheduleDate is empty/null/undefined or null date string
+    // AND requestDate is a valid date
     else if (
       !pendingDetermination.determinationStatus &&
-      isValidDate(pendingDetermination.requestDate) &&
-      (!pendingDetermination.scheduleDate || isNullDateString(pendingDetermination.scheduleDate))
+      isDateStringFalsy(pendingDetermination.scheduleDate) &&
+      isValidDate(pendingDetermination.requestDate)
     ) {
       hasNotYetScheduled = true
     }

--- a/utils/getScenarioContent.tsx
+++ b/utils/getScenarioContent.tsx
@@ -10,7 +10,7 @@
 import { Claim, ClaimDetailsContent, PendingDetermination, ScenarioContent } from '../types/common'
 import getClaimDetails from './getClaimDetails'
 import getClaimStatus from './getClaimStatus'
-import { isDatePast, isValidDate, parseApiGatewayDate } from './formatDate'
+import { isDatePast, isNullDateString, isValidDate, parseApiGatewayDate } from './formatDate'
 import { isFirstTimeSlotEarlier } from './timeSlot'
 
 export enum ScenarioType {
@@ -122,8 +122,8 @@ export function identifyPendingDeterminationScenario(
     // AND requestDate has a value
     else if (
       !pendingDetermination.determinationStatus &&
-      !pendingDetermination.scheduleDate &&
-      pendingDetermination.requestDate
+      isValidDate(pendingDetermination.requestDate) &&
+      (!pendingDetermination.scheduleDate || isNullDateString(pendingDetermination.scheduleDate))
     ) {
       hasNotYetScheduled = true
     }


### PR DESCRIPTION
## Ticket

Resolves #370 

## Changes

- Add a function `isDateStringFalsy()` to check if a dateString evaluates to JS falsy or equals `0001-01-01T00:00:00`
- Require `pendingDetermination.requestDate` to be a valid date
- Update Scenario 1 to use `isDateStringFalsy()` to validate `pendingDetermination.scheduleDate`

## Context

This PR adds two additional validations for the way we handle dates in Scenario 1:
1. `requestDate` must be a valid date
2. `scheduleDate` must either evaluate to false (null, empty, undefined) or equal `0001-01-01T00:00:00`

## Testing

`yarn test`