### PR TITLE
Support more environment-specific links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ relates to weekly certification
 - CERTIFICATE_DIR: The path to the client certificate (certificate must be in PFX/P12 format)
 - PFX_FILE: The name of the client certificate file
 - (Optional) PFX_PASSPHRASE: The import passphrase for the client certificate if there is one
-- (Optional) URL_UIO_LANDING, URL_UIOMOBILE_LANDING: The environment-specific links to the UIO and UIO Mobile landing pages
+- (Optional) URL_PREFIX_UIO, URL_PREFIX_UIO_MOBILE, URL_PREFIX_BPO: Environment-specific path prefixes for UIO and BPO links
 
 For local development:
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -14,7 +14,7 @@ export const Header: React.FC<HeaderProps> = ({ userArrivedFromUioMobile = false
   // Return a link back to:
   //   UIO Mobile landing page if user arrived from UIO Mobile
   //   main UIO landing page if user arrived from main UIO
-  const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-home-url-mobile') : getUrl('uio-home-url-desktop')
+  const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-mobile-home-url') : getUrl('uio-home-url')
 
   return (
     <header className="header border-bottom border-secondary">
@@ -34,10 +34,10 @@ export const Header: React.FC<HeaderProps> = ({ userArrivedFromUioMobile = false
                 <span className="text">{t('header.edd-home')}</span>
               </Nav.Link>
             </Navbar.Collapse>
-            <Nav.Link target="_blank" rel="noopener noreferrer" href={getUrl('edd-help-new-claim')}>
+            <Nav.Link target="_blank" rel="noopener noreferrer" href={getUrl('uio-help-new-claim')}>
               <span className="text">{t('header.help')}</span>
             </Nav.Link>
-            <Nav.Link href={getUrl('edd-log-out')}>
+            <Nav.Link href={getUrl('bpo-log-out')}>
               <span className="text">{t('header.logout')}</span>
             </Nav.Link>
           </Nav>
@@ -57,7 +57,7 @@ export const Header: React.FC<HeaderProps> = ({ userArrivedFromUioMobile = false
           <Navbar.Toggle aria-controls="basic-navbar-nav" />
           <Navbar.Collapse>
             <Nav>
-              <Nav.Link target="_blank" rel="noopener noreferrer" href={uioHomeLink}>
+              <Nav.Link rel="noopener noreferrer" href={uioHomeLink}>
                 <span className="text">{t('header.uio-home')}</span>
               </Nav.Link>
             </Nav>

--- a/components/TimeoutModal.tsx
+++ b/components/TimeoutModal.tsx
@@ -55,7 +55,12 @@ export const TimeoutModal: React.FC<TimeoutModalProps> = ({ timedOut, userArrive
     // And at the end, send back to EDD
     setTimeout(() => {
       if (typeof window !== 'undefined') {
-        const eddLoginLink = getUrl('edd-log-in')?.concat(encodeURIComponent(window.location.toString()))
+        // Note that the concatenated portion of this link is functionally useless, as IDM is not currently
+        // able to redirect based on the resource_url parameter concatenated.
+        const eddLoginLink = getUrl('bpo-log-in')?.concat(
+          '?resource_url=',
+          encodeURIComponent(window.location.toString()),
+        )
         window.location.href = eddLoginLink || ''
       }
     }, REDIRECT_TIMER * ONE_MINUTE_MS)
@@ -71,7 +76,7 @@ export const TimeoutModal: React.FC<TimeoutModalProps> = ({ timedOut, userArrive
   }
 
   function redirectToUIHome() {
-    const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-home-url-mobile') : getUrl('uio-home-url-desktop')
+    const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-mobile-home-url') : getUrl('uio-home-url')
     window.location.href = uioHomeLink || ''
   }
 

--- a/components/TransLine.tsx
+++ b/components/TransLine.tsx
@@ -15,7 +15,7 @@ export interface TransLineProps extends TransLineContent {
 function resolveUrl(link: I18nString, userArrivedFromUioMobile: boolean) {
   // Special case for UIO homepage links.
   if (link === 'uio-home') {
-    const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-home-url-mobile') : getUrl('uio-home-url-desktop')
+    const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-mobile-home-url') : getUrl('uio-home-url')
     if (uioHomeLink) {
       // If the link is for UIO homepage, do a direct getUrl() lookup.
       // Do not pass the looked up url through t() because t() will mangle the url.

--- a/public/urls.json
+++ b/public/urls.json
@@ -5,9 +5,9 @@
   "edd-about-contact": "https://www.edd.ca.gov/About_EDD/Contact_EDD.htm",
   "edd-about-privacy-policy": "https://www.edd.ca.gov/About_EDD/Privacy_Policy.htm",
   "edd-ca-gov": "https://edd.ca.gov",
-  "edd-help-new-claim": "https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=en-US/Public/NewClaim/UIOnlineNewClaimLandingPage.htm",
-  "edd-log-in": "https://portal.edd.ca.gov/WebApp/Login?resource_url=",
-  "edd-log-out": "https://portal.edd.ca.gov/WebApp/Logout",
-  "uio-home-url-desktop": "https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx",
-  "uio-home-url-mobile": "https://uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
+  "bpo-log-in": "https://portal.edd.ca.gov/WebApp/Login",
+  "bpo-log-out": "https://portal.edd.ca.gov/WebApp/Logout",
+  "uio-help-new-claim": "https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=en-US/Public/NewClaim/UIOnlineNewClaimLandingPage.htm",
+  "uio-home-url": "https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx",
+  "uio-mobile-home-url": "https://uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
 }

--- a/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/tests/pages/__snapshots__/index.test.tsx.snap
@@ -128,7 +128,6 @@ exports[`Full page snapshot renders homepage unchanged 1`] = `
               onClick={[Function]}
               onKeyDown={[Function]}
               rel="noopener noreferrer"
-              target="_blank"
             >
               <span
                 className="text"

--- a/utils/getUrl.ts
+++ b/utils/getUrl.ts
@@ -11,12 +11,22 @@ export type UrlType = keyof typeof urls
  * Get url from urls.json
  */
 export default function getUrl(linkKey: string): string | undefined {
-  // Optional environment-specific links back to the UIO landing page, used by EDD testing
-  if (linkKey === 'uio-home-url-desktop' && process.env.URL_UIO_LANDING) return process.env.URL_UIO_LANDING
-  if (linkKey === 'uio-home-url-mobile' && process.env.URL_UIOMOBILE_LANDING) return process.env.URL_UIOMOBILE_LANDING
-
   // Explicitly cast to one of the allowed keys in urls.json.
   // If the key does not exist in urls.json, this function will return undefined.
   const key = linkKey as UrlType
+
+  // Optional environment-specific links back to the UIO landing page, used by EDD testing
+  if (key.startsWith('uio') && process.env.URL_PREFIX_UIO) {
+    return urls[key].replace('uio.edd.ca.gov/UIO', process.env.URL_PREFIX_UIO)
+  }
+
+  if (key.startsWith('uio-mobile') && process.env.URL_PREFIX_UIO_MOBILE) {
+    return urls[key].replace('uiom.edd.ca.gov/UIOM', process.env.URL_PREFIX_UIO_MOBILE)
+  }
+
+  if (key.startsWith('bpo') && process.env.URL_PREFIX_BPO) {
+    return urls[key].replace('portal.edd.ca.gov', process.env.URL_PREFIX_BPO)
+  }
+
   return urls[key]
 }


### PR DESCRIPTION
This PR:

1) makes the UI Home link open in the same window instead of a new tab,
2) makes the new claim link environment specific, and
3) at the end of 30 minutes, redirects to the env specific login link

===

Resolves #XXX

- [ ] Relevant documentation (e.g. READMEs, Technical Foundation) updated
- [ ] Issue AC are copied to this PR & are met
- [ ] Changes are tested on Staging post-merge into `main`
