### PR TITLE
Remove default argument values in InfoField

### DIFF
--- a/components/InfoField.tsx
+++ b/components/InfoField.tsx
@@ -6,11 +6,7 @@ export interface InfoFieldProps {
   text: string
 }
 
-export const InfoField: React.FC<InfoFieldProps> = ({
-  loading = false,
-  label = 'Label text!',
-  text = 'Field text!',
-}) => {
+export const InfoField: React.FC<InfoFieldProps> = ({ loading = false, label, text }) => {
   if (loading) {
     return <ShimmerField />
   }

--- a/stories/InfoField.stories.tsx
+++ b/stories/InfoField.stories.tsx
@@ -10,4 +10,7 @@ export default {
 const Template: Story<InfoFieldProps> = (args) => <InfoFieldComponent {...args} />
 
 export const InfoField = Template.bind({})
-InfoField.args = {}
+InfoField.args = {
+  label: 'Label text!',
+  text: 'Field text!',
+}


### PR DESCRIPTION
## Ticket

Resolves #462 

## Changes

- Removes default arg values in `<InfoField>`
- Adds args to InfoField story

## Context

We should remove the possibility of displaying default/placeholder text on prod.

## Testing

Review storybook.

## Checklist

- N/A Relevant documentation (e.g. READMEs, Technical Foundation) updated
- N/A Issue AC are copied to this PR & are met
- [x] Manual Browser Testing performed (with modheader, either locally or on BrowserStack)
- [ ] Changes are tested on Staging post-merge into `main`
