### PR TITLE
Adds custom error pages

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -32,6 +32,7 @@ export const parameters = {
       method: 'alphabetical',
       order: [
         'Claim Status Tracker',
+        ['Page', '404'],
         'Component',
         ['Page Section', ['Header', 'Main', 'Claim Section', 'Claim Status', 'Next Steps', 'Claim Details', 'Footer']],
         'Atoms',

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -3,7 +3,7 @@ import { MouseEventHandler } from 'react'
 export interface ButtonProps {
   primary?: boolean
   label: string
-  onClick?: MouseEventHandler | string
+  onClick?: MouseEventHandler
 }
 
 export const Button: React.FC<ButtonProps> = ({ primary = false, label, onClick, ...props }) => {

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -3,7 +3,7 @@ import { MouseEventHandler } from 'react'
 export interface ButtonProps {
   primary?: boolean
   label: string
-  onClick?: MouseEventHandler
+  onClick?: MouseEventHandler | string
 }
 
 export const Button: React.FC<ButtonProps> = ({ primary = false, label, onClick, ...props }) => {

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -52,6 +52,6 @@ export default function Custom404({ userArrivedFromUioMobile = false }: Custom40
 
 export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
-    ...(await serverSideTranslations(locale, ['common'])),
+    ...(await serverSideTranslations(locale || 'en', ['common'])),
   },
 })

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,55 @@
+import Head from 'next/head'
+import { useTranslation } from 'next-i18next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { ReactElement } from 'react'
+import Container from 'react-bootstrap/Container'
+
+import { Footer } from '../components/Footer'
+import { Header } from '../components/Header'
+import { Button } from '../components/Button'
+import { UrlPrefixes } from '../types/common'
+import getUrl from '../utils/browser/getUrl'
+
+export interface Custom404Props {
+  userArrivedFromUioMobile?: boolean
+}
+
+export default function Custom404({ userArrivedFromUioMobile = false }: Custom404Props): ReactElement {
+  const { t } = useTranslation('common')
+
+  function redirectToUIHome() {
+    const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-mobile-home-url') : getUrl('uio-desktop-home-url')
+    window.location.href = uioHomeLink || ''
+  }
+
+  return (
+    <Container fluid className="index">
+      <Head>
+        <title>{t('title')}</title>
+        <link rel="icon" href="/claimstatus/favicon.ico" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <Header userArrivedFromUioMobile={userArrivedFromUioMobile} />
+
+      <main className="main">
+        <Container className="error-content">
+          <div className="error-label">{t('errors.not-found.label')}</div>
+          <div className="error-entry">{t('errors.not-found.entry')}</div>
+          <Button primary label={t('errors.not-found.button')} onClick={redirectToUIHome} />
+        </Container>
+      </main>
+      <Footer />
+    </Container>
+  )
+}
+
+export const getStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(locale, ['common'])),
+  },
+})

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,3 +1,4 @@
+import { GetStaticProps } from 'next'
 import Head from 'next/head'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
@@ -7,7 +8,6 @@ import Container from 'react-bootstrap/Container'
 import { Footer } from '../components/Footer'
 import { Header } from '../components/Header'
 import { Button } from '../components/Button'
-import { UrlPrefixes } from '../types/common'
 import getUrl from '../utils/browser/getUrl'
 
 export interface Custom404Props {
@@ -37,10 +37,12 @@ export default function Custom404({ userArrivedFromUioMobile = false }: Custom40
       <Header userArrivedFromUioMobile={userArrivedFromUioMobile} />
 
       <main className="main">
-        <Container className="error-content">
-          <div className="error-label">{t('errors.not-found.label')}</div>
-          <div className="error-entry">{t('errors.not-found.entry')}</div>
-          <Button primary label={t('errors.not-found.button')} onClick={redirectToUIHome} />
+        <Container className="main-content">
+          <div className="error-content">
+            <div className="error-label">{t('errors.not-found.label')}</div>
+            <div className="error-entry">{t('errors.not-found.entry')}</div>
+            <Button primary label={t('errors.button')} onClick={redirectToUIHome} />
+          </div>
         </Container>
       </main>
       <Footer />
@@ -48,7 +50,7 @@ export default function Custom404({ userArrivedFromUioMobile = false }: Custom40
   )
 }
 
-export const getStaticProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale, ['common'])),
   },

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -5,14 +5,23 @@ import { ReactElement } from 'react'
 import { Button } from '../components/Button'
 import getUrl from '../utils/browser/getUrl'
 
-function Error(): ReactElement {
+export interface ErrorProps {
+  userArrivedFromUioMobile?: boolean
+}
+
+function Error({ userArrivedFromUioMobile = false }: ErrorProps): ReactElement {
   const { t } = useTranslation('common')
+
+  function redirectToUIHome() {
+    const uioHomeLink = userArrivedFromUioMobile ? getUrl('uio-mobile-home-url') : getUrl('uio-desktop-home-url')
+    window.location.href = uioHomeLink || ''
+  }
 
   return (
     <div className="error-content">
       <div className="error-label">{t('errors.server-error.label')}</div>
       <div className="error-entry">{t('errors.server-error.entry')}</div>
-      <Button primary label={t('errors.button')} onClick={getUrl('uio-desktop-home-url')} />
+      <Button primary label={t('errors.button')} onClick={redirectToUIHome} />
     </div>
   )
 }

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -26,9 +26,4 @@ function Error({ userArrivedFromUioMobile = false }: ErrorProps): ReactElement {
   )
 }
 
-Error.getInitialProps = ({ res, err }: NextPageContext) => {
-  const statusCode = res ? res.statusCode : err ? err.statusCode : 404
-  return { statusCode }
-}
-
 export default Error

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,0 +1,25 @@
+import { NextPageContext } from 'next'
+import { useTranslation } from 'next-i18next'
+import { ReactElement } from 'react'
+
+import { Button } from '../components/Button'
+import getUrl from '../utils/browser/getUrl'
+
+function Error(): ReactElement {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="error-content">
+      <div className="error-label">{t('errors.server-error.label')}</div>
+      <div className="error-entry">{t('errors.server-error.entry')}</div>
+      <Button primary label={t('errors.button')} onClick={getUrl('uio-desktop-home-url')} />
+    </div>
+  )
+}
+
+Error.getInitialProps = ({ res, err }: NextPageContext) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404
+  return { statusCode }
+}
+
+export default Error

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -43,7 +43,7 @@ export default function Home({
     mainComponent = (
       <main className="main">
         <Container className="main-content">
-          <Error statusCode={errorCode} />
+          <Error userArrivedFromUioMobile />
         </Container>
       </main>
     )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,7 @@ import { ReactElement } from 'react'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { GetServerSideProps } from 'next'
-import Error from 'next/error'
+import Error from './_error'
 import { req as reqSerializer } from 'pino-std-serializers'
 
 import { Header } from '../components/Header'

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -12,8 +12,12 @@
   "errors": {
     "not-found": {
       "label": "We can't find that page.",
-      "entry": "The link you clicked may be broken or the page may have been removed.",
-      "button": "Return to UI Home"
+      "entry": "The link you clicked may be broken or the page may have been removed."
+    },
+    "button": "Return to UI Home",
+    "server-error": {
+      "label": "There’s an error on our end.",
+      "entry": "We are unable to perform your request."
     }
   },
   "claim-status": {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -9,7 +9,13 @@
   },
   "title": "Claim Status Tracker",
   "welcome": "Claim Status Tracker",
-  "change-locale": "En español",
+  "errors": {
+    "not-found": {
+      "label": "We can't find that page.",
+      "entry": "The link you clicked may be broken or the page may have been removed.",
+      "button": "Return to UI Home"
+    }
+  },
   "claim-status": {
     "title": "Claim Status",
     "your-next-steps": "Your Next Steps",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -12,8 +12,12 @@
   "errors": {
     "not-found": {
       "label": "We can't find that page.",
-      "entry": "The link you clicked may be broken or the page may have been removed.",
-      "button": "Return to UI Home"
+      "entry": "The link you clicked may be broken or the page may have been removed."
+    },
+    "button": "Return to UI Home",
+    "server-error": {
+      "label": "There’s an error on our end.",
+      "entry": "We are unable to perform your request."
     }
   },
   "claim-status": {

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -9,7 +9,13 @@
   },
   "title": "Buscador del estatus de su solicitud",
   "welcome": "Buscador del estatus de su solicitud",
-  "change-locale": "In English",
+  "errors": {
+    "not-found": {
+      "label": "We can't find that page.",
+      "entry": "The link you clicked may be broken or the page may have been removed.",
+      "button": "Return to UI Home"
+    }
+  },
   "claim-status": {
     "title": "Estatus de solicitud",
     "your-next-steps": "Sus próximos pasos",

--- a/stories/404.stories.tsx
+++ b/stories/404.stories.tsx
@@ -1,0 +1,21 @@
+import { Story, Meta } from '@storybook/react'
+
+import Custom404, { Custom404Props } from '../pages/404'
+
+// See https://storybook.js.org/docs/riot/essentials/controls#dealing-with-complex-values
+export default {
+  title: 'Claim Status Tracker/404',
+  component: Custom404,
+  argTypes: {
+    userArrivedFromUioMobile: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+} as Meta
+
+const Template: Story<Custom404Props> = (args) => <Custom404 {...args} />
+
+export const errored = Template.bind({})
+errored.args = {}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -162,8 +162,6 @@ body {
     }
 
     .error-content {
-      padding: 15rem;
-
       .error-label {
         font-size: 3.5rem;
         font-weight: 700;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -161,6 +161,22 @@ body {
       padding: 5rem 1rem;
     }
 
+    .error-content {
+      padding: 15rem;
+
+      .error-label {
+        font-size: 3.5rem;
+        font-weight: 700;
+        line-height: 5.25rem;
+      }
+
+      .error-entry {
+        font-size: 1.5rem;
+        padding: 1rem 0;
+        line-height: 2rem;
+      }
+    }
+
     @media (min-width: 768px) {
       .main-content {
         max-width: 650px;


### PR DESCRIPTION
<!-- Write a description below of the changes in this pull request. 

Include images/GIFs if relevant for reviewers. Try Firefox (right-click -> Take Screenshot) for full-page screenshots and LICEcap (macOS) or Peek (ubuntu) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items. -->

Error Pages! Compare to the designs on the "CA UI - Claim Status" figma, tab "SP11 - 7/21" 

Status Code | Image
--|--
404 | ![Claim Status Tracker - 404 error page](https://user-images.githubusercontent.com/6129479/132032329-966c92f3-17fc-4f5a-b413-a07a0433b627.png)
All others (500s) | ![Claim Status Tracker - 500 error page](https://user-images.githubusercontent.com/6129479/132032239-b7e7df76-3134-4df6-8a32-56f7a2672307.png)

 
Testing
 - both pages can be previewed in Storybook (under Page > Errored and 404)
 - navigating to http://localhost:3000/ will show the 404
 - navigating to http://localhost:3000/claimstatus with no unique number will show the 500

===

Resolves #123 

- [x] Show the appropriate error page (404 or 5xx) when triggered
- [x] Manual Browser Testing performed (with modheader, either locally or on BrowserStack)
- [ ] Changes are tested on Staging post-merge into `main`
