### PR TITLE
Update help link to be different for English and Spanish

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -95,7 +95,7 @@ export const Header: React.FC<HeaderProps> = ({ userArrivedFromUioMobile = false
                 <span className="text">{t('header.edd-home')}</span>
               </Nav.Link>
             </Navbar.Collapse>
-            <Nav.Link target="_blank" rel="noopener noreferrer" href={getUrl('uio-desktop-help-new-claim')}>
+            <Nav.Link target="_blank" rel="noopener noreferrer" href={t('urls.header.uio-desktop-help-new-claim')}>
               <span className="text">{t('header.help')}</span>
             </Nav.Link>
             <Nav.Link href={getUrl('bpo-logout')}>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -68,6 +68,9 @@
     "pm": "p.m."
   },
   "urls": {
+    "header": {
+      "uio-desktop-help-new-claim": "https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=en-US/Public/NewClaim/UIOnlineNewClaimLandingPage.htm"
+    },
     "edd": {
       "ui-certify": "https://edd.ca.gov/Unemployment/certify.htm",
       "ui-claim-status": "https://www.edd.ca.gov/unemployment/claim-status.htm",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -68,6 +68,9 @@
     "pm": "p.m."
   },
   "urls": {
+    "header": {
+      "uio-desktop-help-new-claim": "https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=es-MX/Public/NewClaim/UIOnlineNewClaimLandingPage.htm"
+    },
     "edd": {
       "ui-certify": "https://edd.ca.gov/Unemployment/certify-espanol.htm",
       "ui-claim-status": "https://www.edd.ca.gov/unemployment/claim-status-espanol.htm",

--- a/public/urls.json
+++ b/public/urls.json
@@ -7,7 +7,6 @@
   "edd-ca-gov": "https://edd.ca.gov",
   "bpo-login": "https://portal.edd.ca.gov/WebApp/Login",
   "bpo-logout": "https://portal.edd.ca.gov/WebApp/Logout",
-  "uio-desktop-help-new-claim": "https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=en-US/Public/NewClaim/UIOnlineNewClaimLandingPage.htm",
   "uio-desktop-home": "https://uio.edd.ca.gov/UIO/Pages/ExternalUser/ClaimantAccountManagement/UIOnlineHome.aspx",
   "uio-mobile-home": "https://uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx",
   "uio-desktop-landing-page": "https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx",


### PR DESCRIPTION
Updates help link to be different for English and Spanish

From: https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=en-US/Public/NewClaim/UIOnlineNewClaimLandingPage.htm 
To: https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=es-MX/Public/NewClaim/UIOnlineNewClaimLandingPage.htm