### PR TITLE
Update environment-specific links to work in timeout modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ relates to weekly certification
 - CERTIFICATE_DIR: The path to the client certificate (certificate must be in PFX/P12 format)
 - PFX_FILE: The name of the client certificate file
 - (Optional) PFX_PASSPHRASE: The import passphrase for the client certificate if there is one
-- (Optional) URL_PREFIX_UIO, URL_PREFIX_UIO_MOBILE, URL_PREFIX_BPO: Environment-specific path prefixes for UIO and BPO links
+- (Optional) Environment-specific path prefixes for UIO and BPO links, [exposed to the client](https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser)
+  - NEXT_PUBLIC_URL_PREFIX_UIO_DESKTOP
+  - NEXT_PUBLIC_URL_PREFIX_UIO_MOBILE
+  - NEXT_PUBLIC_URL_PREFIX_BPO
 
 For local development:
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ relates to weekly certification
 - CERTIFICATE_DIR: The path to the client certificate (certificate must be in PFX/P12 format)
 - PFX_FILE: The name of the client certificate file
 - (Optional) PFX_PASSPHRASE: The import passphrase for the client certificate if there is one
-- (Optional) Environment-specific path prefixes for UIO and BPO links, [exposed to the client](https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser)
+- (Optional) Environment-specific path prefixes for UIO and BPO links
   - URL_PREFIX_UIO_DESKTOP
   - URL_PREFIX_UIO_MOBILE
   - URL_PREFIX_BPO

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ relates to weekly certification
 - PFX_FILE: The name of the client certificate file
 - (Optional) PFX_PASSPHRASE: The import passphrase for the client certificate if there is one
 - (Optional) Environment-specific path prefixes for UIO and BPO links, [exposed to the client](https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser)
-  - NEXT_PUBLIC_URL_PREFIX_UIO_DESKTOP
-  - NEXT_PUBLIC_URL_PREFIX_UIO_MOBILE
-  - NEXT_PUBLIC_URL_PREFIX_BPO
+  - URL_PREFIX_UIO_DESKTOP
+  - URL_PREFIX_UIO_MOBILE
+  - URL_PREFIX_BPO
 
 For local development:
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -14,7 +14,7 @@ export const Header: React.FC<HeaderProps> = ({ userArrivedFromUioMobile = false
   // Return a link back to:
   //   UIO Mobile landing page if user arrived from UIO Mobile
   //   main UIO landing page if user arrived from main UIO
-  const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-mobile-home-url') : getUrl('uio-home-url')
+  const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-mobile-home-url') : getUrl('uio-desktop-home-url')
 
   return (
     <header className="header border-bottom border-secondary">
@@ -34,7 +34,7 @@ export const Header: React.FC<HeaderProps> = ({ userArrivedFromUioMobile = false
                 <span className="text">{t('header.edd-home')}</span>
               </Nav.Link>
             </Navbar.Collapse>
-            <Nav.Link target="_blank" rel="noopener noreferrer" href={getUrl('uio-help-new-claim')}>
+            <Nav.Link target="_blank" rel="noopener noreferrer" href={getUrl('uio-desktop-help-new-claim')}>
               <span className="text">{t('header.help')}</span>
             </Nav.Link>
             <Nav.Link href={getUrl('bpo-log-out')}>

--- a/components/TimeoutModal.tsx
+++ b/components/TimeoutModal.tsx
@@ -10,6 +10,7 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'next-i18next'
 import Modal from 'react-bootstrap/Modal'
+import { UrlPrefixes } from '../types/common'
 
 import { Button } from './Button'
 import getUrl from '../utils/getUrl'
@@ -19,9 +20,10 @@ let warningTimerId: NodeJS.Timeout | null = null
 export interface TimeoutModalProps {
   userArrivedFromUioMobile: boolean
   timedOut: boolean
+  urlPrefixes: UrlPrefixes
 }
 
-export const TimeoutModal: React.FC<TimeoutModalProps> = ({ timedOut, userArrivedFromUioMobile }) => {
+export const TimeoutModal: React.FC<TimeoutModalProps> = ({ timedOut, userArrivedFromUioMobile, urlPrefixes }) => {
   const { t } = useTranslation()
 
   // handy converter for Minutes -> Milliseconds
@@ -57,7 +59,7 @@ export const TimeoutModal: React.FC<TimeoutModalProps> = ({ timedOut, userArrive
       if (typeof window !== 'undefined') {
         // Note that the concatenated portion of this link is functionally useless, as IDM is not currently
         // able to redirect based on the resource_url parameter concatenated.
-        const eddLoginLink = getUrl('bpo-log-in')?.concat(
+        const eddLoginLink = getUrl('bpo-log-in', urlPrefixes)?.concat(
           '?resource_url=',
           encodeURIComponent(window.location.toString()),
         )
@@ -76,7 +78,9 @@ export const TimeoutModal: React.FC<TimeoutModalProps> = ({ timedOut, userArrive
   }
 
   function redirectToUIHome() {
-    const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-mobile-home-url') : getUrl('uio-desktop-home-url')
+    const uioHomeLink = userArrivedFromUioMobile
+      ? getUrl('uio-mobile-home-url', urlPrefixes)
+      : getUrl('uio-desktop-home-url', urlPrefixes)
     window.location.href = uioHomeLink || ''
   }
 

--- a/components/TimeoutModal.tsx
+++ b/components/TimeoutModal.tsx
@@ -53,7 +53,7 @@ export const TimeoutModal: React.FC<TimeoutModalProps> = ({ timedOut, userArrive
       setShowWarningModal(true)
       setWarned(true)
       setNumberOfMinutes(WARNING_DURATION)
-    }, 10000)
+    }, WARNING_TIMER * ONE_MINUTE_MS)
     // And at the end, send back to EDD
     setTimeout(() => {
       if (typeof window !== 'undefined') {
@@ -65,7 +65,7 @@ export const TimeoutModal: React.FC<TimeoutModalProps> = ({ timedOut, userArrive
         )
         window.location.href = eddLoginLink || ''
       }
-    }, 20000)
+    }, REDIRECT_TIMER * ONE_MINUTE_MS)
   }
 
   function closeWarningModal() {

--- a/components/TimeoutModal.tsx
+++ b/components/TimeoutModal.tsx
@@ -51,7 +51,7 @@ export const TimeoutModal: React.FC<TimeoutModalProps> = ({ timedOut, userArrive
       setShowWarningModal(true)
       setWarned(true)
       setNumberOfMinutes(WARNING_DURATION)
-    }, WARNING_TIMER * ONE_MINUTE_MS)
+    }, 10000)
     // And at the end, send back to EDD
     setTimeout(() => {
       if (typeof window !== 'undefined') {
@@ -63,7 +63,7 @@ export const TimeoutModal: React.FC<TimeoutModalProps> = ({ timedOut, userArrive
         )
         window.location.href = eddLoginLink || ''
       }
-    }, REDIRECT_TIMER * ONE_MINUTE_MS)
+    }, 20000)
   }
 
   function closeWarningModal() {
@@ -76,7 +76,7 @@ export const TimeoutModal: React.FC<TimeoutModalProps> = ({ timedOut, userArrive
   }
 
   function redirectToUIHome() {
-    const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-mobile-home-url') : getUrl('uio-home-url')
+    const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-mobile-home-url') : getUrl('uio-desktop-home-url')
     window.location.href = uioHomeLink || ''
   }
 

--- a/components/TransLine.tsx
+++ b/components/TransLine.tsx
@@ -15,7 +15,7 @@ export interface TransLineProps extends TransLineContent {
 function resolveUrl(link: I18nString, userArrivedFromUioMobile: boolean) {
   // Special case for UIO homepage links.
   if (link === 'uio-home') {
-    const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-mobile-home-url') : getUrl('uio-home-url')
+    const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-mobile-home-url') : getUrl('uio-desktop-home-url')
     if (uioHomeLink) {
       // If the link is for UIO homepage, do a direct getUrl() lookup.
       // Do not pass the looked up url through t() because t() will mangle the url.

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -87,6 +87,9 @@ export default function Home({
 }
 
 export const getServerSideProps: GetServerSideProps = async ({ req, locale, query }) => {
+  // Environment-specific links to UIO, UIO Mobile, and BPO, used by EDD testing
+  // Note: it's not possible to use the NEXT_PUBLIC_ prefix to expose these env vars to the browser
+  // because they're set at build time, and Azure doesn't inject env vars ("App Settings") until runtime
   const URL_PREFIXES = {
     urlPrefixUioDesktop: process.env.URL_PREFIX_UIO_DESKTOP,
     urlPrefixUioMobile: process.env.URL_PREFIX_UIO_MOBILE,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,7 +16,7 @@ import { Footer } from '../components/Footer'
 
 import queryApiGateway, { getUniqueNumber } from '../utils/queryApiGateway'
 import getScenarioContent from '../utils/getScenarioContent'
-import { ScenarioContent } from '../types/common'
+import { UrlPrefixes, ScenarioContent } from '../types/common'
 
 export interface HomeProps {
   scenarioContent: ScenarioContent
@@ -24,6 +24,7 @@ export interface HomeProps {
   loading: boolean
   errorCode?: number | null
   userArrivedFromUioMobile?: boolean
+  urlPrefixes: UrlPrefixes
 }
 
 export default function Home({
@@ -32,6 +33,7 @@ export default function Home({
   loading,
   errorCode = null,
   userArrivedFromUioMobile = false,
+  urlPrefixes,
 }: HomeProps): ReactElement {
   const { t } = useTranslation('common')
 
@@ -77,7 +79,7 @@ export default function Home({
       </Head>
       <Header userArrivedFromUioMobile={userArrivedFromUioMobile} />
       {mainComponent}
-      <TimeoutModal userArrivedFromUioMobile={userArrivedFromUioMobile} timedOut={timedOut} />
+      <TimeoutModal userArrivedFromUioMobile={userArrivedFromUioMobile} timedOut={timedOut} urlPrefixes={urlPrefixes} />
       <Footer />
       {console.dir({ scenarioContent })} {/* @TODO: Remove. For development purposes only. */}
     </Container>
@@ -85,6 +87,12 @@ export default function Home({
 }
 
 export const getServerSideProps: GetServerSideProps = async ({ req, locale, query }) => {
+  const URL_PREFIXES = {
+    urlPrefixUioDesktop: process.env.URL_PREFIX_UIO_DESKTOP,
+    urlPrefixUioMobile: process.env.URL_PREFIX_UIO_MOBILE,
+    urlPrefixBpo: process.env.URL_PREFIX_BPO,
+  }
+
   const isProd = process.env.NODE_ENV === 'production'
   const logger = isProd ? pino({}) : pino({ prettyPrint: true })
   logger.info(req)
@@ -130,6 +138,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, locale, quer
       loading: false,
       errorCode: errorCode,
       userArrivedFromUioMobile: userArrivedFromUioMobile,
+      urlPrefixes: URL_PREFIXES,
       ...(await serverSideTranslations(locale || 'en', ['common', 'claim-details', 'claim-status'])),
     },
   }

--- a/public/urls.json
+++ b/public/urls.json
@@ -7,7 +7,7 @@
   "edd-ca-gov": "https://edd.ca.gov",
   "bpo-log-in": "https://portal.edd.ca.gov/WebApp/Login",
   "bpo-log-out": "https://portal.edd.ca.gov/WebApp/Logout",
-  "uio-help-new-claim": "https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=en-US/Public/NewClaim/UIOnlineNewClaimLandingPage.htm",
-  "uio-home-url": "https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx",
+  "uio-desktop-help-new-claim": "https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=en-US/Public/NewClaim/UIOnlineNewClaimLandingPage.htm",
+  "uio-desktop-home-url": "https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx",
   "uio-mobile-home-url": "https://uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
 }

--- a/types/common.ts
+++ b/types/common.ts
@@ -2,7 +2,7 @@
 export type I18nString = string
 export type ApiGatewayDateString = string
 
-// Types for URL prefixes from env vars
+// Types for URL prefixes loaded from env vars
 export interface UrlPrefixes {
   urlPrefixUioDesktop: string | undefined
   urlPrefixUioMobile: string | undefined

--- a/types/common.ts
+++ b/types/common.ts
@@ -2,6 +2,13 @@
 export type I18nString = string
 export type ApiGatewayDateString = string
 
+// Types for URL prefixes from env vars
+export interface UrlPrefixes {
+  urlPrefixUioDesktop: string | undefined
+  urlPrefixUioMobile: string | undefined
+  urlPrefixBpo: string | undefined
+}
+
 // Types for TransLine component
 export interface TransLineContent {
   i18nKey: I18nString

--- a/utils/getUrl.ts
+++ b/utils/getUrl.ts
@@ -10,17 +10,19 @@ export type UrlType = keyof typeof urls
 
 /**
  * Get url from urls.json
+ * urlPrefixes: environment-specific links to UIO, UIO Mobile, and BPO, used by EDD testing
  */
 export default function getUrl(linkKey: string, urlPrefixes?: UrlPrefixes): string | undefined {
   // Explicitly cast to one of the allowed keys in urls.json.
   // If the key does not exist in urls.json, this function will return undefined.
   const key = linkKey as UrlType
 
+  // urlPrefixes must be passed in if getUrl is called client-side (e.g. from TimeoutModal.tsx),
+  // since env vars aren't accessible client-side; otherwise, prefixes can be loaded from env vars below
   const urlPrefixUioDesktop = urlPrefixes?.urlPrefixUioDesktop || process.env.URL_PREFIX_UIO_DESKTOP
   const urlPrefixUioMobile = urlPrefixes?.urlPrefixUioMobile || process.env.URL_PREFIX_UIO_MOBILE
   const urlPrefixBpo = urlPrefixes?.urlPrefixBpo || process.env.URL_PREFIX_BPO
 
-  // Optional environment-specific links back to the UIO landing page, used by EDD testing
   if (urlPrefixUioDesktop && key.startsWith('uio-desktop')) {
     return urls[key].replace('uio.edd.ca.gov/UIO', urlPrefixUioDesktop)
   }

--- a/utils/getUrl.ts
+++ b/utils/getUrl.ts
@@ -3,6 +3,7 @@
  */
 
 import urls from '../public/urls.json'
+import { UrlPrefixes } from '../types/common'
 
 // Type alias for the keys in urls.json
 export type UrlType = keyof typeof urls
@@ -10,22 +11,26 @@ export type UrlType = keyof typeof urls
 /**
  * Get url from urls.json
  */
-export default function getUrl(linkKey: string): string | undefined {
+export default function getUrl(linkKey: string, urlPrefixes?: UrlPrefixes): string | undefined {
   // Explicitly cast to one of the allowed keys in urls.json.
   // If the key does not exist in urls.json, this function will return undefined.
   const key = linkKey as UrlType
 
+  const urlPrefixUioDesktop = urlPrefixes?.urlPrefixUioDesktop || process.env.URL_PREFIX_UIO_DESKTOP
+  const urlPrefixUioMobile = urlPrefixes?.urlPrefixUioMobile || process.env.URL_PREFIX_UIO_MOBILE
+  const urlPrefixBpo = urlPrefixes?.urlPrefixBpo || process.env.URL_PREFIX_BPO
+
   // Optional environment-specific links back to the UIO landing page, used by EDD testing
-  if (key.startsWith('uio-desktop') && process.env.NEXT_PUBLIC_URL_PREFIX_UIO_DESKTOP) {
-    return urls[key].replace('uio.edd.ca.gov/UIO', process.env.NEXT_PUBLIC_URL_PREFIX_UIO_DESKTOP)
+  if (urlPrefixUioDesktop && key.startsWith('uio-desktop')) {
+    return urls[key].replace('uio.edd.ca.gov/UIO', urlPrefixUioDesktop)
   }
 
-  if (key.startsWith('uio-mobile') && process.env.NEXT_PUBLIC_URL_PREFIX_UIO_MOBILE) {
-    return urls[key].replace('uiom.edd.ca.gov/UIOM', process.env.NEXT_PUBLIC_URL_PREFIX_UIO_MOBILE)
+  if (urlPrefixUioMobile && key.startsWith('uio-mobile')) {
+    return urls[key].replace('uiom.edd.ca.gov/UIOM', urlPrefixUioMobile)
   }
 
-  if (key.startsWith('bpo') && process.env.NEXT_PUBLIC_URL_PREFIX_BPO) {
-    return urls[key].replace('portal.edd.ca.gov', process.env.NEXT_PUBLIC_URL_PREFIX_BPO)
+  if (urlPrefixBpo && key.startsWith('bpo')) {
+    return urls[key].replace('portal.edd.ca.gov', urlPrefixBpo)
   }
 
   return urls[key]

--- a/utils/getUrl.ts
+++ b/utils/getUrl.ts
@@ -16,16 +16,16 @@ export default function getUrl(linkKey: string): string | undefined {
   const key = linkKey as UrlType
 
   // Optional environment-specific links back to the UIO landing page, used by EDD testing
-  if (key.startsWith('uio') && process.env.URL_PREFIX_UIO) {
-    return urls[key].replace('uio.edd.ca.gov/UIO', process.env.URL_PREFIX_UIO)
+  if (key.startsWith('uio-desktop') && process.env.NEXT_PUBLIC_URL_PREFIX_UIO_DESKTOP) {
+    return urls[key].replace('uio.edd.ca.gov/UIO', process.env.NEXT_PUBLIC_URL_PREFIX_UIO_DESKTOP)
   }
 
-  if (key.startsWith('uio-mobile') && process.env.URL_PREFIX_UIO_MOBILE) {
-    return urls[key].replace('uiom.edd.ca.gov/UIOM', process.env.URL_PREFIX_UIO_MOBILE)
+  if (key.startsWith('uio-mobile') && process.env.NEXT_PUBLIC_URL_PREFIX_UIO_MOBILE) {
+    return urls[key].replace('uiom.edd.ca.gov/UIOM', process.env.NEXT_PUBLIC_URL_PREFIX_UIO_MOBILE)
   }
 
-  if (key.startsWith('bpo') && process.env.URL_PREFIX_BPO) {
-    return urls[key].replace('portal.edd.ca.gov', process.env.URL_PREFIX_BPO)
+  if (key.startsWith('bpo') && process.env.NEXT_PUBLIC_URL_PREFIX_BPO) {
+    return urls[key].replace('portal.edd.ca.gov', process.env.NEXT_PUBLIC_URL_PREFIX_BPO)
   }
 
   return urls[key]


### PR DESCRIPTION
#400 added support for environment-specific links; however, it didn't work for links in the timeout modal, because the timeout modal generates the URL on the client side, and environment variables can't be accessed client-side. This PR imports the link env vars on the server side in index.tsx and makes them available to be passed into getUrl which generates the environment-specific links.

Tested locally and in the Azure test env. Change `WARNING_TIMER * ONE_MINUTE_MS` to 10000 (milliseconds) and `REDIRECT_TIMER * ONE_MINUTE_MS` to 20000 in TimeoutModal.tsx to make testing quicker.

===

- [ ] Relevant documentation (e.g. READMEs, Technical Foundation) updated
- [ ] Issue AC are copied to this PR & are met
- [ ] Changes are tested on Staging post-merge into `main`
