### PR TITLE
Add storybook for NextStepsList

### DIFF
--- a/components/NextSteps.tsx
+++ b/components/NextSteps.tsx
@@ -5,7 +5,7 @@ import { TransLineContent } from '../types/common'
 export interface NextStepsProps {
   loading: boolean
   userArrivedFromUioMobile: boolean
-  header: string[]
+  header: string
   nextSteps: Array<TransLineContent | TransLineContent[]>
 }
 

--- a/stories/NextSteps.stories.tsx
+++ b/stories/NextSteps.stories.tsx
@@ -10,6 +10,7 @@ const Template: Story<NextStepsProps> = (args) => <NextStepsComponent {...args} 
 
 export const NextSteps = Template.bind({})
 NextSteps.args = {
+  header: 'EDD Next Steps',
   nextSteps: [
     {
       i18nKey: 'claim-status:scenarios.scenario1.your-next-steps.0.text',

--- a/stories/NextStepsList.stories.tsx
+++ b/stories/NextStepsList.stories.tsx
@@ -1,0 +1,32 @@
+import { Story, Meta } from '@storybook/react'
+import { NextStepsList as NextStepsListComponent, NextStepsListProps } from '../components/NextStepsList'
+
+export default {
+  title: 'Component/Atoms/Next Steps List',
+  component: NextStepsListComponent,
+} as Meta
+
+const Template: Story<NextStepsListProps> = (args) => <NextStepsListComponent {...args} />
+
+export const NextStepsList = Template.bind({})
+NextStepsList.args = {
+  nextSteps: [
+    [
+      {
+        i18nKey: 'claim-status:scenarios.scenario1.your-next-steps.0.text',
+      },
+      {
+        i18nKey: 'Sub bullet 1',
+      },
+      {
+        i18nKey: 'Sub bullet 2',
+      },
+      {
+        i18nKey: 'Sub bullet 3',
+      },
+      {
+        i18nKey: 'Sub bullet 4',
+      },
+    ],
+  ],
+}


### PR DESCRIPTION
## Ticket

- Resolves #355 

## Changes

- Adds a storybook story for `<NextStepsList>`
- Fixes typing for `NextStepsProps`

## Context

See https://github.com/cagov/ui-claim-tracker/pull/349#pullrequestreview-719230796

## Testing

- `yarn storybook`