### PR TITLE
Refactor logging into a shared utility

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,12 +1,12 @@
 const { i18n } = require('./next-i18next.config')
 
-const isProd = process.env.NODE_ENV === 'production'
+const isAzureEnv = process.env.NODE_ENV === 'production'
 
 module.exports = {
   // The Claim Tracker application must live at /claimstatus because IDM Webgate
   // expects the "context root" to be /claimstatus, and all other pages must be sub-paths.
   basePath: '/claimstatus',
-  assetPrefix: isProd ? '/claimstatus' : '',
+  assetPrefix: isAzureEnv ? '/claimstatus' : '',
   i18n,
   webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
     config.resolve.fallback = {

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "chromatic": "npx chromatic --project-token $CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
-    "@types/pino": "^6.3.8",
     "applicationinsights": "^2.1.5",
     "bootstrap": "^4.6.0",
     "date-fns": "^2.22.1",
     "date-fns-tz": "^1.1.4",
     "next": "^11.1.0",
     "pino": "^6.11.3",
+    "pino-applicationinsights": "^2.1.0",
     "react": "^17.0.2",
     "react-bootstrap": "^1.5.2",
     "react-dom": "^17.0.2"
@@ -56,6 +56,8 @@
     "@testing-library/react": "^11.2.5",
     "@types/node": "^14.14.33",
     "@types/pem": "^1.9.5",
+    "@types/pino": "^6.3.11",
+    "@types/pumpify": "^1.4.1",
     "@types/react": "^17.0.3",
     "@types/react-test-renderer": "^17.0.1",
     "@typescript-eslint/eslint-plugin": "^4.19.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { GetServerSideProps } from 'next'
 import Error from 'next/error'
 import pino from 'pino'
+import { req as reqSerializer } from 'pino-std-serializers'
 
 import { Header } from '../components/Header'
 import { Title } from '../components/Title'
@@ -110,8 +111,16 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale, quer
 
   // Proceed only if pino has been configured and there have been no errors up to this point.
   if (pino) {
-    pino.info(req, 'Request')
-    pino.info(query, 'Query')
+    pino.info(
+      {
+        // If you call pino.info(req), pino does some behind the scenes serialization.
+        // If you put the req into an object, it doesn't automatically do the serialization,
+        // so we explicitly call it here.
+        request: reqSerializer(req),
+        query: query,
+      },
+      'Request',
+    )
 
     // If there is no unique number in the header, AND it is the Front Door health probe,
     // then display a 500 but don't log an error.

--- a/types/pino-applicationinsights/index.d.ts
+++ b/types/pino-applicationinsights/index.d.ts
@@ -1,0 +1,11 @@
+declare module 'pino-applicationinsights' {
+  import Pumpify from 'pumpify'
+  import ApplicationInsights from 'appliactioninsights'
+
+  interface WriteStreamOptions {
+    key?: string
+    setup?: (applicationInsights: ApplicationInsights) => void
+  }
+
+  function createWriteStream(options?: WriteStreamOptions): Promise<Pumpify>
+}

--- a/utils/getClaimDetails.ts
+++ b/utils/getClaimDetails.ts
@@ -7,6 +7,7 @@
 
 import { ClaimDetailsContent, ClaimDetailsResult, I18nString } from '../types/common'
 import formatDate from './formatDate'
+import { Logger } from './logger'
 
 export interface ProgramType {
   [key: string]: string
@@ -104,13 +105,16 @@ export const programExtensionPairs = {
  * Given a ProgramType string by the API gateway, return a pair of user-facing translation strings.
  */
 export function getProgramExtensionPair(apiString: string): programExtensionPairType {
+  const logger: Logger = Logger.getInstance()
+
   for (const [id, pair] of Object.entries(programExtensionPairs)) {
     if (apiString === programTypeNames[id]) {
+      logger.pino.info({ programType: apiString }, 'Program Type: Known')
       return pair
     }
   }
   // If no known mapping is found, pass through the raw program type.
-  // @TODO: log this case
+  logger.pino.info({ programType: apiString }, 'Program Type: Unknown')
   return {
     programType: apiString,
     extensionType: '',

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,67 @@
+/**
+ * Utility for shared logging.
+ *
+ * The logger uses the singleton pattern in order to avoid creating multiple pino
+ * instances. In order to support easier log debugging, the incoming request is
+ * logged once as an info call.
+ *
+ * To import the logger: `import { Logger } from '../utils/logger`
+ *
+ * To get the single logger instance: `const logger: Logger = Logger.getInstance()`
+ *
+ * To access the pino instance: `const pino = logger.pino`
+ *
+ * In `index.tsx`, initialize pino: `await logger.initialize()`
+ */
+
+import pino from 'pino'
+import pinoAppInsights from 'pino-applicationinsights'
+
+/**
+ * Logger singleton class.
+ */
+export class Logger {
+  static instance: Logger
+  pino!: pino.Logger
+
+  // Include an empty private constructor in order to use the singleton pattern.
+  // eslint-disable-next-line no-useless-constructor, @typescript-eslint/no-empty-function
+  private constructor() {}
+
+  /**
+   * Get the single Logger instance.
+   */
+  static getInstance(): Logger {
+    if (!this.instance) {
+      this.instance = new Logger()
+    }
+    return this.instance
+  }
+
+  /**
+   * Initialize pino.
+   *
+   * This needs to be called once. Presumably in index.tsx.
+   */
+  async initialize(): Promise<void> {
+    // const isAzureEnv = process.env.NODE_ENV === 'production'
+
+    // // Use pretty print and log to STDOUT for local environments.
+    // this.pino = pino({ prettyPrint: true })
+
+    // // Otherwise, log to Azure Application Insights.
+    // if (isAzureEnv) {
+
+    // Only log to Application Insights if there is a connection string env var.
+    const connectionString = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING ?? ''
+    if (connectionString) {
+      const appInsightsStream = await pinoAppInsights.createWriteStream({
+        key: connectionString,
+      })
+      this.pino = pino(appInsightsStream)
+    } else {
+      throw new Error('Missing Application Insights connection string')
+    }
+    // }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3157,6 +3157,13 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/duplexify@*":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@types/duplexify/-/duplexify-3.6.0.tgz#dfc82b64bd3a2168f5bd26444af165bf0237dcd8"
+  integrity sha512-5zOA53RUlzN74bvrSGwjudssD9F3a797sDZQkiYpUOxW+WHaXTCPz4/d5Dgi6FKnOqZ2CpaTo0DhgIfsXAOE/A==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob-base@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@types/glob-base/-/glob-base-0.3.0.tgz#a581d688347e10e50dd7c17d6f2880a10354319d"
@@ -3346,7 +3353,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/pino@*", "@types/pino@^6.3.8":
+"@types/pino@*", "@types/pino@^6.3.11":
   version "6.3.11"
   resolved "https://registry.yarnpkg.com/@types/pino/-/pino-6.3.11.tgz#83652799e76b3ad692aaf68f6fbf994e83af5db2"
   integrity sha512-S7+fLONqSpHeW9d7TApUqO6VN47KYgOXhCNKwGBVLHObq8HhaAYlVqUNdfnvoXjCMiwE5xcPm/5R2ZUh8bgaXQ==
@@ -3370,6 +3377,14 @@
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
+
+"@types/pumpify@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@types/pumpify/-/pumpify-1.4.1.tgz#5a0650f39a3f8f077c7e544d0c5ae2899b28394c"
+  integrity sha512-l7u/Dnh1OG9T7VH6TvulR0g8oE8hgIW5409mSUKi8Vxw2+JV18aTa06Sv5bvNjrD0zbsB/cuZ/iTFQgFNfzIuw==
+  dependencies:
+    "@types/duplexify" "*"
+    "@types/node" "*"
 
 "@types/qs@^6.9.5":
   version "6.9.7"
@@ -4024,6 +4039,16 @@ app-root-dir@^1.0.2:
   resolved "https://registry.yarnpkg.com/app-root-dir/-/app-root-dir-1.0.2.tgz#38187ec2dea7577fff033ffcb12172692ff6e118"
   integrity sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=
 
+applicationinsights@^1.8.3:
+  version "1.8.10"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.8.10.tgz#fffa482cd1519880fb888536a87081ac05130667"
+  integrity sha512-ZLDA7mShh4mP2Z/HlFolmvhBPX1LfnbIWXrselyYVA7EKjHhri1fZzpu2EiWAmfbRxNBY6fRjoPJWbx5giKy4A==
+  dependencies:
+    cls-hooked "^4.2.2"
+    continuation-local-storage "^3.2.1"
+    diagnostic-channel "0.3.1"
+    diagnostic-channel-publishers "0.4.4"
+
 applicationinsights@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-2.1.5.tgz#06b589b882ae0f5c4d9bb413ad73615ea5260b26"
@@ -4594,6 +4619,13 @@ batch-processor@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/batch-processor/-/batch-processor-1.0.0.tgz#75c95c32b748e0850d10c2b168f6bdbe9891ace8"
   integrity sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg=
+
+batch2@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/batch2/-/batch2-2.0.0.tgz#5dfd62e73aa895dd0f151ffffc2bd8822171d590"
+  integrity sha512-aUjwtuR/V1pgc6nTkao5T/vvNrvbX70iseoYijPjydc48dYzyCxHOWwlNAdSbK5aC609cSAfTsZKSUhVpVbzRQ==
+  dependencies:
+    through2 "^4.0.2"
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -5447,7 +5479,7 @@ commander@^4.1.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-commander@^6.2.0, commander@^6.2.1:
+commander@^6.1.0, commander@^6.2.0, commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
@@ -6132,10 +6164,22 @@ detect-port@^1.3.0:
     address "^1.0.1"
     debug "^2.6.0"
 
+diagnostic-channel-publishers@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.4.tgz#57c3b80b7e7f576f95be3a257d5e94550f0082d6"
+  integrity sha512-l126t01d2ZS9EreskvEtZPrcgstuvH3rbKy82oUhUrVmBaGx4hO9wECdl3cvZbKDYjMF3QJDB5z5dL9yWAjvZQ==
+
 diagnostic-channel-publishers@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.2.tgz#474cc391422dbcc085cbc200f3bcf4a11afd3b85"
   integrity sha512-pehVi/egaf7PIZQeetZuAd7VFpIOicv1uGh5AjM6YQRgOtckwKTONcOtdW9HFymSmjfiGg9kcRlHTD3dbwq0ww==
+
+diagnostic-channel@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz#7faa143e107f861be3046539eb4908faab3f53fd"
+  integrity sha512-6eb9YRrimz8oTr5+JDzGmSYnXy5V7YnK5y/hd8AUDK1MssHjQKm9LlD6NSrHx4vMDF3+e/spI2hmWTviElgWZA==
+  dependencies:
+    semver "^5.3.0"
 
 diagnostic-channel@1.0.0:
   version "1.0.0"
@@ -6338,6 +6382,16 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+duplexify@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-4.1.2.tgz#18b4f8d28289132fa0b9573c898d9f903f81c7b0"
+  integrity sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==
+  dependencies:
+    end-of-stream "^1.4.1"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+    stream-shift "^1.0.0"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -6380,6 +6434,11 @@ elliptic@^6.5.3:
     inherits "^2.0.4"
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
+
+emitter-component@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/emitter-component/-/emitter-component-1.1.1.tgz#065e2dbed6959bf470679edabeaf7981d1003ab6"
+  integrity sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY=
 
 emitter-listener@^1.0.1, emitter-listener@^1.1.1:
   version "1.1.2"
@@ -6444,7 +6503,7 @@ encoding@0.1.13:
   dependencies:
     iconv-lite "^0.6.2"
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -11357,6 +11416,19 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
+pino-applicationinsights@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pino-applicationinsights/-/pino-applicationinsights-2.1.0.tgz#145da81717fffff24c2344aeff8e569539359d5a"
+  integrity sha512-4xzTOfYOzfoUoAkid3LWZBbYeXF76EU+9OWymxqMP1YODVu0sIyWTu7LwbWjImkY8z42iciNjSLIY+DyZYOMgA==
+  dependencies:
+    applicationinsights "^1.8.3"
+    batch2 "^2.0.0"
+    commander "^6.1.0"
+    fast-json-parse "^1.0.3"
+    pumpify "^2.0.1"
+    split2 "^3.2.2"
+    stream "0.0.2"
+
 pino-pretty@^4.8.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-4.8.0.tgz#f2f3055bf222456217b14ffb04d8be0a0cc17fce"
@@ -11836,6 +11908,15 @@ pumpify@^1.3.3:
     duplexify "^3.6.0"
     inherits "^2.0.3"
     pump "^2.0.0"
+
+pumpify@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-2.0.1.tgz#abfc7b5a621307c728b551decbbefb51f0e4aa1e"
+  integrity sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==
+  dependencies:
+    duplexify "^4.1.1"
+    inherits "^2.0.3"
+    pump "^3.0.0"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -12383,7 +12464,7 @@ read-pkg@^5.2.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.0, readable-stream@^3.5.0, readable-stream@^3.6.0:
+readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.1.1, readable-stream@^3.5.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -13393,7 +13474,7 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-split2@^3.1.1:
+split2@^3.1.1, split2@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/split2/-/split2-3.2.2.tgz#bf2cf2a37d838312c249c89206fd7a17dd12365f"
   integrity sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==
@@ -13578,6 +13659,13 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+stream@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stream/-/stream-0.0.2.tgz#7f5363f057f6592c5595f00bc80a27f5cec1f0ef"
+  integrity sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=
+  dependencies:
+    emitter-component "^1.1.1"
 
 string-argv@0.3.1, string-argv@^0.3.1:
   version "0.3.1"
@@ -14032,6 +14120,13 @@ through2@^2.0.0, through2@~2.0.3:
   dependencies:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
+
+through2@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-4.0.2.tgz#a7ce3ac2a7a8b0b966c80e7c49f0484c3b239764"
+  integrity sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==
+  dependencies:
+    readable-stream "3"
 
 through@^2.3.8:
   version "2.3.8"


### PR DESCRIPTION
## Ticket

- Resolves #332 
- Resolves #320 

## Changes

- Re-adds all functionality from #288 that was temporarily reverted in #366 (and that was not included in #402), including:
  - Adds [`pino-applicationinsights`](https://github.com/ovhemert/pino-applicationinsights) as a dependency to log directly to Azure Application Insights in Production
  - Adds a type declaration file for `pino-applicationinsights`
- Creates a shared logger utility that can be called in the back end code
- Combines logging for `request` and `query` data into one call

## Context

This PR adds our logger shared utility to log directly to Azure Application Insights.

## Testing

I've deployed this branch to the Internal Azure environment so that we can verify that it's working as expected.

1. Make a few requests against the site deployed on Internal, using a few different unique numbers
2. Run `traces | sort by timestamp desc` in App Insights Logs for Internal against the last 30m and verify you can view data about your request. Right now, for each request to the app, you should see:
  - a `Request` log entry with request and query data (you should see the unique number you sent in the header)
  - a `ClaimData` log entry with the returned claim data from the API gateway
  - a `ScenarioContent` log entry with the FE props
  - a `Program Type` log entry that lists which program type is returned
3. Run `requests | sort by timestamp desc` to make sure behavior from #402 has not reverted.

Note: Right now, we have redundant `console.log` calls for claim data. Please ignore those.