### PR TITLE
Set result status code when returning a non-200 response

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -84,7 +84,7 @@ export default function Home({
   )
 }
 
-export const getServerSideProps: GetServerSideProps = async ({ req, locale, query }) => {
+export const getServerSideProps: GetServerSideProps = async ({ req, res, locale, query }) => {
   const isProd = process.env.NODE_ENV === 'production'
   const logger = isProd ? pino({}) : pino({ prettyPrint: true })
   logger.info(req)
@@ -122,6 +122,11 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale, quer
   // Note whether the user came from the main UIO website or UIO Mobile, and match
   // that in our links back out to UIO.
   const userArrivedFromUioMobile = query?.from === 'uiom'
+
+  // If there is an errorCode, set the response statusCode to match.
+  if (errorCode) {
+    res.statusCode = errorCode
+  }
 
   // Return Props.
   return {


### PR DESCRIPTION
## Ticket

Resolves #406 

## Changes

- Explicitly set the response status code if there is an error

## Context

Right now, if we return an error page, we are still sending a 200 response code. We should be setting the appropriate HTTP response code.

Note: It turns out that writing a unit test for HTTP responses in Next.js is non-trivial, so I broke that out into a separate ticket so we can get the functionality merged now: #411 Here are a few leads:
- Using cypress: https://blog.logrocket.com/testing-and-error-handling-patterns-in-next-js/
- Manually: https://github.com/vercel/next.js/discussions/15166
- Using [next-test-api-route-handler](https://github.com/Xunnamius/next-test-api-route-handler)

## Testing

1. Checkout this branch
2. Run `yarn dev`
3. Open the browser Network pane
3. Make a request without passing a unique header
4. Verify that the Claim Status Tracker displays a 500 error and also returns HTTP error 500