### PR TITLE
Updates Spanish claim status section headers

### DIFF
--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -33,9 +33,9 @@
     "entry2": "Thank you for your patience as we continue to improve our services."
   },
   "claim-status": {
-    "title": "Estatus de solicitud",
-    "your-next-steps": "Sus próximos pasos",
-    "edd-next-steps": "Próximos pasos del EDD"
+    "title": "Estatus de la solicitud",
+    "your-next-steps": "Sus siguientes pasos",
+    "edd-next-steps": "Siguientes pasos del EDD"
   },
   "claim-details": {
     "title": "Detalles de la solicitud",


### PR DESCRIPTION
<!-- Write a description below of the changes in this pull request. 
Include images/GIFs if relevant for reviewers. Try Firefox (right-click -> Take Screenshot) for full-page screenshots and LICEcap (macOS) or Peek (ubuntu) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items. -->


[See Storybook](https://60705d04dcad7600211e34d2-fitgkrisle.chromatic.com/) to confirm!


---

 - [ ] CST showing “Estatus de solicitud” instead of “Estatus de la solicitud”
 - [ ] CST showing “Sus proximos pasos” instead of “Sus siguientes pasos”
 - [ ] CST showing “Proximos pasos del EDD” instead of “Siguientes pasos del EDD”