### PR TITLE
Change 'Notification' to 'Claim Status'

### DIFF
--- a/public/locales/en/claim-status.json
+++ b/public/locales/en/claim-status.json
@@ -158,7 +158,7 @@
       ],
       "your-next-steps": [
         {
-          "text": "Select <strong>Certify for Benefits</strong> in the Notification section on your <0>UI Online homepage</0>.",
+          "text": "Select <strong>Certify for Benefits</strong> in the Claim Status section on your <0>UI Online homepage</0>.",
           "links": ["uio-home"]
         }
       ],

--- a/public/locales/es/claim-status.json
+++ b/public/locales/es/claim-status.json
@@ -148,7 +148,7 @@
       ],
       "your-next-steps": [
         {
-          "text": "Seleccione <strong>Certificar para beneficios</strong> en la sección de Notificación en su <0>página principal de UI Online</0>."
+          "text": "Seleccione <strong>Certificar para beneficios</strong> en la sección de Estatus de solicitud en su <0>página principal de UI Online</0>."
         }
       ],
       "edd-next-steps": [

--- a/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
+++ b/tests/components/__snapshots__/ClaimStatus.test.tsx.snap
@@ -2352,7 +2352,7 @@ exports[`Scenario 6 matches, on desktop 1`] = `
           <strong>
             Certify for Benefits
           </strong>
-           in the Notification section on your 
+           in the Claim Status section on your 
           <a
             href="https://uio.edd.ca.gov/UIO/Pages/ExternalUser/ClaimantAccountManagement/UIOnlineHome.aspx"
           >
@@ -2454,7 +2454,7 @@ exports[`Scenario 6 matches, on mobile 1`] = `
           <strong>
             Certify for Benefits
           </strong>
-           in the Notification section on your 
+           in the Claim Status section on your 
           <a
             href="https://uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx"
           >


### PR DESCRIPTION
This PR updates the content for scenario 6 in both English and Spanish from 'Notification' to 'Claim Status'.

- [x] wording updated per the referenced google docs

===

Resolves #573 

- [ ] Relevant documentation (e.g. READMEs, Technical Foundation) updated
- [x] Issue AC are copied to this PR & are met
- [ ] Manual Browser Testing performed (with modheader, either locally or on BrowserStack)
- [ ] Changes are tested on Staging post-merge into `main`
