### PR TITLE
Add maintenance page

### DIFF
--- a/components/Maintenance.tsx
+++ b/components/Maintenance.tsx
@@ -5,8 +5,9 @@ export const Maintenance: React.FC = () => {
 
   return (
     <div className="error-content">
-      <div className="error-label">{t('errors.server-error.label')}</div>
-      <div className="error-entry">{t('errors.server-error.entry')}</div>
+      <div className="error-label">{t('maintenance.label')}</div>
+      <div className="error-entry">{t('maintenance.entry')}</div>
+      <div className="error-entry">{t('maintenance.entry2')}</div>
     </div>
   )
 }

--- a/components/Maintenance.tsx
+++ b/components/Maintenance.tsx
@@ -1,0 +1,12 @@
+import { useTranslation } from 'next-i18next'
+
+export const Maintenance: React.FC = () => {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="error-content">
+      <div className="error-label">{t('errors.server-error.label')}</div>
+      <div className="error-entry">{t('errors.server-error.entry')}</div>
+    </div>
+  )
+}

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,4 +1,3 @@
-import { NextPageContext } from 'next'
 import { useTranslation } from 'next-i18next'
 import { ReactElement } from 'react'
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,6 +11,7 @@ import { Header } from '../components/Header'
 import { Title } from '../components/Title'
 import { ClaimSection } from '../components/ClaimSection'
 import { TimeoutModal } from '../components/TimeoutModal'
+import { Maintenance } from '../components/Maintenance'
 import { Footer } from '../components/Footer'
 
 import { ScenarioContent, UrlPrefixes } from '../types/common'
@@ -26,6 +27,7 @@ export interface HomeProps {
   userArrivedFromUioMobile?: boolean
   urlPrefixes: UrlPrefixes
   enableGoogleAnalytics: string
+  enableMaintenancePage: string
 }
 
 export default function Home({
@@ -36,6 +38,7 @@ export default function Home({
   userArrivedFromUioMobile = false,
   urlPrefixes,
   enableGoogleAnalytics,
+  enableMaintenancePage,
 }: HomeProps): ReactElement {
   const { t } = useTranslation('common')
 
@@ -65,7 +68,9 @@ export default function Home({
 
   // If any errorCode is provided, render the error page.
   let mainContent: JSX.Element
-  if (errorCode) {
+  if (enableMaintenancePage) {
+    mainContent = <Maintenance />
+  } else if (errorCode) {
     mainContent = <Error userArrivedFromUioMobile />
   } else {
     mainContent = (
@@ -121,6 +126,9 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res, locale,
 
   // Set to 'enabled' to include Google Analytics code
   const ENABLE_GOOGLE_ANALYTICS = process.env.ENABLE_GOOGLE_ANALYTICS ?? ''
+
+  // Set to 'enabled' to display down-for-maintenance page
+  const ENABLE_MAINTENANCE_PAGE = process.env.ENABLE_MAINTENANCE_PAGE ?? ''
 
   // Other vars.
   let errorCode: number | null = null
@@ -193,6 +201,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res, locale,
       userArrivedFromUioMobile: userArrivedFromUioMobile,
       urlPrefixes: URL_PREFIXES,
       enableGoogleAnalytics: ENABLE_GOOGLE_ANALYTICS,
+      enableMaintenancePage: ENABLE_MAINTENANCE_PAGE,
       ...(await serverSideTranslations(locale || 'en', ['common', 'claim-details', 'claim-status'])),
     },
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -64,28 +64,20 @@ export default function Home({
   )
 
   // If any errorCode is provided, render the error page.
-  let mainComponent: JSX.Element
+  let mainContent: JSX.Element
   if (errorCode) {
-    mainComponent = (
-      <main className="main">
-        <Container className="main-content">
-          <Error userArrivedFromUioMobile />
-        </Container>
-      </main>
-    )
+    mainContent = <Error userArrivedFromUioMobile />
   } else {
-    mainComponent = (
-      <main className="main">
-        <Container className="main-content">
-          <Title />
-          <ClaimSection
-            loading={loading}
-            userArrivedFromUioMobile={userArrivedFromUioMobile}
-            statusContent={scenarioContent.statusContent}
-            detailsContent={scenarioContent.detailsContent}
-          />
-        </Container>
-      </main>
+    mainContent = (
+      <>
+        <Title />
+        <ClaimSection
+          loading={loading}
+          userArrivedFromUioMobile={userArrivedFromUioMobile}
+          statusContent={scenarioContent.statusContent}
+          detailsContent={scenarioContent.detailsContent}
+        />
+      </>
     )
   }
 
@@ -104,7 +96,9 @@ export default function Home({
         {enableGoogleAnalytics === 'enabled' && googleAnalytics}
       </Head>
       <Header userArrivedFromUioMobile={userArrivedFromUioMobile} />
-      {mainComponent}
+      <main className="main">
+        <Container className="main-content">{mainContent}</Container>
+      </main>
       <TimeoutModal userArrivedFromUioMobile={userArrivedFromUioMobile} timedOut={timedOut} urlPrefixes={urlPrefixes} />
       <Footer />
     </Container>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -20,6 +20,7 @@
       "entry": "We are unable to perform your request."
     }
   },
+  "maintenance": "We'll be back soon",
   "claim-status": {
     "title": "Claim Status",
     "your-next-steps": "Your Next Steps",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -20,7 +20,11 @@
       "entry": "We are unable to perform your request."
     }
   },
-  "maintenance": "We'll be back soon",
+  "maintenance": {
+    "label": "We'll be back soon",
+    "entry": "This page is currently unavailable.",
+    "entry2": "Thank you for your patience as we continue to improve our services."
+  },
   "claim-status": {
     "title": "Claim Status",
     "your-next-steps": "Your Next Steps",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -21,8 +21,8 @@
     }
   },
   "maintenance": {
-    "label": "We'll be back soon",
-    "entry": "This page is currently unavailable.",
+    "label": "We'll Be Back Soon",
+    "entry": "This page is currently unavailable during system maintenance.",
     "entry2": "Thank you for your patience as we continue to improve our services."
   },
   "claim-status": {

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -20,6 +20,7 @@
       "entry": "We are unable to perform your request."
     }
   },
+  "maintenance": "We'll be back soon",
   "claim-status": {
     "title": "Estatus de solicitud",
     "your-next-steps": "Sus próximos pasos",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -20,7 +20,11 @@
       "entry": "We are unable to perform your request."
     }
   },
-  "maintenance": "We'll be back soon",
+  "maintenance": {
+    "label": "We'll be back soon",
+    "entry": "This page is currently unavailable.",
+    "entry2": "Thank you for your patience as we continue to improve our services."
+  },
   "claim-status": {
     "title": "Estatus de solicitud",
     "your-next-steps": "Sus próximos pasos",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -21,8 +21,8 @@
     }
   },
   "maintenance": {
-    "label": "We'll be back soon",
-    "entry": "This page is currently unavailable.",
+    "label": "We'll Be Back Soon",
+    "entry": "This page is currently unavailable during system maintenance.",
     "entry2": "Thank you for your patience as we continue to improve our services."
   },
   "claim-status": {


### PR DESCRIPTION
This PR adds a down-for-maintenance page that can be manually enabled by setting a new ENABLE_MAINTENANCE_PAGE environment variable to 'enabled'. 

===

Resolves #376

- [ ] Relevant documentation (e.g. READMEs, Technical Foundation) updated
- [ ] Issue AC are copied to this PR & are met
- [ ] Manual Browser Testing performed (with modheader, either locally or on BrowserStack)
- [ ] Changes are tested on Staging post-merge into `main`
