### PR TITLE
Make the language switcher tab navigable

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -12,11 +12,14 @@ export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ userArrivedF
   const router = useRouter()
 
   const queryString = userArrivedFromUioMobile ? { from: 'uiom' } : {}
+  // The Next Link will add the href value to the final <a> tag
+  /* eslint-disable jsx-a11y/anchor-is-valid */
   return (
     <div className="language-switcher">
       <Link href={{ pathname: '/', query: queryString }} locale={router.locale === 'en' ? 'es' : 'en'}>
-        <span className="text">{t('change-locale')}</span>
+        <a className="text">{t('change-locale')}</a>
       </Link>
     </div>
   )
+  /* eslint-enable jsx-a11y/anchor-is-valid */
 }

--- a/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/tests/pages/__snapshots__/index.test.tsx.snap
@@ -155,13 +155,14 @@ exports[`Full page snapshot renders homepage unchanged 1`] = `
       <div
         className="language-switcher"
       >
-        <span
+        <a
           className="text"
+          href="/"
           onClick={[Function]}
           onMouseEnter={[Function]}
         >
           En español
-        </span>
+        </a>
       </div>
       <div
         className="claim-section"


### PR DESCRIPTION
<!-- Write a description below of the changes in this pull request. 

Include images/GIFs if relevant for reviewers. Try Firefox (right-click -> Take Screenshot) for full-page screenshots and LICEcap (macOS) or Peek (ubuntu) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items. -->

Updates the Language switcher to be a proper `<a>` tag, so that tabbing will properly cycle through it.

Test by running locally and tabbing through!

===

Resolves #389 

- [ ] Language Switcher reachable via tab
- [ ] Changes are tested on Staging post-merge into `main`
