### PR TITLE
Add an environment variable for more flexibility for static asset path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repo contains the Claim Status Tracker app, which helps Californians better
   - URL_PREFIX_UIO_DESKTOP
   - URL_PREFIX_UIO_MOBILE
   - URL_PREFIX_BPO
-- (Optional) ASSET_PREFIX: The static asset path (default is `/claimstatus`)
+- ASSET_PREFIX: The static asset path (default is `/claimstatus`; this env var is required for local development)
 
 For local development:
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ This repo contains the Claim Status Tracker app, which helps Californians better
   - URL_PREFIX_UIO_DESKTOP
   - URL_PREFIX_UIO_MOBILE
   - URL_PREFIX_BPO
+- (Optional) ASSET_PREFIX: The static asset path (default is `/claimstatus`)
 
 For local development:
 
 1. Create a `.env.local` file in the root of this repo
 2. Define each of the environment variables above
    - Nava Engineers - see Vault for preconfigured `.env.local`
+   - Set `ASSET_PREFIX` to `""`
 3. Configure a test header
    - Configure ModHeader ([firefox](https://addons.mozilla.org/en-US/firefox/addon/modheader-firefox/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=search)/[chrome](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj?hl=en)) to send the ID_HEADER_NAME defined header value to the local dev environment - see Vault for value. Also, we recommend limiting ModHeader to only modify `localhost:3000`
    - Please add nava_test=YOUR_NAME as an additional header to make it easier to distinguish ModHeader queries

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,12 @@
 const { i18n } = require('./next-i18next.config')
 
-const isAzureEnv = process.env.NODE_ENV === 'production'
+const assetPrefix =
+  process.env.ASSET_PREFIX === 'undefined' || process.env.ASSET_PREFIX === undefined
+    ? '/claimstatus'
+    : process.env.ASSET_PREFIX
 
 module.exports = {
-  assetPrefix: isAzureEnv ? '/claimstatus' : '',
+  assetPrefix: assetPrefix,
   i18n,
   webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
     config.resolve.fallback = {

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -18,8 +18,10 @@ export default function Custom404({ userArrivedFromUioMobile = false }: Custom40
   const { t } = useTranslation('common')
 
   // We need to route our static content through /claimstatus to work properly through EDD
-  const isAzureEnv = process.env.NODE_ENV === 'production'
-  const assetPrefix = isAzureEnv ? '/claimstatus' : ''
+  const assetPrefix =
+    process.env.ASSET_PREFIX === 'undefined' || process.env.ASSET_PREFIX === undefined
+      ? '/claimstatus'
+      : process.env.ASSET_PREFIX
   const favicon = assetPrefix + '/favicon.ico'
 
   function redirectToUIHome() {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,7 +25,7 @@ export interface HomeProps {
   loading: boolean
   errorCode?: number | null
   userArrivedFromUioMobile?: boolean
-  isAzureEnv?: boolean
+  assetPrefix: string
   urlPrefixes: UrlPrefixes
   enableGoogleAnalytics: string
   enableMaintenancePage: string
@@ -37,7 +37,7 @@ export default function Home({
   loading,
   errorCode = null,
   userArrivedFromUioMobile = false,
-  isAzureEnv = false,
+  assetPrefix,
   urlPrefixes,
   enableGoogleAnalytics,
   enableMaintenancePage,
@@ -45,7 +45,6 @@ export default function Home({
   const { t } = useTranslation('common')
 
   // We need to route our static content through /claimstatus to work properly through EDD
-  const assetPrefix = isAzureEnv ? '/claimstatus' : ''
   const favicon = assetPrefix + '/favicon.ico'
 
   // Once CSP is enabled, if you change the GA script code, you need to update the hash in csp.js to allow
@@ -120,7 +119,10 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res, locale,
   // Note whether the user came from the main UIO website or UIO Mobile, and match
   // that in our links back out to UIO.
   const userArrivedFromUioMobile = query?.from === 'uiom'
-  const isAzureEnv = process.env.NODE_ENV === 'production'
+  const assetPrefix =
+    process.env.ASSET_PREFIX === 'undefined' || process.env.ASSET_PREFIX === undefined
+      ? '/claimstatus'
+      : process.env.ASSET_PREFIX
 
   // Environment-specific links to UIO, UIO Mobile, and BPO, used by EDD testing
   // Note: it's not possible to use the NEXT_PUBLIC_ prefix to expose these env vars to the browser
@@ -204,7 +206,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res, locale,
       loading: false,
       errorCode: errorCode,
       userArrivedFromUioMobile: userArrivedFromUioMobile,
-      isAzureEnv: isAzureEnv,
+      assetPrefix: assetPrefix,
       urlPrefixes: URL_PREFIXES,
       enableGoogleAnalytics: ENABLE_GOOGLE_ANALYTICS,
       enableMaintenancePage: ENABLE_MAINTENANCE_PAGE,


### PR DESCRIPTION
## Ticket

Resolves #512 

## Changes

- Adds an environment variable `ASSET_PREFIX`

## Context

This PR decouples the static asset path from whether the app is running in an Azure environment vs a non-Azure environment. It introduces a new optional environment variable `ASSET_PREFIX` that allows us to more easily control the asset prefix (i.e. Azure environments that don't have Front Door url rewriting can still work). The app by default assumes the static asset prefix should be `/claimstatus`. The environment variable allows us to _override_ the default to be something else (typically should be `""`).

## Testing

- [x] Locally, `ASSET_PREFIX=""` should work correctly
- [x] Locally, not setting an `ASSET_PREFIX` env var should _not_ work
- [x] In Azure, `ASSET_PREFIX=""` should work correctly for environments that _don't_ have Front Door url rewriting enabled
- [x] In Azure, not setting an `ASSET_PREFIX` env var should work correctly for environments that _do_ have Front Door url rewriting