### PR TITLE
Refactor azure pipeline tasks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,11 @@ pr: none
 pool:
   vmImage: 'ubuntu-latest'
 
+# Disable next.js telemetry
+variables:
+  - name: 'NEXT_TELEMETRY_DISABLED'
+    value: '1'
+
 steps:
   - task: NodeAndNpmTool@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,14 +37,40 @@ steps:
   - script: yarn build
     displayName: 'Run yarn build'
 
+  # Docs: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/copy-files?view=azure-devops&tabs=yaml
+  # Default files needed to run yarn start: https://github.com/vercel/next.js/blob/0af3b526408bae26d6b3f8cab75c4229998bf7cb/examples/with-docker/Dockerfile
+  # Note: CST also needs a few additional config/startup files to run
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: '$(Build.SourcesDirectory)'
+      contents: |
+        package.json
+        .next/**
+        node_modules/**
+        public/**
+        next.config.js
+        next-i18next.config.js
+        server-preload.js
+      targetFolder: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId)'
+    displayName: 'Copy files needed for yarn start'
+
+  # Docs: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/archive-files
+  # Note: Zip up only the necessary files
   - task: ArchiveFiles@2
     inputs:
-      rootFolderOrFile: '$(Build.SourcesDirectory)'
+      rootFolderOrFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId)'
       includeRootFolder: false
-    displayName: 'Zip build files'
+    displayName: 'Zip files needed for yarn start'
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish artifacts: drop'
+  # Docs: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/publish-pipeline-artifact
+  # Docs: https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts
+  # Docs: https://docs.microsoft.com/en-us/azure/app-service/deploy-run-package
+  # Publish the zip to deploy to App Service using a package, which mounts the zip as a read-only dir
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
+      artifactName: '$(Build.BuildId)'
+    displayName: 'Publish artifact: $(Build.BuildId)'
 
   - task: Veracode@3
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,47 +4,49 @@
 # https://aka.ms/yaml
 
 trigger:
-- main
-
+  - main
 
 # no PR triggers
 pr: none
 
 pool:
-  vmImage: "ubuntu-latest"
+  vmImage: 'ubuntu-latest'
 
 steps:
   - task: NodeAndNpmTool@1
     inputs:
       versionSpec: '14.x'
       checkLatest: true
+    displayName: 'Install node'
 
   - script: sudo npm install -g yarn
+    displayName: 'Install yarn'
 
   - script: yarn install
     displayName: 'Install dependencies'
 
   - script: yarn build
-    displayName: 'build'
+    displayName: 'Run yarn build'
 
   - task: ArchiveFiles@2
     inputs:
-      rootFolderOrFile: "$(build.sourcesDirectory)"
+      rootFolderOrFile: '$(Build.SourcesDirectory)'
       includeRootFolder: false
+    displayName: 'Zip build files'
 
   - script: zip -r --symlinks '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip' .
     displayName: 'ZIP com SymLinks'
 
   - task: PublishBuildArtifacts@1
-    displayName: "Publish artifacts: drop"
+    displayName: 'Publish artifacts: drop'
 
   - task: Veracode@3
-    displayName: 'Upload and scan: $(build.artifactstagingdirectory)'
     inputs:
       ConnectionDetailsSelection: 'Endpoint'
       AnalysisService: 'veracode'
       veracodeAppProfile: 'uiclaim.tracker'
-      version: '$(build.buildNumber)'
+      version: '$(Build.BuildNumber)'
       filepath: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
       createProfile: true
     continueOnError: true
+    displayName: 'Upload and scan: $(Build.ArtifactStagingDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ variables:
     value: '1'
 
 steps:
-  # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/node-js?view=azure-devops
+  # Docs: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/node-js
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
@@ -28,7 +28,10 @@ steps:
   - script: sudo npm install -g yarn
     displayName: 'Install yarn'
 
-  - script: yarn install
+  # Docs: https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-no-bin-links
+  # Zipping files with symlinks introduces a potential security vulnerability, so we use
+  #   --no-bin-links to prevent symlinks from being created in node_modules.
+  - script: yarn install --no-bin-links
     displayName: 'Install dependencies'
 
   - script: yarn build
@@ -39,9 +42,6 @@ steps:
       rootFolderOrFile: '$(Build.SourcesDirectory)'
       includeRootFolder: false
     displayName: 'Zip build files'
-
-  - script: zip -r --symlinks '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip' .
-    displayName: 'ZIP com SymLinks'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifacts: drop'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ pool:
   vmImage: 'ubuntu-latest'
 
 # Disable next.js telemetry
+# Docs: https://nextjs.org/telemetry
 variables:
   - name: 'NEXT_TELEMETRY_DISABLED'
     value: '1'
@@ -28,18 +29,18 @@ steps:
   - script: sudo npm install -g yarn
     displayName: 'Install yarn'
 
-  # Docs: https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-no-bin-links
   # Zipping files with symlinks introduces a potential security vulnerability, so we use
   #   --no-bin-links to prevent symlinks from being created in node_modules.
+  # Docs: https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-no-bin-links
   - script: yarn install --no-bin-links
     displayName: 'Install dependencies'
 
   - script: yarn build
     displayName: 'Run yarn build'
 
-  # Docs: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/copy-files?view=azure-devops&tabs=yaml
+  # CST needs the default next.js files plus a few additional config/startup files to run
+  # Docs: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/copy-files
   # Default files needed to run yarn start: https://github.com/vercel/next.js/blob/0af3b526408bae26d6b3f8cab75c4229998bf7cb/examples/with-docker/Dockerfile
-  # Note: CST also needs a few additional config/startup files to run
   - task: CopyFiles@2
     inputs:
       sourceFolder: '$(Build.SourcesDirectory)'
@@ -54,18 +55,23 @@ steps:
       targetFolder: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId)'
     displayName: 'Copy files needed for yarn start'
 
+  # Zip up only the necessary files
   # Docs: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/archive-files
-  # Note: Zip up only the necessary files
   - task: ArchiveFiles@2
     inputs:
       rootFolderOrFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId)'
       includeRootFolder: false
     displayName: 'Zip files needed for yarn start'
 
+  # Publish the zip to deploy to App Service using a package, which mounts the zip as a read-only dir
   # Docs: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/publish-pipeline-artifact
   # Docs: https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts
+
+  # The release pipeline uses the AzureRmWebAppDeployment Task (not part of this file)
+  # Docs: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/azure-rm-web-app-deployment
+
+  # The App Service deploys the zip package (not part of this file)
   # Docs: https://docs.microsoft.com/en-us/azure/app-service/deploy-run-package
-  # Publish the zip to deploy to App Service using a package, which mounts the zip as a read-only dir
   - task: PublishPipelineArtifact@1
     inputs:
       targetPath: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,8 @@ variables:
     value: '1'
 
 steps:
-  - task: NodeAndNpmTool@1
+  # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/node-js?view=azure-devops
+  - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
       checkLatest: true

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
-    "start": "node -r ./server-preload.js ./node_modules/.bin/next start -p 8080",
+    "build": "./node_modules/next/dist/bin/next build",
+    "start": "node -r ./server-preload.js ./node_modules/next/dist/bin/next start -p 8080",
     "test": "jest --ci --coverage",
     "test:update-snapshots": "jest -u",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Ticket

Resolves #388 
Resolves #450

## Changes

- Replaces necessity of zipping symlinks by using `yarn install --no-bin-links`
- Publishes only the files needed to run `yarn start` and no extra files
- Replaces `NodeAndNpmTool@1` with `NodeTool@0` 
- Replaces `PublishBuildArtifacts@1` with `PublishPipelineArtifact@1`
- Disables Next.js telemetry

## Context

This PR makes changes to the Azure Devops pipelines build task. The are two main changes:

- This PR removes the `zip --symlink` process, which can be a [security vulnerability](https://security.stackexchange.com/questions/73718/how-zip-symlink-works). This was previously needed because `yarn install`/`npm install` will create a number of symlinks from `node_modules/.bin` to various package binaries. We can avoid needing to zip symlinks by using [`yarn install --no-bin-links`](https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-no-bin-links). 
  - Note: As a result, this PR updates `package.json` to use the non-symlink binaries to ensure functionality in both local and production environments.
  - Note: We want to publish a zip file as an artifact, rather than just the files themselves, because Azure App Service provides a [deploy by zip package](https://docs.microsoft.com/en-us/azure/app-service/deploy-run-package) functionality.
- This PR only zips up and publishes the files CST needs to run `yarn start`. Previously, we were zipping the entire git repo (including `.git`), which includes way too many files. The fewer files deployed, the smaller the attack surface.

There are a few minor changes:

- Replacing [deprecated](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/publish-build-artifacts?view=azure-devops) `PublishBuildArtifacts@1` with recommended `PublishPipelineArtifact@1`
- Replacing node task (no documentation available for `NodeAndNpmTool@1`, whereas `NodeTool@0` is the [officially supported](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/node-js) node task)
- Disabling [next.js telemetry](https://nextjs.org/telemetry)

## Testing

Build this branch and deploy to Internal. Test to ensure that all functionality still works as expected.