### PR TITLE
Missing Application Insights environment variable should not disrupt claimant experience

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -139,10 +139,8 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res, locale,
   try {
     await logger.initialize()
   } catch (error) {
-    // If we are unable to set up logging, return 500 and log to console.
-    // As long as server-preload.js is configured with setAutoCollectConsole(true, true),
-    // this console.log will be logged in Application Insights.
-    errorCode = 500
+    // If we are unable to set up logging, log to console.
+    // This is accessible in Azure Monitor AppServiceHTTPLogs.
     console.log(error)
   }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -140,7 +140,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res, locale,
     await logger.initialize()
   } catch (error) {
     // If we are unable to set up logging, log to console.
-    // This is accessible in Azure Monitor AppServiceHTTPLogs.
+    // This is accessible in Azure Monitor AppServiceConsoleLogs.
     console.log(error)
   }
 

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -80,7 +80,7 @@ export class Logger {
   // eslint-disable-next-line @typescript-eslint/ban-types
   log(logFn: LogFunction, mergingObject: object, message: string): void {
     if (this.pino === undefined) {
-      console.log('Pino is undefined')
+      console.log('Pino is undefined. Application will not log requests until corrected.')
     } else {
       if (mergingObject) {
         this.pino[logFn](mergingObject, message)

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -80,7 +80,7 @@ export class Logger {
   // eslint-disable-next-line @typescript-eslint/ban-types
   log(logFn: LogFunction, mergingObject: object, message: string): void {
     if (this.pino === undefined) {
-      throw new Error('Pino is undefined')
+      console.log('Pino is undefined')
     } else {
       if (mergingObject) {
         this.pino[logFn](mergingObject, message)


### PR DESCRIPTION
## Ticket

Resolves #468 

## Changes

- Do not display 500 for missing Application Insights environment variable
- Do not throw errors if logger is not working

## Context

If the Application Insights environment variable is missing, we should log an error and get an alert. However, it does not actually impact CST behavior and so we should not unnecessarily disrupt the claimant experience. 

## Testing

- Checkout this branch
- Comment out most of the code in `logger.ts:initialize()` and only throw an error. https://github.com/cagov/ui-claim-tracker/blob/72d5437615433f590f792d12461ad9c9290355ab/utils/logger.ts#L52-L75
- Run `yarn dev` and confirm the application loads as expected and that the appropriate `console.log()` messages are logged

## Checklist 

- N/A Relevant documentation (e.g. READMEs, Technical Foundation) updated
- [x] Issue AC are copied to this PR & are met
- [x] Manual Browser Testing performed (with modheader, either locally or on BrowserStack)
- [ ] Changes are tested on Staging post-merge into `main`
