### PR TITLE
Adds ansi-html-community to resolve abandoned ansi-html vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "chromatic": "npx chromatic --project-token $CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
+    "ansi-html-community": "0.0.8",
     "applicationinsights": "^2.1.8",
     "bootstrap": "^4.6.0",
     "luxon": "^2.0.2",
@@ -121,6 +122,7 @@
     "**/highlight.js": "^10.4.1",
     "**/set-value": "^4.0.1",
     "**/ansi-regex": "^5.0.1",
-    "**/applicationinsights": "^2.1.8"
+    "**/applicationinsights": "^2.1.8",
+    "ansi-html": "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3842,10 +3842,10 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-html@0.0.7, ansi-html@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
-  integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
+ansi-html-community@0.0.8, ansi-html@0.0.7, ansi-html@^0.0.7, "ansi-html@https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
+  integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
 ansi-regex@^2.0.0, ansi-regex@^3.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
<!-- Write a description below of the changes in this pull request. 

Include images/GIFs if relevant for reviewers. Try Firefox (right-click -> Take Screenshot) for full-page screenshots and LICEcap (macOS) or Peek (ubuntu) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items. -->

Resolves vulnerability CVE-2021-23424 in abandoned module `ansi-html` with new `ansi-html-community` module. See https://github.com/Tjatse/ansi-html/issues/19#issuecomment-936734884

===

Resolves #XXX

- [ ] builds, tests pass, storybook works