### PR TITLE
Track individual scenarios in Google Analytics

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -50,9 +50,16 @@ export default function Home({
   // We need to route our static content through /claimstatus to work properly through EDD
   const favicon = assetPrefix + '/favicon.ico'
 
-  // Once CSP is enabled, if you change the GA script code, you need to update the hash in csp.js to allow
-  // this script to run. Chrome dev tools will have an error with the correct hash value to use.
-  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#Unsafe_inline_script
+  // Get scenario name to display in Google Analytics.
+  // Default to "None" if no scenario is passed through. This can happen in error cases.
+  const scenarioDimension = scenarioContent?.scenarioName ?? 'None'
+
+  // - Once CSP is enabled, if you change the GA script code, you need to update the hash in csp.js to allow
+  //   this script to run. Chrome dev tools will have an error with the correct hash value to use.
+  //   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#Unsafe_inline_script
+  // - Send custom dimensions to EDD google analytics instance to capture data about scenarios.
+  //   Dimension 2 has been configured in the GA UI for CST Scenarios.
+  //   https://developers.google.com/analytics/devguides/collection/gtagjs/custom-dims-mets#send-custom-dimensions
   const gaScript = `
         window.dataLayer = window.dataLayer || []
         function gtag(){dataLayer.push(arguments)}
@@ -60,7 +67,13 @@ export default function Home({
         // For details see: https://support.google.com/analytics/answer/9310895?hl=en
         // https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization
         gtag('config', 'UA-3419582-2', { 'anonymize_ip': true }) // www.ca.gov
-        gtag('config', 'UA-3419582-31', { 'anonymize_ip': true }) // edd.ca.gov`
+        gtag('config', 'UA-3419582-31', { 'anonymize_ip': true, 'custom_map': {'dimension2': 'scenario'} }) // edd.ca.gov
+        gtag('event', 'CST Scenario', {
+          "scenario": "${scenarioDimension}",
+          "event_category": "Claim Status Tracker",
+          "event_label": "${scenarioDimension}",
+          "non_interaction": true
+        })`
 
   const googleAnalytics = (
     <>

--- a/types/common.ts
+++ b/types/common.ts
@@ -90,6 +90,7 @@ export interface ClaimDetailsContent {
 }
 
 export interface ScenarioContent {
+  scenarioName?: string
   statusContent: ClaimStatusContent
   detailsContent: null | ClaimDetailsContent
 }

--- a/utils/getScenarioContent.ts
+++ b/utils/getScenarioContent.ts
@@ -29,18 +29,18 @@ export enum ScenarioType {
 }
 
 export const ScenarioTypeNames = {
-  [ScenarioType.Scenario1]: 'Determination interview: not yet scheduled',
-  [ScenarioType.Scenario2]: 'Determination interview: scheduled',
-  [ScenarioType.Scenario3]: 'Determination interview: awaiting decision',
-  [ScenarioType.Scenario4]: 'Generic pending state: pending weeks',
-  [ScenarioType.Scenario5]: 'Base state: no pending weeks, no weeks to certify',
-  [ScenarioType.Scenario6]: 'Base state: no pending weeks, weeks to certify',
-  [ScenarioType.Scenario7]: 'Benefit year end: Regular UI',
-  [ScenarioType.Scenario8]: 'Benefit year end: PUA',
-  [ScenarioType.Scenario9]: 'Benefit year end: DUA',
-  [ScenarioType.Scenario10]: 'Benefit year end: Old Extensions',
-  [ScenarioType.Scenario11]: 'Benefit year end: Pandemic Extensions',
-  [ScenarioType.Scenario12]: 'Benefit year end: FED-ED Extension',
+  [ScenarioType.Scenario1]: 'Pending Eligibility: Phone Interview Will Be Scheduled',
+  [ScenarioType.Scenario2]: 'Pending Eligibility: Phone Interview Scheduled',
+  [ScenarioType.Scenario3]: 'Pending Eligibility: Under Review',
+  [ScenarioType.Scenario4]: 'Review Required',
+  [ScenarioType.Scenario5]: 'No Weeks Available to Certify',
+  [ScenarioType.Scenario6]: 'Weeks Available to Certify',
+  [ScenarioType.Scenario7]: 'Benefit Year Has Ended',
+  [ScenarioType.Scenario8]: 'Pandemic Unemployment Assistance Has Ended',
+  [ScenarioType.Scenario9]: 'Disaster Unemployment Assistance Has Ended',
+  [ScenarioType.Scenario10]: 'Federal Unemployment Benefits Have Ended',
+  [ScenarioType.Scenario11]: 'Pandemic Emergency Unemployment Compensation Has Ended',
+  [ScenarioType.Scenario12]: 'Federal-State Extended Duration Benefits Have Ended',
 }
 
 interface PendingDeterminationScenario {

--- a/utils/getScenarioContent.ts
+++ b/utils/getScenarioContent.ts
@@ -346,6 +346,7 @@ export default function getScenarioContent(claimData: Claim): ScenarioContent {
   }
 
   const content: ScenarioContent = {
+    scenarioName: ScenarioTypeNames[scenarioType],
     statusContent: statusContent,
     detailsContent: detailsContent,
   }


### PR DESCRIPTION
## Ticket

- Resolves #327 

## Changes

- Updates `getScenarioContent()` to return the scenario name
- Updates scenario names to match EDD naming 
- Passes scenario name to Google Analytics as a custom dimension

## Testing

It's not easy to test Google Analytics because we don't want to send test data to production Google Analytics instances. I've created a sandbox GA instance that we can send test data to.

1. Check out branch `rocket/327-ga-testing`
2. Compare branch `rocket/327-ga` against `rocket/327-ga-testing` and confirm that the only differences are the specific GA instance ID and the dimension number
3. Edit `.env.local` and set `ENABLE_GOOGLE_ANALYTICS="enabled"`
4. Run `yarn dev` and navigate to `localhost:3000` in your browser with modheader set to a valid unique number
5. Wait some amount of time for the data to correctly propagate to GA
6. Log into analytics.google.com and navigate to the test GA sandbox property
7. Navigate to Behavior > Site Content > All Pages
8. Set the date to include the date you navigated to `localhost:3000` in step 4 above
9. Set a secondary dimension: Secondary dimension > custom dimensions > scenario
10. Verify your visit is logged