### PR TITLE
Adds luxon DateTimes & uses them inside critical functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "chromatic": "npx chromatic --project-token $CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
-    "@types/pino": "^6.3.8",
     "bootstrap": "^4.6.0",
     "date-fns": "^2.22.1",
     "date-fns-tz": "^1.1.4",
+    "luxon": "^2.0.2",
     "next": "^11.1.0",
     "pino": "^6.11.3",
     "react": "^17.0.2",
@@ -53,8 +53,10 @@
     "@testing-library/dom": "^7.30.0",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
+    "@types/luxon": "^2.0.0",
     "@types/node": "^14.14.33",
     "@types/pem": "^1.9.5",
+    "@types/pino": "^6.3.8",
     "@types/react": "^17.0.3",
     "@types/react-test-renderer": "^17.0.1",
     "@typescript-eslint/eslint-plugin": "^4.19.0",

--- a/tests/utils/formatDate.test.ts
+++ b/tests/utils/formatDate.test.ts
@@ -1,7 +1,14 @@
 import MockDate from 'mockdate'
 import { toDate } from 'date-fns-tz'
+import { DateTime, Settings } from 'luxon'
 
-import formatDate, { formatAppointmentDate, isDatePast, isDateStringFalsy, isValidDate } from '../../utils/formatDate'
+import formatDate, {
+  formatAppointmentDate,
+  formatFromApiGateway,
+  isDatePast,
+  isDateStringFalsy,
+  isValidDate,
+} from '../../utils/formatDate'
 
 // Test isValidDate()
 describe('Valid dates: A date is', () => {
@@ -86,5 +93,30 @@ describe('Formatting dates', () => {
     const notFormatted = '2013-09-27T00:00:00'
     const formatted = formatDate(notFormatted)
     expect(formatted).toEqual('9/27/2013')
+  })
+})
+
+// Test formatFromApiGateway()
+describe('Requesting a date adjusted from existing in the correct format', () => {
+  it('has our time set to PT!', () => {
+    expect(DateTime.local().zoneName).toEqual('America/Los_Angeles')
+  })
+
+  it('displays the expected date string', () => {
+    const baseDate = DateTime.fromISO('2021-09-10T02:00:00')
+    const adjustment = -1
+    const newDate = formatFromApiGateway(adjustment, baseDate)
+
+    expect(newDate).toEqual('2021-09-09T00:00:00')
+  })
+
+  it('handles PT edge cases', () => {
+    // Tricky time - 10pm PT means its always* the next day ET & UTC
+    // *like, casually true but don't hold me to this time is hard okay?
+    const baseDate = DateTime.fromISO('2021-09-01T22:00:00')
+    const adjustment = 3
+    const newDate = formatFromApiGateway(adjustment, baseDate)
+
+    expect(newDate).toEqual('2021-09-04T00:00:00')
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3154,6 +3154,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/luxon@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-2.0.0.tgz#3dd1d8c51b49e34585c5158ba3393e95c51fee89"
+  integrity sha512-L7iL3FitRSeuz8fbeLtql7qU6inHVtwEDWI1+vBXgyp0J2tmxOD7TgMBiEQjII/Y/TPcwrKasXb1BPuiCXRgxg==
+
 "@types/markdown-to-jsx@^6.11.3":
   version "6.11.3"
   resolved "https://registry.yarnpkg.com/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.3.tgz#cdd1619308fecbc8be7e6a26f3751260249b020e"
@@ -9897,6 +9902,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+luxon@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.0.2.tgz#11f2cd4a11655fdf92e076b5782d7ede5bcdd133"
+  integrity sha512-ZRioYLCgRHrtTORaZX1mx+jtxKtKuI5ZDvHNAmqpUzGqSrR+tL4FVLn/CUGMA3h0+AKD1MAxGI5GnCqR5txNqg==
 
 lz-string@^1.4.4:
   version "1.4.4"


### PR DESCRIPTION
<!-- Write a description below of the changes in this pull request. 

Include images/GIFs if relevant for reviewers. Try Firefox (right-click -> Take Screenshot) for full-page screenshots and LICEcap (macOS) or Peek (ubuntu) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items. -->

PR 1 of 2

This is the minimal changes to actually solve #385, while leaving the rest of the date functionality unchanged.

 - Adds luxon DateTime
 - Sets our Luxon TZ to 'America/Los_Angeles'
 - Teaches `formatFromApiGateway` to act properly around midnight
 - Teaches `isDatePast` to act properly around midnight

However this is a _bad idea_ to do halfway! now we have two time-handling processes! That handle time zones differently! AHHH

So see the next PR in the stack for the full refactor. I just want to hold this distinct for reviewing.

Testing:
  - [ ] All scenarios still load properly - but especially 2 & 3
  - [ ] Tests pass, with no snapshot changes

===

Resolves #385

- [x] Scenario 2 should be returned for appointments that are "today" until 11:59pm PT. Scenario 3 should not be displayed until it is 12:00am PT the next calendar day
- [ ] Changes are tested on Staging post-merge into `main`
