### PR TITLE
Add a comment to avoid throwing errors from within logger.log()

### DIFF
--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -104,6 +104,10 @@ export class Logger {
 
   /**
    * Wrapper for all pino log functions.
+   *
+   * Important note! Do not `throw` any errors from inside this function. This
+   * function is often called from within a catch block and throwing a function
+   * at that stage will break the application in an undesirable way.
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
   log(childLogger: pino.Logger | null, logFn: LogFunction, mergingObject: object, message: string): void {


### PR DESCRIPTION
## Ticket

- Resolves #471 

## Changes

- Adds a comment

## Context

In #471, we identified that uncaught errors will cause the application to display an unrendered and untranslated 500 error page. After researching this issue, I came to the conclusion that there isn't an easy technical solution. We have already put all of our function calls inside `try/catch` blocks. 

It is possible to generate an uncaught error if you `throw new Error()` inside of `logger.log()`. That's what caused the issue in #471. However, we have already removed that throw. This PR adds a comment to `logger.log()` to warn future developers away from accidentally re-introducing this issue.