### PR TITLE
Add updated BYE scenario logic for FED-ED

### DIFF
--- a/tests/utils/formatDate.test.ts
+++ b/tests/utils/formatDate.test.ts
@@ -1,6 +1,12 @@
 import { DateTime } from 'luxon'
 
-import formatDate, { formatFromApiGateway, isDatePast, isDateStringFalsy, isValidDate } from '../../utils/formatDate'
+import formatDate, {
+  formatFromApiGateway,
+  isDatePast,
+  isDateStringFalsy,
+  isFirstDateBefore,
+  isValidDate,
+} from '../../utils/formatDate'
 import { Logger } from '../../utils/logger'
 
 // Test isValidDate()
@@ -64,6 +70,22 @@ describe('Past dates: A date is', () => {
   it('correctly identified as not past if it is in the future', () => {
     const tomorrow = DateTime.now().plus({ days: 1 })
     expect(isDatePast(tomorrow)).toBe(false)
+  })
+})
+
+// Test isFirstDateBefore()
+describe('Comparing dates: The first date is', () => {
+  const yesterday = formatFromApiGateway(-1)
+  const tomorrow = formatFromApiGateway(1)
+
+  it('correctly identified as being before', () => {
+    expect(isFirstDateBefore(yesterday, tomorrow)).toBe(true)
+  })
+  it('correctly identified as being after', () => {
+    expect(isFirstDateBefore(tomorrow, yesterday)).toBe(false)
+  })
+  it('correctly identified as being after if the second date is equivalent', () => {
+    expect(isFirstDateBefore(yesterday, yesterday)).toBe(false)
   })
 })
 

--- a/tests/utils/getScenarioContent.test.ts
+++ b/tests/utils/getScenarioContent.test.ts
@@ -72,7 +72,7 @@ describe('The BYE scenarios (scenarios 7, 8, 9, 10, 11, 12)', () => {
     ['UI', ScenarioType.Scenario7],
     ['PUA', ScenarioType.Scenario8],
     ['DUA', ScenarioType.Scenario9],
-    ['Other Extension', ScenarioType.Scenario10],
+    ['Old Extension', ScenarioType.Scenario10],
     ['Pandemic Extension', ScenarioType.Scenario11],
     ['FED-ED Extension', ScenarioType.Scenario12],
   ]
@@ -135,6 +135,13 @@ describe('The BYE scenarios (scenarios 7, 8, 9, 10, 11, 12)', () => {
     const scenarioObject = getScenario(byeInvalidProgram)
     expect(scenarioObject.scenarioType).not.toBe(ScenarioType.Scenario7)
     expect(scenarioObject.scenarioType).toBe(ScenarioType.Scenario5)
+  })
+
+  it('FED-ED prior to cutoff date should return Scenario 10', () => {
+    const scenarioObject = getScenario(
+      apiGatewayStub(ScenarioType.Scenario12, false, true, 'FED-ED', '2016-10-05T00:00:00'),
+    )
+    expect(scenarioObject.scenarioType).toBe(ScenarioType.Scenario10)
   })
 })
 

--- a/tests/utils/getScenarioContent.test.ts
+++ b/tests/utils/getScenarioContent.test.ts
@@ -143,6 +143,25 @@ describe('The BYE scenarios (scenarios 7, 8, 9, 10, 11, 12)', () => {
     )
     expect(scenarioObject.scenarioType).toBe(ScenarioType.Scenario10)
   })
+
+  const falseyBenefitYearEndDates = [
+    ['null', null],
+    ['undefined', undefined],
+    ['empty string', ''],
+  ]
+  it.each(falseyBenefitYearEndDates)(
+    'FED-ED with %s benefit year end date throws an error',
+    (description, benefitYearEndDate) => {
+      const invalidByeProgram = apiGatewayStub(ScenarioType.Scenario12, false, false, 'FED-ED', benefitYearEndDate)
+      // Create an invalid claim object by removing benefitYearEndDate.
+      if (benefitYearEndDate === undefined) {
+        delete invalidByeProgram.claimDetails.benefitYearEndDate
+      }
+      expect(() => {
+        getScenario(invalidByeProgram)
+      }).toThrowError('Claim is marked as isBYE, but is missing benefit year end date value')
+    },
+  )
 })
 
 /**

--- a/utils/apiGatewayStub.ts
+++ b/utils/apiGatewayStub.ts
@@ -16,6 +16,7 @@ export default function apiGatewayStub(
   hasCertificationWeeksAvailable = false,
   hasClaimDetails = true,
   programType = 'UI',
+  benefitYearEndDate = '2021-03-20T00:00:00',
 ): Claim {
   // Default empty response from the API gateway
   const claim: Claim = {
@@ -133,7 +134,7 @@ export default function apiGatewayStub(
     claim.claimDetails = {
       programType: programType,
       benefitYearStartDate: '2020-03-21T00:00:00',
-      benefitYearEndDate: '2021-03-20T00:00:00',
+      benefitYearEndDate: benefitYearEndDate,
       claimBalance: 1100.45,
       weeklyBenefitAmount: 111,
       lastPaymentIssued: '2021-04-29T00:00:00',

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -102,6 +102,18 @@ export function isDatePast(date: DateTime): boolean {
 }
 
 /**
+ * Determine if the first date is before (not equal to) the second date.
+ */
+export function isFirstDateBefore(
+  firstDateString: ApiGatewayDateString,
+  secondDateString: ApiGatewayDateString,
+): boolean {
+  const firstDate = parseApiGatewayDate(firstDateString)
+  const secondDate = parseApiGatewayDate(secondDateString)
+  return firstDate < secondDate
+}
+
+/**
  * Format dates for user-facing display.
  *
  * Does not care if the given dateString is a valid date.

--- a/utils/getScenarioContent.ts
+++ b/utils/getScenarioContent.ts
@@ -254,6 +254,8 @@ export function byeScenario(claimData: Claim): ScenarioType | null {
           } else {
             return ScenarioType.Scenario12
           }
+        } else {
+          throw new Error('Claim is marked as isBYE, but is missing benefit year end date value')
         }
     }
   }

--- a/utils/getScenarioContent.ts
+++ b/utils/getScenarioContent.ts
@@ -10,7 +10,7 @@
 import { Claim, ClaimDetailsContent, PendingDetermination, ScenarioContent } from '../types/common'
 import getClaimDetails from './getClaimDetails'
 import getClaimStatus from './getClaimStatus'
-import { isDatePast, isDateStringFalsy, isValidDate, parseApiGatewayDate } from './formatDate'
+import { isDatePast, isDateStringFalsy, isFirstDateBefore, isValidDate, parseApiGatewayDate } from './formatDate'
 import { isFirstTimeSlotEarlier } from './timeSlot'
 
 export enum ScenarioType {
@@ -226,6 +226,7 @@ export function isBenefitYearExpired(claimData: Claim): boolean {
  **/
 export function byeScenario(claimData: Claim): ScenarioType | null {
   const programType = claimData.claimDetails?.programType
+  const benefitYearEndDate = claimData.claimDetails?.benefitYearEndDate
 
   if (programType) {
     if (isOldExtension(programType)) {
@@ -243,8 +244,17 @@ export function byeScenario(claimData: Claim): ScenarioType | null {
         return ScenarioType.Scenario8
       case 'DUA':
         return ScenarioType.Scenario9
+
+      // BYE scenarios with the Program Type 'FED-ED' are treated differently depending
+      // on whether the benefitYearEndDate is before or on/after 2020-05-10.
       case 'FED-ED Extension':
-        return ScenarioType.Scenario12
+        if (benefitYearEndDate) {
+          if (isFirstDateBefore(benefitYearEndDate, '2020-05-10T00:00:00')) {
+            return ScenarioType.Scenario10
+          } else {
+            return ScenarioType.Scenario12
+          }
+        }
     }
   }
 


### PR DESCRIPTION
## Ticket

- Resolves #539 

## Changes

- Adds logic to handle BYE scenarios for FED-ED program type based on benefitYearEndDate
- Adds a helper function for comparing date strings

## Context

Scenario 10 logic should be updated from just EUC, EUX,  EUY, EUW, EUZ to:
- matching EUC, EUX,  EUY, EUW, EUZ
- OR FED-ED if `benefitYearEndDate` is before 05/10/2020

Scenario 12 logic should be updated from any FED-ED to:
- FED-ED only if `benefitYearEndDate` is on or after 05/10/2020

Edge case is covered: If `isBYE` is true AND `programType` is `FED-ED Extension` AND `benefitYearEndDate` is javascript falsey (e.g. undefined, null, empty string, etc), then throw an error.

## Testing

- [x] Test against dev for a claim that has `isBYE=true`, `programType=FED-ED`, and `benefitYearEndDate<5/10/2020` == Scenario 10
- [x] Test against dev for a claim that has `isBYE=true`, `programType=FED-ED`, and `benefitYearEndDate>=5/10/2020` == Scenario 12
- [x] Test against latest https://github.com/rocketnova/ca-ui-mini-api-mock and use unique number `invalid_feded_bye` == error
