### PR TITLE
Strip trailing slash from API_URL

### DIFF
--- a/utils/queryApiGateway.ts
+++ b/utils/queryApiGateway.ts
@@ -50,7 +50,8 @@ export function getApiVars(): ApiEnvVars {
   apiEnvVars.idHeaderName = process.env.ID_HEADER_NAME ?? ''
 
   // API fields
-  apiEnvVars.apiUrl = process.env.API_URL ?? ''
+  // Remove trailing slash from API_URL if one exists
+  apiEnvVars.apiUrl = (process.env.API_URL ?? '').replace(/\/$/, '')
   apiEnvVars.apiUserKey = process.env.API_USER_KEY ?? ''
 
   // TLS Certificate fields


### PR DESCRIPTION
This PR strips the trailing slash from the API_URL environment variable, since the endpoint in the URL should never contain a trailing slash. 

===

Resolves #438

- [ ] Relevant documentation (e.g. READMEs, Technical Foundation) updated
- [ ] Issue AC are copied to this PR & are met
- [ ] Changes are tested on Staging post-merge into `main`
