### PR TITLE
Display $0.00 for Claim Balance and Weekly Benefit Amount when API response returns 0.00

### DIFF
--- a/tests/utils/getClaimDetails.test.ts
+++ b/tests/utils/getClaimDetails.test.ts
@@ -95,6 +95,58 @@ describe('Constructing the Claim Details object', () => {
     expect(claimDetails).toStrictEqual(expected)
   })
 
+  it('zero dollar claimBalance is displayed', () => {
+    // Mock ClaimDetailsResults
+    const rawDetails = {
+      programType: 'UI',
+      benefitYearStartDate: '2021-05-21T00:00:00',
+      benefitYearEndDate: '2022-05-20T00:00:00',
+      claimBalance: 0.0,
+      weeklyBenefitAmount: 25,
+      lastPaymentIssued: '2021-03-12T00:00:00',
+      lastPaymentAmount: 10,
+      monetaryStatus: 'active',
+    }
+
+    // Expected results
+    const expected = {
+      programType: 'claim-details:program-type.ui',
+      benefitYear: '5/21/2021–5/20/2022',
+      claimBalance: '$0.00',
+      weeklyBenefitAmount: '$25.00',
+      lastPaymentIssued: '$10.00 on 3/12/2021',
+      extensionType: '',
+    }
+    const claimDetails = getClaimDetails(rawDetails)
+    expect(claimDetails).toStrictEqual(expected)
+  })
+
+  it('zero dollar weeklyBenefitAmount is displayed', () => {
+    // Mock ClaimDetailsResults
+    const rawDetails = {
+      programType: 'UI',
+      benefitYearStartDate: '2021-05-21T00:00:00',
+      benefitYearEndDate: '2022-05-20T00:00:00',
+      claimBalance: 100,
+      weeklyBenefitAmount: 0.0,
+      lastPaymentIssued: '2021-03-12T00:00:00',
+      lastPaymentAmount: 10,
+      monetaryStatus: 'active',
+    }
+
+    // Expected results
+    const expected = {
+      programType: 'claim-details:program-type.ui',
+      benefitYear: '5/21/2021–5/20/2022',
+      claimBalance: '$100.00',
+      weeklyBenefitAmount: '$0.00',
+      lastPaymentIssued: '$10.00 on 3/12/2021',
+      extensionType: '',
+    }
+    const claimDetails = getClaimDetails(rawDetails)
+    expect(claimDetails).toStrictEqual(expected)
+  })
+
   it('null lastPaymentIssued date makes the final lastPaymentIssued null', () => {
     // Mock ClaimDetailsResults
     const rawDetails = {
@@ -141,6 +193,32 @@ describe('Constructing the Claim Details object', () => {
       claimBalance: '$100.00',
       weeklyBenefitAmount: '$25.00',
       lastPaymentIssued: null,
+      extensionType: '',
+    }
+    const claimDetails = getClaimDetails(rawDetails)
+    expect(claimDetails).toStrictEqual(expected)
+  })
+
+  it('zero dollar lastPaymentAmount displays the final lastPaymentIssued', () => {
+    // Mock ClaimDetailsResults
+    const rawDetails = {
+      programType: 'UI',
+      benefitYearStartDate: '2021-05-21T00:00:00',
+      benefitYearEndDate: '2022-05-20T00:00:00',
+      claimBalance: 100,
+      weeklyBenefitAmount: 25,
+      lastPaymentIssued: '2021-03-12T00:00:00',
+      lastPaymentAmount: 0.0,
+      monetaryStatus: 'active',
+    }
+
+    // Expected results
+    const expected = {
+      programType: 'claim-details:program-type.ui',
+      benefitYear: '5/21/2021–5/20/2022',
+      claimBalance: '$100.00',
+      weeklyBenefitAmount: '$25.00',
+      lastPaymentIssued: '$0.00 on 3/12/2021',
       extensionType: '',
     }
     const claimDetails = getClaimDetails(rawDetails)

--- a/utils/getClaimDetails.ts
+++ b/utils/getClaimDetails.ts
@@ -132,18 +132,32 @@ export function formatCurrency(amount: number): string {
 }
 
 /**
+ * Check for zero dollar amounts.
+ */
+export function isZero(amount: number): boolean {
+  return amount === 0
+}
+
+/**
  * Get Claim Details content.
  */
 export default function getClaimDetails(rawDetails: ClaimDetailsResult): ClaimDetailsContent {
   // Get programType and extensionType.
   const pair: programExtensionPairType = getProgramExtensionPair(rawDetails.programType)
 
-  // construct our fields
+  // Construct claim details fields.
   const benefitYear = buildBenefitYear(rawDetails.benefitYearStartDate, rawDetails.benefitYearEndDate)
-  const claimBalance = rawDetails.claimBalance ? formatCurrency(rawDetails.claimBalance) : null
-  const weeklyBenefitAmount = rawDetails.weeklyBenefitAmount ? formatCurrency(rawDetails.weeklyBenefitAmount) : null
+
+  // Return null (aka hide the field) if the raw value is falsy.
+  // Exception: display the value if the dollar amount is zero.
+  const claimBalance =
+    rawDetails.claimBalance || isZero(rawDetails.claimBalance) ? formatCurrency(rawDetails.claimBalance) : null
+  const weeklyBenefitAmount =
+    rawDetails.weeklyBenefitAmount || isZero(rawDetails.weeklyBenefitAmount)
+      ? formatCurrency(rawDetails.weeklyBenefitAmount)
+      : null
   const lastPaymentIssued =
-    rawDetails.lastPaymentAmount && rawDetails.lastPaymentIssued
+    rawDetails.lastPaymentIssued && (rawDetails.lastPaymentAmount || isZero(rawDetails.lastPaymentAmount))
       ? `${formatCurrency(rawDetails.lastPaymentAmount)} on ${formatDate(rawDetails.lastPaymentIssued)}`
       : null
 


### PR DESCRIPTION
## Ticket

Resolves #414 

## Changes

- Change logic for claim details: display fields when receiving a zero dollar amount

## Context

We're currently Claim Details fields when the raw data is Javascript falsy, but we want to make an exception and display the fields when the raw data is `0.0`.

## Testing

`yarn test`