### PR TITLE
Displays None when no last payment provided

### DIFF
--- a/components/ClaimDetails.tsx
+++ b/components/ClaimDetails.tsx
@@ -29,13 +29,6 @@ export const ClaimDetails: React.FC<ClaimDetailsProps> = ({
     )
   }
 
-  let lastPaymentIssuedField: JSX.Element | null = null
-  if (lastPaymentIssued) {
-    lastPaymentIssuedField = (
-      <InfoField loading={loading} label={t('claim-details.last-payment-issued')} text={lastPaymentIssued} />
-    )
-  }
-
   let extensionField: JSX.Element | null = null
   if (extensionType) {
     extensionField = (
@@ -61,7 +54,11 @@ export const ClaimDetails: React.FC<ClaimDetailsProps> = ({
 
             {weeklyBenefitAmountField}
 
-            {lastPaymentIssuedField}
+            <InfoField
+              loading={loading}
+              label={t('claim-details.last-payment-issued')}
+              text={lastPaymentIssued || t('claim-details.none')}
+            />
           </div>
           {extensionField}
         </div>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -22,6 +22,7 @@
     "claim-balance": "Claim Balance",
     "weekly-benefit-amount": "Weekly Benefit Amount",
     "last-payment-issued": "Last Payment Issued",
+    "none": "None",
     "extension-type": "Extension Type"
   },
   "footer": {

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -22,6 +22,7 @@
     "claim-balance": "Balance de la solicitud",
     "weekly-benefit-amount": "Cantidad de beneficios semanal",
     "last-payment-issued": "Último pago emitido",
+    "none": "Ninguno",
     "extension-type": "Tipo de extensión"
   },
   "footer": {

--- a/tests/components/ClaimDetails.test.tsx
+++ b/tests/components/ClaimDetails.test.tsx
@@ -78,7 +78,7 @@ describe('ClaimDetails with nullable fields', () => {
 
     expect(screen.queryByText('Weekly Benefit Amount')).not.toBeInTheDocument()
   })
-  it('Null Last Payment Issued hides the field', () => {
+  it('Null Last Payment Issued shows None', () => {
     const mockRouter = {
       locale: 'en',
     }
@@ -96,6 +96,7 @@ describe('ClaimDetails with nullable fields', () => {
       />,
     )
 
-    expect(screen.queryByText('Last Payment Issued')).not.toBeInTheDocument()
+    expect(screen.queryByText('Last Payment Issued')).toBeInTheDocument()
+    expect(screen.queryByText('None')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
<!-- Write a description below of the changes in this pull request. 

Include images/GIFs if relevant for reviewers. Try Firefox (right-click -> Take Screenshot) for full-page screenshots and LICEcap (macOS) or Peek (ubuntu) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items. -->

What it says on the tin!

Test in storybook:
- Component level, use storybook to manually test
  - Set the value to empty on the component http://localhost:6006/?path=/story/component-page-section-claim-details--claim-details
- API level & component level are also both tested in the tests
  - `yarn test` 

===

Resolves #419

- [x]  When either lastPaymentIssued of lastPaymentAmount returns null, the field value for Last Payment Issue under Claim Details displays as "None"
- [ ] Changes are tested on Staging post-merge into `main`
