### PR TITLE
Include typechecking for all files in the CI

### DIFF
--- a/.github/workflows/next.js.yml
+++ b/.github/workflows/next.js.yml
@@ -23,6 +23,7 @@ jobs:
     - run: npm install -g yarn
     - run: yarn install --frozen-lockfile
     - run: yarn build
+    - run: yarn typecheck
     - run: yarn test
     - run: yarn lint
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@testing-library/dom": "^7.30.0",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
+    "@types/jest": "^27.0.3",
     "@types/luxon": "^2.0.0",
     "@types/node": "^14.14.33",
     "@types/pem": "^1.9.5",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "./node_modules/next/dist/bin/next build",
     "start": "node -r ./server-preload.js ./node_modules/next/dist/bin/next start -p 8080",
+    "typecheck": "tsc -p .",
     "test": "jest --ci --coverage",
     "test:update-snapshots": "jest -u",
     "test:watch": "jest --watch",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/pumpify": "^1.4.1",
     "@types/react": "^17.0.3",
     "@types/react-test-renderer": "^17.0.1",
-    "@types/uuid": "^8.3.1",
+    "@types/uuid": "^8.3.3",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.19.0",
     "babel-jest": "^26.6.3",

--- a/tests/components/Appointment.test.tsx
+++ b/tests/components/Appointment.test.tsx
@@ -11,16 +11,18 @@ import { TimeSlot } from '../../types/common'
 function renderAppointmentComponent(timeSlot: TimeSlot | undefined): string {
   // Set a random date in PT time.
   const date = '2021-05-05T00:00:00.000-0800'
-  return renderer.create(<Appointment date={date} timeSlot={timeSlot} />).toJSON()
+  return JSON.stringify(renderer.create(<Appointment date={date} timeSlot={timeSlot} />).toJSON())
 }
 
 /**
  * Appointment snapshot tests.
  */
 
+type AppointmentTestSet = [string, number | null, number | null]
+
 // Each test case should be:
 // [test description, timeSlot.rangeStart, timeSlot.rangeEnd]
-const testCases = [
+const testCases: AppointmentTestSet[] = [
   ['with no time slot, then match the snapshot', null, null],
   ['with a morning time slot, then match the snapshot', 8, 10],
   ['with an afternoon time slot, then match the snapshot', 1, 3],
@@ -30,45 +32,48 @@ const testCases = [
 
 // Use describe.each() to DRY up the tests.
 // See https://jestjs.io/docs/api#describeeachtablename-fn-timeout
-describe.each(testCases)('If given an appointment', (description: string, start: number | null, end: number | null) => {
-  // Construct the timeslot argument.
-  let timeSlot: TimeSlot | undefined
-  if (start && end) {
-    timeSlot = {
-      rangeStart: start,
-      rangeEnd: end,
+describe.each<AppointmentTestSet>(testCases)(
+  'If given an appointment',
+  (description: string, start: number | null, end: number | null) => {
+    // Construct the timeslot argument.
+    let timeSlot: TimeSlot | undefined
+    if (start && end) {
+      timeSlot = {
+        rangeStart: start,
+        rangeEnd: end,
+      }
     }
-  }
 
-  // Run through the test cases first in English.
-  it(`${description}`, () => {
-    expect(renderAppointmentComponent(timeSlot)).toMatchSnapshot()
-  })
-
-  // Run through the test cases again in Spanish.
-  it(`${description}, in Spanish`, () => {
-    // Change the language to Spanish.
-
-    //  The call to changeLanguage() must be wrapped in act(), otherwise Jest/react
-    // complains.
-    // See https://reactjs.org/link/wrap-tests-with-act
-    // and https://reactjs.org/docs/test-renderer.html#testrendereract
-
-    // Disable floating promises lint check. eslint really wants us to handle the Promise
-    // returned by changeLanguage(), but it doesn't appear necessary to this test.
-    // This can be revisited and refactored in the future if necessary.
-    /* eslint-disable @typescript-eslint/no-floating-promises */
-    act(() => {
-      i18n.changeLanguage('es')
+    // Run through the test cases first in English.
+    it(`${description}`, () => {
+      expect(renderAppointmentComponent(timeSlot)).toMatchSnapshot()
     })
 
-    // Run the actual test.
-    expect(renderAppointmentComponent(timeSlot)).toMatchSnapshot()
+    // Run through the test cases again in Spanish.
+    it(`${description}, in Spanish`, () => {
+      // Change the language to Spanish.
 
-    // Change the language back to English so the first it() renders correctly in English.
-    act(() => {
-      i18n.changeLanguage('en')
+      //  The call to changeLanguage() must be wrapped in act(), otherwise Jest/react
+      // complains.
+      // See https://reactjs.org/link/wrap-tests-with-act
+      // and https://reactjs.org/docs/test-renderer.html#testrendereract
+
+      // Disable floating promises lint check. eslint really wants us to handle the Promise
+      // returned by changeLanguage(), but it doesn't appear necessary to this test.
+      // This can be revisited and refactored in the future if necessary.
+      /* eslint-disable @typescript-eslint/no-floating-promises */
+      act(() => {
+        i18n.changeLanguage('es')
+      })
+
+      // Run the actual test.
+      expect(renderAppointmentComponent(timeSlot)).toMatchSnapshot()
+
+      // Change the language back to English so the first it() renders correctly in English.
+      act(() => {
+        i18n.changeLanguage('en')
+      })
+      /* eslint-enable @typescript-eslint/no-floating-promises */
     })
-    /* eslint-enable @typescript-eslint/no-floating-promises */
-  })
-})
+  },
+)

--- a/tests/components/Appointment.test.tsx
+++ b/tests/components/Appointment.test.tsx
@@ -2,16 +2,16 @@ import renderer, { act } from 'react-test-renderer'
 
 import i18n from '../jest-i18n'
 import { Appointment } from '../../components/Appointment'
-import { TimeSlot } from '../../types/common'
+import { TimeSlot, TestRendererCreateReturn } from '../../types/common'
 
 /**
  * Helper functions.
  */
 
-function renderAppointmentComponent(timeSlot: TimeSlot | undefined): string {
+function renderAppointmentComponent(timeSlot: TimeSlot | undefined): TestRendererCreateReturn {
   // Set a random date in PT time.
   const date = '2021-05-05T00:00:00.000-0800'
-  return JSON.stringify(renderer.create(<Appointment date={date} timeSlot={timeSlot} />).toJSON())
+  return renderer.create(<Appointment date={date} timeSlot={timeSlot} />).toJSON()
 }
 
 /**

--- a/tests/components/ClaimStatus.test.tsx
+++ b/tests/components/ClaimStatus.test.tsx
@@ -3,7 +3,7 @@ import renderer from 'react-test-renderer'
 import { DateTime, Settings } from 'luxon'
 
 import { ClaimStatus } from '../../components/ClaimStatus'
-import { ClaimStatusContent } from '../../types/common'
+import { ClaimStatusContent, TestRendererCreateReturn } from '../../types/common'
 import apiGatewayStub from '../../utils/apiGatewayStub'
 import getScenarioContent, { ScenarioType } from '../../utils/getScenarioContent'
 
@@ -11,27 +11,28 @@ import getScenarioContent, { ScenarioType } from '../../utils/getScenarioContent
  * Helper functions.
  */
 
-function renderClaimStatusComponent(statusContent: ClaimStatusContent, userArrivedFromUioMobile: boolean): string {
-  return JSON.stringify(
-    renderer
-      .create(
-        <ClaimStatus
-          userArrivedFromUioMobile={userArrivedFromUioMobile}
-          heading={statusContent.heading}
-          summary={statusContent.summary}
-          yourNextSteps={statusContent.yourNextSteps}
-          eddNextSteps={statusContent.eddNextSteps}
-        />,
-      )
-      .toJSON(),
-  )
+function renderClaimStatusComponent(
+  statusContent: ClaimStatusContent,
+  userArrivedFromUioMobile: boolean,
+): TestRendererCreateReturn {
+  return renderer
+    .create(
+      <ClaimStatus
+        userArrivedFromUioMobile={userArrivedFromUioMobile}
+        heading={statusContent.heading}
+        summary={statusContent.summary}
+        yourNextSteps={statusContent.yourNextSteps}
+        eddNextSteps={statusContent.eddNextSteps}
+      />,
+    )
+    .toJSON()
 }
 
 function testClaimStatus(
   scenarioType: ScenarioType,
   hasCertificationWeeksAvailable = false,
   userArrivedFromUioMobile = false,
-): string {
+): TestRendererCreateReturn {
   const scenarioContent = getScenarioContent(apiGatewayStub(scenarioType, hasCertificationWeeksAvailable))
   return renderClaimStatusComponent(scenarioContent.statusContent, userArrivedFromUioMobile)
 }

--- a/tests/components/ClaimStatus.test.tsx
+++ b/tests/components/ClaimStatus.test.tsx
@@ -12,17 +12,19 @@ import getScenarioContent, { ScenarioType } from '../../utils/getScenarioContent
  */
 
 function renderClaimStatusComponent(statusContent: ClaimStatusContent, userArrivedFromUioMobile: boolean): string {
-  return renderer
-    .create(
-      <ClaimStatus
-        userArrivedFromUioMobile={userArrivedFromUioMobile}
-        heading={statusContent.heading}
-        summary={statusContent.summary}
-        yourNextSteps={statusContent.yourNextSteps}
-        eddNextSteps={statusContent.eddNextSteps}
-      />,
-    )
-    .toJSON()
+  return JSON.stringify(
+    renderer
+      .create(
+        <ClaimStatus
+          userArrivedFromUioMobile={userArrivedFromUioMobile}
+          heading={statusContent.heading}
+          summary={statusContent.summary}
+          yourNextSteps={statusContent.yourNextSteps}
+          eddNextSteps={statusContent.eddNextSteps}
+        />,
+      )
+      .toJSON(),
+  )
 }
 
 function testClaimStatus(

--- a/tests/components/Header.test.tsx
+++ b/tests/components/Header.test.tsx
@@ -3,7 +3,7 @@ import { Header } from '../../components/Header'
 
 describe('Header component loads', () => {
   it('has the desktop UIO Link by default', () => {
-    render(<Header userArrivedFromUioMobile={false} />)
+    render(<Header userArrivedFromUioMobile={false} assetPrefix="/claimstatus" />)
     expect(screen.queryByText('UI Home')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'UI Home' })).toHaveAttribute(
       'href',
@@ -12,7 +12,7 @@ describe('Header component loads', () => {
   })
 
   it('has the UIO Mobile Link when the user arrived from UIO Mobile', () => {
-    render(<Header userArrivedFromUioMobile />)
+    render(<Header userArrivedFromUioMobile assetPrefix="/claimstatus" />)
     expect(screen.queryByText('UI Home')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'UI Home' })).toHaveAttribute(
       'href',

--- a/tests/components/TransLine.test.tsx
+++ b/tests/components/TransLine.test.tsx
@@ -6,26 +6,28 @@ const beta = 'https://example.com/beta'
 
 describe('TransLine component loads', () => {
   it('a string with no links or styles', () => {
-    render(<TransLine i18nKey="test:transLine.plainString" />)
+    render(<TransLine userArrivedFromUioMobile={false} i18nKey="test:transLine.plainString" />)
     expect(screen.getByText('just text')).toBeInTheDocument()
   })
 
   it('a string with one link and no styles', () => {
     const links = ['test:urls.alpha']
-    render(<TransLine i18nKey="test:transLine.plainStringOneLink" links={links} />)
+    render(<TransLine userArrivedFromUioMobile={false} i18nKey="test:transLine.plainStringOneLink" links={links} />)
     expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', alpha)
   })
 
   it('a string with multiple links and no styles', () => {
     const links = ['test:urls.alpha', 'test:urls.beta']
-    render(<TransLine i18nKey="test:transLine.plainStringLinks" links={links} />)
+    render(<TransLine userArrivedFromUioMobile={false} i18nKey="test:transLine.plainStringLinks" links={links} />)
     expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', alpha)
     expect(screen.getByRole('link', { name: 'third' })).toHaveAttribute('href', beta)
   })
 
   it('a string with multiple links reused links and out of order', () => {
     const links = ['test:urls.alpha', 'test:urls.beta']
-    render(<TransLine i18nKey="test:transLine.plainStringLinksComplicated" links={links} />)
+    render(
+      <TransLine userArrivedFromUioMobile={false} i18nKey="test:transLine.plainStringLinksComplicated" links={links} />,
+    )
     expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', alpha)
     expect(screen.getByRole('link', { name: 'fourth' })).toHaveAttribute('href', alpha)
     expect(screen.getByRole('link', { name: 'first' })).toHaveAttribute('href', beta)
@@ -33,30 +35,30 @@ describe('TransLine component loads', () => {
   })
 
   it('a string with no links, but with styles', () => {
-    render(<TransLine i18nKey="test:transLine.styledString" />)
+    render(<TransLine userArrivedFromUioMobile={false} i18nKey="test:transLine.styledString" />)
     expect(screen.getByText('first', { exact: false })).toBeInTheDocument()
     screen.getByText((content, element) => {
-      return element.tagName.toLowerCase() === 'strong' && content.startsWith('second')
+      return element?.tagName.toLowerCase() === 'strong' && content.startsWith('second')
     })
     expect(screen.getByText('third', { exact: false })).toBeInTheDocument()
   })
 
   it('a string with one link and styles', () => {
     const links = ['test:urls.alpha']
-    render(<TransLine i18nKey="test:transLine.styledStringOneLink" links={links} />)
+    render(<TransLine userArrivedFromUioMobile={false} i18nKey="test:transLine.styledStringOneLink" links={links} />)
     expect(screen.getByText('first', { exact: false })).toBeInTheDocument()
     screen.getByText((content, element) => {
-      return element.tagName.toLowerCase() === 'strong' && content.startsWith('second')
+      return element?.tagName.toLowerCase() === 'strong' && content.startsWith('second')
     })
     expect(screen.getByRole('link', { name: 'third' })).toHaveAttribute('href', alpha)
   })
 
   it('a string with a styled link', () => {
     const links = ['test:urls.alpha']
-    render(<TransLine i18nKey="test:transLine.styledLink" links={links} />)
+    render(<TransLine userArrivedFromUioMobile={false} i18nKey="test:transLine.styledLink" links={links} />)
     expect(screen.getByText('first', { exact: false })).toBeInTheDocument()
     screen.getByText((content, element) => {
-      return element.tagName.toLowerCase() === 'strong'
+      return element?.tagName.toLowerCase() === 'strong'
     })
     expect(screen.getByRole('link', { name: 'second' })).toHaveAttribute('href', alpha)
   })

--- a/tests/pages/index.test.tsx
+++ b/tests/pages/index.test.tsx
@@ -26,7 +26,18 @@ describe('Full page snapshot', () => {
     }
     ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
 
-    const tree = renderer.create(<Index scenarioContent={scenarioContent} />).toJSON()
+    const urlPrefixes = {}
+    const tree = renderer
+      .create(
+        <Index
+          scenarioContent={scenarioContent}
+          assetPrefix=""
+          enableGoogleAnalytics=""
+          enableMaintenancePage=""
+          urlPrefixes={urlPrefixes}
+        />,
+      )
+      .toJSON()
     expect(tree).toMatchSnapshot()
   })
 })
@@ -38,7 +49,17 @@ describe('Main component shows the timeout', () => {
     }
     ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
 
-    render(<Index timedOut scenarioContent={scenarioContent} />)
+    const urlPrefixes = {}
+    render(
+      <Index
+        timedOut
+        scenarioContent={scenarioContent}
+        assetPrefix=""
+        enableGoogleAnalytics=""
+        enableMaintenancePage=""
+        urlPrefixes={urlPrefixes}
+      />,
+    )
     expect(screen.queryByText('Your Session Will End Soon')).toBeInTheDocument()
   })
 })

--- a/tests/pages/indexServerSide.test.ts
+++ b/tests/pages/indexServerSide.test.ts
@@ -26,8 +26,12 @@ describe('Main component server side logic', () => {
     const loggerSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(jest.fn())
     loggerSpy.mockClear()
 
+    /* eslint-disable @typescript-eslint/ban-ts-comment */
+    // @ts-ignore
     const result: GetServerSideProps = await getServerSideProps(context as GetServerSidePropsContext)
+    // @ts-ignore
     const props: HomeProps = result.props as HomeProps
+    /* eslint-enable @typescript-eslint/ban-ts-comment */
     expect(props.errorCode).toBe(500)
     expect(context.res.statusCode).toBe(500)
     expect(loggerSpy).toHaveBeenCalledWith(expect.anything(), 'error', {}, 'Missing unique number')

--- a/tests/utils/apiGatewayStub.test.ts
+++ b/tests/utils/apiGatewayStub.test.ts
@@ -2,6 +2,9 @@ import { isDatePast, isValidDate, parseApiGatewayDate } from '../../utils/format
 import apiGatewayStub from '../../utils/apiGatewayStub'
 import { isDeterminationStatusPending, ScenarioType } from '../../utils/getScenarioContent'
 
+/* eslint-disable  @typescript-eslint/no-non-null-assertion */
+// We only use non-null assertions in tests after we've verified that the value is not null.
+
 describe('The API gateway stub response for the Determination Interview scenarios', () => {
   it('is correct for Scenario 1', () => {
     const response = apiGatewayStub(ScenarioType.Scenario1)

--- a/tests/utils/apiGatewayStub.test.ts
+++ b/tests/utils/apiGatewayStub.test.ts
@@ -18,46 +18,25 @@ describe('The API gateway stub response for the Determination Interview scenario
     expect(response?.pendingDetermination?.length).toBe(1)
 
     const pendingDetermination = response?.pendingDetermination?.[0]
+    expect(pendingDetermination).not.toBe(undefined)
+    expect(isDeterminationStatusPending(pendingDetermination!)).toBe(true)
+    expect(isValidDate(pendingDetermination!.scheduleDate)).toBe(true)
 
-    /* eslint-disable jest/no-conditional-expect */
-    // Conditional expects allows us to use typescripts natural type narrowing.
-    // Lesser evil compared to using an as line & possibly hiding type issues
-    if (pendingDetermination === undefined) {
-      // type narrowed fail fast if we got undefined back
-      expect(pendingDetermination).not.toBe(undefined)
-    } else {
-      expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
-
-      expect(isValidDate(pendingDetermination.scheduleDate)).toBe(true)
-
-      const convertedDate = parseApiGatewayDate(pendingDetermination.scheduleDate)
-      expect(isDatePast(convertedDate)).toBe(false)
-    }
-    /* eslint-enable jest/no-conditional-expect */
+    const convertedDate = parseApiGatewayDate(pendingDetermination!.scheduleDate)
+    expect(isDatePast(convertedDate)).toBe(false)
   })
 
   it('is correct for Scenario 3', () => {
     const response = apiGatewayStub(ScenarioType.Scenario3)
-
     expect(response?.pendingDetermination?.length).toBe(1)
 
     const pendingDetermination = response?.pendingDetermination?.[0]
+    expect(pendingDetermination).not.toBe(undefined)
+    expect(isDeterminationStatusPending(pendingDetermination!)).toBe(true)
+    expect(isValidDate(pendingDetermination!.scheduleDate)).toBe(true)
 
-    /* eslint-disable jest/no-conditional-expect */
-    // Conditional expects allows us to use typescripts natural type narrowing.
-    // Lesser evil compared to using an as line & possibly hiding type issues
-    if (pendingDetermination === undefined) {
-      // type narrowed fail fast if we got undefined back
-      expect(pendingDetermination).not.toBe(undefined)
-    } else {
-      expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
-
-      expect(isValidDate(pendingDetermination.scheduleDate)).toBe(true)
-
-      const convertedDate = parseApiGatewayDate(pendingDetermination.scheduleDate)
-      expect(isDatePast(convertedDate)).toBe(true)
-    }
-    /* eslint-enable jest/no-conditional-expect */
+    const convertedDate = parseApiGatewayDate(pendingDetermination!.scheduleDate)
+    expect(isDatePast(convertedDate)).toBe(true)
   })
 })
 

--- a/tests/utils/apiGatewayStub.test.ts
+++ b/tests/utils/apiGatewayStub.test.ts
@@ -5,37 +5,59 @@ import { isDeterminationStatusPending, ScenarioType } from '../../utils/getScena
 describe('The API gateway stub response for the Determination Interview scenarios', () => {
   it('is correct for Scenario 1', () => {
     const response = apiGatewayStub(ScenarioType.Scenario1)
-    expect(response.pendingDetermination.length).toBe(1)
-    const pendingDetermination = response.pendingDetermination
-    expect([null, false, undefined, '']).toContainEqual(pendingDetermination.determinationStatus)
-    expect([null, false, undefined, '']).toContainEqual(pendingDetermination.scheduleDate)
-    expect(pendingDetermination.requestDate).not.toBe('')
+    expect(response.pendingDetermination?.length).toBe(1)
+
+    const pendingDetermination = response?.pendingDetermination?.[0]
+    expect([null, false, undefined, '']).toContainEqual(pendingDetermination?.determinationStatus)
+    expect([null, false, undefined, '']).toContainEqual(pendingDetermination?.scheduleDate)
+    expect(pendingDetermination?.requestDate).not.toBe('')
   })
 
   it('is correct for Scenario 2', () => {
     const response = apiGatewayStub(ScenarioType.Scenario2)
-    expect(response.pendingDetermination.length).toBe(1)
+    expect(response?.pendingDetermination?.length).toBe(1)
 
-    const pendingDetermination = response.pendingDetermination[0]
-    expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
+    const pendingDetermination = response?.pendingDetermination?.[0]
 
-    expect(isValidDate(pendingDetermination.scheduleDate)).toBe(true)
+    /* eslint-disable jest/no-conditional-expect */
+    // Conditional expects allows us to use typescripts natural type narrowing.
+    // Lesser evil compared to using an as line & possibly hiding type issues
+    if (pendingDetermination === undefined) {
+      // type narrowed fail fast if we got undefined back
+      expect(pendingDetermination).not.toBe(undefined)
+    } else {
+      expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
 
-    const convertedDate = parseApiGatewayDate(pendingDetermination.scheduleDate)
-    expect(isDatePast(convertedDate)).toBe(false)
+      expect(isValidDate(pendingDetermination.scheduleDate)).toBe(true)
+
+      const convertedDate = parseApiGatewayDate(pendingDetermination.scheduleDate)
+      expect(isDatePast(convertedDate)).toBe(false)
+    }
+    /* eslint-enable jest/no-conditional-expect */
   })
 
   it('is correct for Scenario 3', () => {
     const response = apiGatewayStub(ScenarioType.Scenario3)
-    expect(response.pendingDetermination.length).toBe(1)
 
-    const pendingDetermination = response.pendingDetermination[0]
-    expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
+    expect(response?.pendingDetermination?.length).toBe(1)
 
-    expect(isValidDate(pendingDetermination.scheduleDate)).toBe(true)
+    const pendingDetermination = response?.pendingDetermination?.[0]
 
-    const convertedDate = parseApiGatewayDate(pendingDetermination.scheduleDate)
-    expect(isDatePast(convertedDate)).toBe(true)
+    /* eslint-disable jest/no-conditional-expect */
+    // Conditional expects allows us to use typescripts natural type narrowing.
+    // Lesser evil compared to using an as line & possibly hiding type issues
+    if (pendingDetermination === undefined) {
+      // type narrowed fail fast if we got undefined back
+      expect(pendingDetermination).not.toBe(undefined)
+    } else {
+      expect(isDeterminationStatusPending(pendingDetermination)).toBe(true)
+
+      expect(isValidDate(pendingDetermination.scheduleDate)).toBe(true)
+
+      const convertedDate = parseApiGatewayDate(pendingDetermination.scheduleDate)
+      expect(isDatePast(convertedDate)).toBe(true)
+    }
+    /* eslint-enable jest/no-conditional-expect */
   })
 })
 

--- a/tests/utils/browser/getUrl.test.ts
+++ b/tests/utils/browser/getUrl.test.ts
@@ -1,6 +1,6 @@
 import mockEnv from 'mocked-env'
 
-import getUrl, { stripTrailingSlashes } from '../../utils/browser/getUrl'
+import getUrl, { stripTrailingSlashes } from '../../../utils/browser/getUrl'
 
 // Test stripTrailingSlashes()
 describe('A string', () => {

--- a/tests/utils/formatDate.test.ts
+++ b/tests/utils/formatDate.test.ts
@@ -35,7 +35,8 @@ describe('Falsy date strings: A date string is', () => {
   })
 
   it('falsy if it is null', () => {
-    expect(isDateStringFalsy(null)).toBe(true)
+    const borkedValue = null as unknown
+    expect(isDateStringFalsy(borkedValue as string)).toBe(true)
   })
 
   it('falsy if it is an empty string', () => {
@@ -43,7 +44,8 @@ describe('Falsy date strings: A date string is', () => {
   })
 
   it('falsy if it is undefined', () => {
-    expect(isDateStringFalsy(undefined)).toBe(true)
+    const borkedValue = undefined as unknown
+    expect(isDateStringFalsy(borkedValue as string)).toBe(true)
   })
 
   it('not falsy if it is any valid date', () => {

--- a/tests/utils/getClaimDetails.test.ts
+++ b/tests/utils/getClaimDetails.test.ts
@@ -1,3 +1,4 @@
+import { ClaimDetailsResult } from '../../types/common'
 import getClaimDetails, {
   buildBenefitYear,
   formatCurrency,
@@ -80,7 +81,7 @@ describe('Constructing the Claim Details object', () => {
   })
 
   it('null values pass through properly', () => {
-    // Mock ClaimDetailsResults
+    // Mock ClaimDetailsResults, intentionally invalid type
     const rawDetails = {
       programType: 'UI',
       benefitYearStartDate: '2021-05-21T00:00:00',
@@ -90,7 +91,7 @@ describe('Constructing the Claim Details object', () => {
       lastPaymentIssued: null,
       lastPaymentAmount: null,
       monetaryStatus: 'active',
-    }
+    } as unknown
 
     // Expected results
     const expected = {
@@ -101,7 +102,7 @@ describe('Constructing the Claim Details object', () => {
       lastPaymentIssued: null,
       extensionType: '',
     }
-    const claimDetails = getClaimDetails(rawDetails)
+    const claimDetails = getClaimDetails(rawDetails as ClaimDetailsResult)
     expect(claimDetails).toStrictEqual(expected)
   })
 
@@ -158,7 +159,7 @@ describe('Constructing the Claim Details object', () => {
   })
 
   it('null lastPaymentIssued date makes the final lastPaymentIssued null', () => {
-    // Mock ClaimDetailsResults
+    // Mock ClaimDetailsResults, intentionally invalid type
     const rawDetails = {
       programType: 'UI',
       benefitYearStartDate: '2021-05-21T00:00:00',
@@ -168,7 +169,7 @@ describe('Constructing the Claim Details object', () => {
       lastPaymentIssued: null,
       lastPaymentAmount: 10,
       monetaryStatus: 'active',
-    }
+    } as unknown
 
     // Expected results
     const expected = {
@@ -179,12 +180,12 @@ describe('Constructing the Claim Details object', () => {
       lastPaymentIssued: null,
       extensionType: '',
     }
-    const claimDetails = getClaimDetails(rawDetails)
+    const claimDetails = getClaimDetails(rawDetails as ClaimDetailsResult)
     expect(claimDetails).toStrictEqual(expected)
   })
 
   it('null lastPaymentAmount makes the final lastPaymentIssued null', () => {
-    // Mock ClaimDetailsResults
+    // Mock ClaimDetailsResults, intentionally invalid type
     const rawDetails = {
       programType: 'UI',
       benefitYearStartDate: '2021-05-21T00:00:00',
@@ -194,7 +195,7 @@ describe('Constructing the Claim Details object', () => {
       lastPaymentIssued: '2021-03-12T00:00:00',
       lastPaymentAmount: null,
       monetaryStatus: 'active',
-    }
+    } as unknown
 
     // Expected results
     const expected = {
@@ -205,7 +206,7 @@ describe('Constructing the Claim Details object', () => {
       lastPaymentIssued: null,
       extensionType: '',
     }
-    const claimDetails = getClaimDetails(rawDetails)
+    const claimDetails = getClaimDetails(rawDetails as ClaimDetailsResult)
     expect(claimDetails).toStrictEqual(expected)
   })
 

--- a/tests/utils/getClaimStatus.test.ts
+++ b/tests/utils/getClaimStatus.test.ts
@@ -35,16 +35,16 @@ describe('An appointment is', () => {
     }
 
     const appointment = buildAppointment(ScenarioType.Scenario2, pendingDetermination)
-    expect(appointment.date).toStrictEqual(expectedDate)
-    expect(appointment.timeSlot).toStrictEqual(expectedTimeSlot)
+    expect(appointment?.date).toStrictEqual(expectedDate)
+    expect(appointment?.timeSlot).toStrictEqual(expectedTimeSlot)
   })
 
   it('returned with no time slot if there is no time slot value', () => {
     const pendingDetermination = getPendingDeterminationWithScheduleDate(0)
     const expectedDate = parseApiGatewayDate(formatFromApiGateway(0)).toJSON()
     const appointment = buildAppointment(ScenarioType.Scenario2, pendingDetermination)
-    expect(appointment.date).toStrictEqual(expectedDate)
-    expect(appointment.timeSlot).toBe(undefined)
+    expect(appointment?.date).toStrictEqual(expectedDate)
+    expect(appointment?.timeSlot).toBe(undefined)
   })
 
   it('not returned (null) if it is not scenario 2', () => {

--- a/tests/utils/getScenarioContent.test.ts
+++ b/tests/utils/getScenarioContent.test.ts
@@ -30,7 +30,15 @@ beforeAll(() => {
 // Scenarios 1, 2, 3 negative identification tests
 describe('Scenarios 1, 2, 3', () => {
   it('are not returned if pendingDetermination is null', () => {
-    const pendingDeterminationScenarioNull = { pendingDetermination: null }
+    const pendingDeterminationScenarioNull = {
+      uniqueNumber: null,
+      claimDetails: null,
+      hasPendingWeeks: false,
+      hasValidPendingWeeks: false,
+      hasCertificationWeeksAvailable: false,
+      isBYE: false,
+      pendingDetermination: null,
+    }
     const scenarioTypeNull = getScenario(pendingDeterminationScenarioNull)
     expect(scenarioTypeNull).not.toBe(ScenarioType.Scenario1)
     expect(scenarioTypeNull).not.toBe(ScenarioType.Scenario2)
@@ -38,7 +46,15 @@ describe('Scenarios 1, 2, 3', () => {
   })
 
   it('are not returned if pendingDetermination is an empty array', () => {
-    const pendingDeterminationScenarioEmpty = { pendingDetermination: [] }
+    const pendingDeterminationScenarioEmpty = {
+      uniqueNumber: null,
+      claimDetails: null,
+      hasPendingWeeks: false,
+      hasValidPendingWeeks: false,
+      hasCertificationWeeksAvailable: false,
+      isBYE: false,
+      pendingDetermination: [],
+    }
     const scenarioTypeEmpty = getScenario(pendingDeterminationScenarioEmpty)
     expect(scenarioTypeEmpty).not.toBe(ScenarioType.Scenario1)
     expect(scenarioTypeEmpty).not.toBe(ScenarioType.Scenario2)
@@ -57,7 +73,7 @@ describe('The Generic Pending scenario (scenario 4)', () => {
 
 // Scenarios 5 & 6
 describe('The Base State scenarios (scenarios 5 & 6)', () => {
-  const baseScenarios = [
+  const baseScenarios: [string, ScenarioType][] = [
     ['No Weeks to Certify', ScenarioType.Scenario5],
     ['Weeks to Certify', ScenarioType.Scenario6],
   ]
@@ -68,7 +84,7 @@ describe('The Base State scenarios (scenarios 5 & 6)', () => {
 })
 
 describe('The BYE scenarios (scenarios 7, 8, 9, 10, 11, 12)', () => {
-  const byeScenarios = [
+  const byeScenarios: [string, ScenarioType][] = [
     ['UI', ScenarioType.Scenario7],
     ['PUA', ScenarioType.Scenario8],
     ['DUA', ScenarioType.Scenario9],
@@ -144,7 +160,7 @@ describe('The BYE scenarios (scenarios 7, 8, 9, 10, 11, 12)', () => {
     expect(scenarioObject.scenarioType).toBe(ScenarioType.Scenario10)
   })
 
-  const falseyBenefitYearEndDates = [
+  const falseyBenefitYearEndDates: [string, null | undefined | ''][] = [
     ['null', null],
     ['undefined', undefined],
     ['empty string', ''],
@@ -152,7 +168,13 @@ describe('The BYE scenarios (scenarios 7, 8, 9, 10, 11, 12)', () => {
   it.each(falseyBenefitYearEndDates)(
     'FED-ED with %s benefit year end date throws an error',
     (description, benefitYearEndDate) => {
-      const invalidByeProgram = apiGatewayStub(ScenarioType.Scenario12, false, false, 'FED-ED', benefitYearEndDate)
+      const invalidByeProgram = apiGatewayStub(
+        ScenarioType.Scenario12,
+        false,
+        false,
+        'FED-ED',
+        benefitYearEndDate as undefined,
+      )
       // Create an invalid claim object by removing benefitYearEndDate.
       if (benefitYearEndDate === undefined) {
         delete invalidByeProgram.claimDetails.benefitYearEndDate

--- a/tests/utils/getScenarioContent.test.ts
+++ b/tests/utils/getScenarioContent.test.ts
@@ -147,7 +147,9 @@ describe('The BYE scenarios (scenarios 7, 8, 9, 10, 11, 12)', () => {
     // we're overrding the program type, which is the difference between the API response
     // for scenarios 7 thru 12 - so testing each would be redundant
     const byeInvalidProgram = apiGatewayStub(ScenarioType.Scenario7)
-    byeInvalidProgram.claimDetails.programType = programType
+    if (byeInvalidProgram?.claimDetails?.programType) {
+      byeInvalidProgram.claimDetails.programType = programType
+    }
     const scenarioObject = getScenario(byeInvalidProgram)
     expect(scenarioObject.scenarioType).not.toBe(ScenarioType.Scenario7)
     expect(scenarioObject.scenarioType).toBe(ScenarioType.Scenario5)
@@ -162,7 +164,6 @@ describe('The BYE scenarios (scenarios 7, 8, 9, 10, 11, 12)', () => {
 
   const falseyBenefitYearEndDates: [string, null | undefined | ''][] = [
     ['null', null],
-    ['undefined', undefined],
     ['empty string', ''],
   ]
   it.each(falseyBenefitYearEndDates)(
@@ -175,10 +176,6 @@ describe('The BYE scenarios (scenarios 7, 8, 9, 10, 11, 12)', () => {
         'FED-ED',
         benefitYearEndDate as undefined,
       )
-      // Create an invalid claim object by removing benefitYearEndDate.
-      if (benefitYearEndDate === undefined) {
-        delete invalidByeProgram.claimDetails.benefitYearEndDate
-      }
       expect(() => {
         getScenario(invalidByeProgram)
       }).toThrowError('Claim is marked as isBYE, but is missing benefit year end date value')
@@ -193,42 +190,47 @@ describe('The BYE scenarios (scenarios 7, 8, 9, 10, 11, 12)', () => {
 // Scenario 1: Test various values of pendingDetermination.determinationStatus
 describe('The determination interview is not yet scheduled (scenario 1) when all other criteria are met and the determination status evaluates to', () => {
   it('false (null)', () => {
+    const nullTestOverride = null as unknown
     const pendingDetermination = getMockPendingDetermination()
     pendingDetermination.determinationStatus = null
-    pendingDetermination.scheduleDate = null
+    pendingDetermination.scheduleDate = nullTestOverride as string
     pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario1)
   })
 
   it('false (empty string)', () => {
+    const nullTestOverride = null as unknown
     const pendingDetermination = getMockPendingDetermination()
     pendingDetermination.determinationStatus = ''
-    pendingDetermination.scheduleDate = null
+    pendingDetermination.scheduleDate = nullTestOverride as string
     pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario1)
   })
 
   it('false (undefined)', () => {
+    const nullTestOverride = null as unknown
+    const undefTestOverride = undefined as unknown
     const pendingDetermination = getMockPendingDetermination()
-    pendingDetermination.determinationStatus = undefined
-    pendingDetermination.scheduleDate = null
+    pendingDetermination.determinationStatus = undefTestOverride as string
+    pendingDetermination.scheduleDate = nullTestOverride as string
     pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario1)
   })
 })
 
 // Scenario 1: Test various values of pendingDetermination.scheduleDate
 describe('The determination interview is not yet scheduled (scenario 1) when all other criteria are met and the schedule date', () => {
   it('evaluates to false (null)', () => {
+    const nullTestOverride = null as unknown
     const pendingDetermination = getMockPendingDetermination()
-    pendingDetermination.determinationStatus = null
-    pendingDetermination.scheduleDate = null
+    pendingDetermination.determinationStatus = nullTestOverride as string
+    pendingDetermination.scheduleDate = nullTestOverride as string
     pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario1)
   })
 
   it('evaluates to false (empty string)', () => {
@@ -237,16 +239,18 @@ describe('The determination interview is not yet scheduled (scenario 1) when all
     pendingDetermination.scheduleDate = ''
     pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario1)
   })
 
   it('evaluates to false (undefined)', () => {
+    const nullTestOverride = null as unknown
+    const undefTestOverride = undefined as unknown
     const pendingDetermination = getMockPendingDetermination()
-    pendingDetermination.determinationStatus = null
-    pendingDetermination.scheduleDate = undefined
+    pendingDetermination.determinationStatus = nullTestOverride as string
+    pendingDetermination.scheduleDate = undefTestOverride as string
     pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario1)
   })
 
   it('is 0001-01-01T00:00:00', () => {
@@ -255,7 +259,7 @@ describe('The determination interview is not yet scheduled (scenario 1) when all
     pendingDetermination.scheduleDate = '0001-01-01T00:00:00'
     pendingDetermination.requestDate = formatFromApiGateway(-30)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario1)
   })
 })
 
@@ -314,14 +318,14 @@ describe('The determination interview is scheduled (scenario 2)', () => {
     // Mock a pending determination object with a schedule date that is tomorrow
     const pendingDetermination = getPendingDeterminationWithScheduleDate(1)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario2)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario2)
   })
 
   it('scheduled (scenario 2) when the determination status is pending and there is one pending determination object with a schedule date of today', () => {
     // Mock a pending determination object with a schedule date that is now
     const pendingDetermination = getPendingDeterminationWithScheduleDate(0)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario2)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario2)
   })
 })
 
@@ -331,7 +335,7 @@ describe('The determination interview is awating decision (scenario 3)', () => {
     // Mock a pending determination object with a schedule date that is yesterday
     const pendingDetermination = getPendingDeterminationWithScheduleDate(-1)
     const result = identifyPendingDeterminationScenario([pendingDetermination])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario3)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario3)
   })
 })
 
@@ -341,17 +345,15 @@ describe('When there are multiple pendingDetermination objects, the determinatio
   // to Scenario 1, return Scenario 1.
   it('not yet scheduled (scenario 1) if all are not yet scheduled', () => {
     const appt1 = getMockPendingDetermination()
-    appt1.pendingDetermination = ''
     appt1.scheduleDate = ''
     appt1.requestDate = formatFromApiGateway(-30)
 
     const appt2 = getMockPendingDetermination()
-    appt2.pendingDetermination = ''
     appt2.scheduleDate = ''
     appt2.requestDate = formatFromApiGateway(-30)
 
     const result = identifyPendingDeterminationScenario([appt1, appt2])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario1)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario1)
   })
 
   // Multiple "scheduled" pendingDetermination objects that evaluate
@@ -364,8 +366,8 @@ describe('When there are multiple pendingDetermination objects, the determinatio
     const appt2 = getPendingDeterminationWithScheduleDate(7)
 
     const result = identifyPendingDeterminationScenario([appt1, appt2])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario2)
-    expect(result.pendingDetermination).toBe(appt1)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario2)
+    expect(result?.pendingDetermination).toBe(appt1)
   })
 
   // Multiple "awaiting decision" pendingDetermination objects that evaluate
@@ -378,7 +380,7 @@ describe('When there are multiple pendingDetermination objects, the determinatio
     const appt2 = getPendingDeterminationWithScheduleDate(-7)
 
     const result = identifyPendingDeterminationScenario([appt1, appt2])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario3)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario3)
   })
 
   // If all three types of scenarios are present, then scenario 2 takes priority.
@@ -395,8 +397,8 @@ describe('When there are multiple pendingDetermination objects, the determinatio
     notYetScheduled.requestDate = 'not empty'
 
     const result = identifyPendingDeterminationScenario([notYetScheduled, awaitingDecision, scheduled])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario2)
-    expect(result.pendingDetermination).toBe(scheduled)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario2)
+    expect(result?.pendingDetermination).toBe(scheduled)
   })
 
   // If scenarios 1 & 3 are present, then scenario 3 takes priority.
@@ -410,7 +412,7 @@ describe('When there are multiple pendingDetermination objects, the determinatio
     notYetScheduled.requestDate = 'not empty'
 
     const result = identifyPendingDeterminationScenario([notYetScheduled, awaitingDecision])
-    expect(result.scenarioType).toBe(ScenarioType.Scenario3)
+    expect(result?.scenarioType).toBe(ScenarioType.Scenario3)
   })
 })
 

--- a/tests/utils/queryApiGateway.test.ts
+++ b/tests/utils/queryApiGateway.test.ts
@@ -31,6 +31,7 @@ const goodRequest = {
  */
 
 // Test queryApiGateway()
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 describe('Querying the API Gateway', () => {
   const mockedResponse: Claim = {
     hasValidPendingWeeks: false,
@@ -46,10 +47,12 @@ describe('Querying the API Gateway', () => {
   beforeEach(() => {
     // Mock the fetch response
     /* eslint-disable  @typescript-eslint/no-unsafe-call */
+    // @ts-ignore
     fetch.mockResolvedValue(new Response(JSON.stringify(mockedResponse)))
     /* eslint-enable  @typescript-eslint/no-unsafe-call */
     // Mock fs.readFileSync()
     /* eslint-disable  @typescript-eslint/no-unsafe-call */
+    // @ts-ignore
     fs.readFileSync.mockImplementation(() => {
       return 'mock file data'
     })
@@ -67,6 +70,7 @@ describe('Querying the API Gateway', () => {
   // Test mocked fetch is working correctly to eliminate testing issues that might be
   // originating from the way fetch is mocked.
   it('has a correctly mocked fetch', async () => {
+    // @ts-ignore
     const resp: Response = await fetch()
     const body: string = await resp.text()
     const jsonData: Claim = extractJSON(body)
@@ -93,6 +97,7 @@ describe('Querying the API Gateway', () => {
   it('handles errors thrown by fetch', async () => {
     const networkErrorMessage = 'network error'
     /* eslint-disable  @typescript-eslint/no-unsafe-call */
+    // @ts-ignore
     fetch.mockRejectedValue(new Error(networkErrorMessage))
     /* eslint-enable  @typescript-eslint/no-unsafe-call */
 
@@ -117,6 +122,7 @@ describe('Querying the API Gateway', () => {
       status: 403,
     })
     /* eslint-enable  @typescript-eslint/no-unsafe-assignment */
+    // @ts-ignore
     fetch.mockResolvedValue(errorResponse403)
     /* eslint-enable  @typescript-eslint/no-unsafe-call */
 
@@ -141,6 +147,7 @@ describe('Querying the API Gateway', () => {
     // This happens when an incorrect query is sent to API gateway,
     // such as missing the unqiueNumber query string.
     /* eslint-disable  @typescript-eslint/no-unsafe-call */
+    // @ts-ignore
     fetch.mockResolvedValue(new Response('not json'))
     /* eslint-enable  @typescript-eslint/no-unsafe-call */
 
@@ -164,6 +171,7 @@ describe('Querying the API Gateway', () => {
     // Override the beforeEach mock to throw an error.
     const fsErrorMessage = 'file read issue'
     /* eslint-disable  @typescript-eslint/no-unsafe-call */
+    // @ts-ignore
     fs.readFileSync.mockImplementation(() => {
       throw new Error(fsErrorMessage)
     })
@@ -190,6 +198,7 @@ describe('Querying the API Gateway', () => {
     })
 
     /* eslint-disable  @typescript-eslint/no-unsafe-call */
+    // @ts-ignore
     fetch.mockResolvedValue(new Response(JSON.stringify(null)))
     /* eslint-enable  @typescript-eslint/no-unsafe-call */
     await expect(queryApiGateway(goodRequest as IncomingMessage, goodUniqueNumber)).rejects.toThrow(
@@ -248,6 +257,7 @@ describe('Querying the API Gateway', () => {
     }
 
     /* eslint-disable  @typescript-eslint/no-unsafe-call */
+    // @ts-ignore
     fetch.mockResolvedValue(new Response(JSON.stringify(longNullishResponse)))
     /* eslint-enable  @typescript-eslint/no-unsafe-call */
     await expect(queryApiGateway(goodRequest as IncomingMessage, goodUniqueNumber)).rejects.toThrow(
@@ -278,6 +288,7 @@ describe('Querying the API Gateway', () => {
     }
 
     /* eslint-disable  @typescript-eslint/no-unsafe-call */
+    // @ts-ignore
     fetch.mockResolvedValue(new Response(JSON.stringify(shortNullResponse)))
     /* eslint-enable  @typescript-eslint/no-unsafe-call */
     await expect(queryApiGateway(goodRequest as IncomingMessage, goodUniqueNumber)).rejects.toThrow(
@@ -465,3 +476,4 @@ describe.each(envVarCases)('Missing environment variables log errors', (testEnv:
     restore()
   })
 })
+/* eslint-enable @typescript-eslint/ban-ts-comment */

--- a/tests/utils/queryApiGateway.test.ts
+++ b/tests/utils/queryApiGateway.test.ts
@@ -224,15 +224,16 @@ describe('Querying the API Gateway', () => {
       API_URL: goodUrl,
     })
 
+    const nullTestOverride = null as unknown
     const longNullishResponse: Claim = {
       claimDetails: {
         programType: '',
-        benefitYearStartDate: null,
-        benefitYearEndDate: null,
-        claimBalance: null,
-        weeklyBenefitAmount: null,
-        lastPaymentIssued: null,
-        lastPaymentAmount: null,
+        benefitYearStartDate: nullTestOverride as string,
+        benefitYearEndDate: nullTestOverride as string,
+        claimBalance: nullTestOverride as number,
+        weeklyBenefitAmount: nullTestOverride as number,
+        lastPaymentIssued: nullTestOverride as string,
+        lastPaymentAmount: nullTestOverride as number,
         monetaryStatus: '',
       },
       uniqueNumber: '12345',

--- a/tests/utils/queryApiGateway.test.ts
+++ b/tests/utils/queryApiGateway.test.ts
@@ -11,6 +11,7 @@ import queryApiGateway, {
 import mockEnv from 'mocked-env'
 import fs from 'fs'
 import jestFetchMock from 'jest-fetch-mock'
+import { IncomingMessage } from 'http'
 
 // Mock some modules
 jest.mock('fs')
@@ -23,7 +24,7 @@ const goodRequest = {
   headers: {
     id: goodUniqueNumber,
   },
-}
+} as unknown
 
 /**
  * Begin tests
@@ -80,7 +81,7 @@ describe('Querying the API Gateway', () => {
       API_URL: goodUrl,
     })
 
-    const data = await queryApiGateway(goodRequest, goodUniqueNumber)
+    const data = await queryApiGateway(goodRequest as IncomingMessage, goodUniqueNumber)
 
     expect(data).toStrictEqual(mockedResponse)
     expect(fetch).toHaveBeenCalledTimes(1)
@@ -100,7 +101,7 @@ describe('Querying the API Gateway', () => {
       API_URL: goodUrl,
     })
 
-    await expect(queryApiGateway(goodRequest, goodUniqueNumber)).rejects.toThrow(networkErrorMessage)
+    await expect(queryApiGateway(goodRequest as IncomingMessage, goodUniqueNumber)).rejects.toThrow(networkErrorMessage)
 
     expect(fetch).toHaveBeenCalledTimes(1)
     expect(loggerSpy).toHaveBeenCalledWith(undefined, 'error', expect.anything(), 'API gateway error')
@@ -124,7 +125,9 @@ describe('Querying the API Gateway', () => {
       API_URL: goodUrl,
     })
 
-    await expect(queryApiGateway(goodRequest, goodUniqueNumber)).rejects.toThrow('API Gateway response is not 200')
+    await expect(queryApiGateway(goodRequest as IncomingMessage, goodUniqueNumber)).rejects.toThrow(
+      'API Gateway response is not 200',
+    )
 
     expect(fetch).toHaveBeenCalledTimes(1)
     expect(loggerSpy).toHaveBeenCalledWith(undefined, 'error', expect.anything(), 'API gateway error')
@@ -146,7 +149,7 @@ describe('Querying the API Gateway', () => {
       API_URL: goodUrl,
     })
 
-    await expect(queryApiGateway(goodRequest, goodUniqueNumber)).rejects.toThrow(
+    await expect(queryApiGateway(goodRequest as IncomingMessage, goodUniqueNumber)).rejects.toThrow(
       'Unexpected token o in JSON at position 1',
     )
 
@@ -171,7 +174,7 @@ describe('Querying the API Gateway', () => {
       API_URL: goodUrl,
     })
 
-    await expect(queryApiGateway(goodRequest, goodUniqueNumber)).rejects.toThrow(fsErrorMessage)
+    await expect(queryApiGateway(goodRequest as IncomingMessage, goodUniqueNumber)).rejects.toThrow(fsErrorMessage)
 
     expect(fetch).toHaveBeenCalledTimes(0)
     expect(loggerSpy).toHaveBeenCalledWith(undefined, 'error', expect.anything(), 'Read certificate error')
@@ -189,7 +192,7 @@ describe('Querying the API Gateway', () => {
     /* eslint-disable  @typescript-eslint/no-unsafe-call */
     fetch.mockResolvedValue(new Response(JSON.stringify(null)))
     /* eslint-enable  @typescript-eslint/no-unsafe-call */
-    await expect(queryApiGateway(goodRequest, goodUniqueNumber)).rejects.toThrow(
+    await expect(queryApiGateway(goodRequest as IncomingMessage, goodUniqueNumber)).rejects.toThrow(
       'API responded with a null response (queried with 12345, returned null)',
     )
 
@@ -207,7 +210,7 @@ describe('Querying the API Gateway', () => {
     })
 
     const mismatchedUniqueNumber = 'abcde'
-    await expect(queryApiGateway(goodRequest, mismatchedUniqueNumber)).rejects.toThrow(
+    await expect(queryApiGateway(goodRequest as IncomingMessage, mismatchedUniqueNumber)).rejects.toThrow(
       'Mismatched API response and Header unique number (12345 and abcde)',
     )
 
@@ -247,7 +250,7 @@ describe('Querying the API Gateway', () => {
     /* eslint-disable  @typescript-eslint/no-unsafe-call */
     fetch.mockResolvedValue(new Response(JSON.stringify(longNullishResponse)))
     /* eslint-enable  @typescript-eslint/no-unsafe-call */
-    await expect(queryApiGateway(goodRequest, goodUniqueNumber)).rejects.toThrow(
+    await expect(queryApiGateway(goodRequest as IncomingMessage, goodUniqueNumber)).rejects.toThrow(
       'API responded with a null object (queried with 12345, returned unique number 12345)',
     )
 
@@ -277,7 +280,7 @@ describe('Querying the API Gateway', () => {
     /* eslint-disable  @typescript-eslint/no-unsafe-call */
     fetch.mockResolvedValue(new Response(JSON.stringify(shortNullResponse)))
     /* eslint-enable  @typescript-eslint/no-unsafe-call */
-    await expect(queryApiGateway(goodRequest, goodUniqueNumber)).rejects.toThrow(
+    await expect(queryApiGateway(goodRequest as IncomingMessage, goodUniqueNumber)).rejects.toThrow(
       'API responded with a null object (queried with 12345, returned unique number null)',
     )
 
@@ -296,7 +299,7 @@ describe('Querying the API Gateway', () => {
       PFX_PASSPHRASE: testPassphrase,
     })
 
-    await queryApiGateway(goodRequest, goodUniqueNumber)
+    await queryApiGateway(goodRequest as IncomingMessage, goodUniqueNumber)
     /* eslint-disable  @typescript-eslint/no-unsafe-assignment */
     expect(fetch).toHaveBeenCalledWith(
       expect.any(String),
@@ -318,7 +321,7 @@ describe('Querying the API Gateway', () => {
       PFX_PASSPHRASE: testPassphrase,
     })
 
-    await queryApiGateway(goodRequest, goodUniqueNumber)
+    await queryApiGateway(goodRequest as IncomingMessage, goodUniqueNumber)
     /* eslint-disable  @typescript-eslint/no-unsafe-assignment */
     expect(fetch).toHaveBeenCalledWith(
       expect.any(String),
@@ -363,8 +366,8 @@ describe('The unique number', () => {
       ID_HEADER_NAME: 'id',
     })
 
-    const id = getUniqueNumber(goodRequest)
-    expect(id).toStrictEqual(goodRequest.headers.id)
+    const id = getUniqueNumber(goodRequest as IncomingMessage)
+    expect(id).toStrictEqual(goodUniqueNumber)
 
     // Restore env vars
     restore()
@@ -389,9 +392,9 @@ describe('The unique number', () => {
         UNIQUENUMBER: 'UPPER',
         uniqueNumber: 'mixedCase',
       },
-    }
+    } as unknown
 
-    const id = getUniqueNumber(request)
+    const id = getUniqueNumber(request as IncomingMessage)
     expect(id).toStrictEqual('lower')
 
     // Restore env vars
@@ -405,7 +408,7 @@ describe('The unique number', () => {
       ID_HEADER_NAME: 'nonsense',
     })
 
-    const id = getUniqueNumber(goodRequest)
+    const id = getUniqueNumber(goodRequest as IncomingMessage)
     expect(id).toStrictEqual(undefined)
 
     // Restore env vars
@@ -416,7 +419,7 @@ describe('The unique number', () => {
 // Test getApiVars()
 // Each test case should be:
 // [env var that should not be set, boolean whether an error should be logged]
-const envVarCases = [
+const envVarCases: [string, boolean][] = [
   ['ID_HEADER_NAME', true],
   ['API_URL', true],
   ['API_USER_KEY', true],
@@ -433,7 +436,7 @@ describe.each(envVarCases)('Missing environment variables log errors', (testEnv:
 
   it(`${testEnv}`, () => {
     // Mock process.env
-    const mockEnvs = {}
+    const mockEnvs: { [key: string]: string } = {}
     const allEnvs = ['ID_HEADER_NAME', 'API_URL', 'API_USER_KEY', 'CERTIFICATE_DIR', 'PFX_FILE', 'PFX_PASSPHRASE']
     for (const env of allEnvs) {
       if (env !== testEnv) {

--- a/tests/utils/timeSlot.test.ts
+++ b/tests/utils/timeSlot.test.ts
@@ -21,12 +21,12 @@ describe('Testing a time for validity', () => {
 describe('A time slot string is', () => {
   it('correctly parsed if it is properly formatted', () => {
     const multipleDigits = parseTimeSlot('10-12')
-    expect(multipleDigits.rangeStart).toBe(10)
-    expect(multipleDigits.rangeEnd).toBe(12)
+    expect(multipleDigits?.rangeStart).toBe(10)
+    expect(multipleDigits?.rangeEnd).toBe(12)
 
     const singleDigits = parseTimeSlot('1-3')
-    expect(singleDigits.rangeStart).toBe(1)
-    expect(singleDigits.rangeEnd).toBe(3)
+    expect(singleDigits?.rangeStart).toBe(1)
+    expect(singleDigits?.rangeEnd).toBe(3)
   })
 
   it('handled if it is improperly formatted', () => {
@@ -46,14 +46,14 @@ describe('A time slot string is', () => {
 
   it('handled if the separator is an ndash', () => {
     const multipleDigits = parseTimeSlot('10–12')
-    expect(multipleDigits.rangeStart).toBe(10)
-    expect(multipleDigits.rangeEnd).toBe(12)
+    expect(multipleDigits?.rangeStart).toBe(10)
+    expect(multipleDigits?.rangeEnd).toBe(12)
   })
 
   it('handled if the separator is an mdash', () => {
     const multipleDigits = parseTimeSlot('10—12')
-    expect(multipleDigits.rangeStart).toBe(10)
-    expect(multipleDigits.rangeEnd).toBe(12)
+    expect(multipleDigits?.rangeStart).toBe(10)
+    expect(multipleDigits?.rangeEnd).toBe(12)
   })
 })
 

--- a/types/common.ts
+++ b/types/common.ts
@@ -4,10 +4,10 @@ export type ApiGatewayDateString = string
 
 // Types for URL prefixes loaded from env vars
 export interface UrlPrefixes {
-  urlPrefixUioDesktop: string
-  urlPrefixUioMobile: string
-  urlPrefixBpo: string
-  urlPrefixUioClaimstatus: string
+  urlPrefixUioDesktop?: string
+  urlPrefixUioMobile?: string
+  urlPrefixBpo?: string
+  urlPrefixUioClaimstatus?: string
 }
 
 // Types for TransLine component

--- a/types/common.ts
+++ b/types/common.ts
@@ -1,3 +1,5 @@
+import { ReactTestRendererJSON } from 'react-test-renderer'
+
 // Type aliases
 export type I18nString = string
 export type ApiGatewayDateString = string
@@ -112,3 +114,6 @@ export interface ScenarioContent {
   statusContent: ClaimStatusContent
   detailsContent: null | ClaimDetailsContent
 }
+
+// Test types
+export type TestRendererCreateReturn = ReactTestRendererJSON | ReactTestRendererJSON[] | null

--- a/yarn.lock
+++ b/yarn.lock
@@ -3146,6 +3146,14 @@
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
 
+"@types/jest@^27.0.3":
+  version "27.0.3"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.3.tgz#0cf9dfe9009e467f70a342f0f94ead19842a783a"
+  integrity sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==
+  dependencies:
+    jest-diff "^27.0.0"
+    pretty-format "^27.0.0"
+
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3394,10 +3394,10 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
-"@types/uuid@^8.3.1":
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.1.tgz#1a32969cf8f0364b3d8c8af9cc3555b7805df14f"
-  integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
+"@types/uuid@^8.3.3":
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.3.tgz#c6a60686d953dbd1b1d45e66f4ecdbd5d471b4d0"
+  integrity sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==
 
 "@types/warning@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
<!-- Write a description below of the changes in this pull request. 

Include images/GIFs if relevant for reviewers. Try Firefox (right-click -> Take Screenshot) for full-page screenshots and LICEcap (macOS) or Peek (ubuntu) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items. -->

Changes in this PR!    
    
  - Adds the typescript build to our CI, so that all files are typecheckd    
  - Adds the missing types for jest with the `@types/jest` plugin    
  - Corrects all ~100 type errors in our tests. Types of corrections include:    
    - Actual type fixes
      - see return type in `Appointment.test.tsx` as an example    
      - see proper parameters in `Header.test.tsx` as an example                              
    - More explicit types, to help the TS compiler                           
      - see the types for objects passed to `describe.each` loops            
    - Adding `?` to checks where the base object could be `undefined`        
      - Many places. i.e. `element?.tagName.toLowerCase() === 'strong'` in `TransLine.test.tsx`    
    - Added type narrowing to assert the object is not undefined for assertions to use              
      - See `apiGatewayStub.test.ts` if it does return `undefined` it should throw a failure           
    - Explicit `as unknown`, `as string` overrides to test unexpected, mistyped values    
      - See getScenarioContent.test.ts as example                                                       
    - Explicitly casts `IncomingMessage` in `queryApiGateway.test.ts`, to avoid a huge mock             
  - Adds two TS overrides for now, for places that may involve code changes. Will file tickets for these.                      
    - `tests/pages/indexServerSide.test.ts` - nextJS & typescript cannot agree on typing.           
    - `tests/utils/apiGatewayStub.test.ts` - mocking for fs, fetch & typescript do not agree on typing                     
  - Moves the `getUrl.test.ts` to a matching subdir to its utility      
  
TK: tickets for resolving overrides:
  - mocks + typescript (jest & fs) #587 
  - serverSideRender + typescript #586 


===

Resolves #444

- [ ] Tests that fall out of date will alert the dev