### PR TITLE
Change help link to Spanish link when in Spanish mode

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -95,7 +95,11 @@ export const Header: React.FC<HeaderProps> = ({ userArrivedFromUioMobile = false
                 <span className="text">{t('header.edd-home')}</span>
               </Nav.Link>
             </Navbar.Collapse>
-            <Nav.Link target="_blank" rel="noopener noreferrer" href={getUrl('uio-desktop-help-new-claim')}>
+            <Nav.Link
+              target="_blank"
+              rel="noopener noreferrer"
+              href={getUrl('uio-desktop-help-new-claim', urlPrefixes, i18n.language)}
+            >
               <span className="text">{t('header.help')}</span>
             </Nav.Link>
             <Nav.Link href={getUrl('bpo-logout')}>

--- a/public/urls.json
+++ b/public/urls.json
@@ -8,6 +8,7 @@
   "bpo-login": "https://portal.edd.ca.gov/WebApp/Login",
   "bpo-logout": "https://portal.edd.ca.gov/WebApp/Logout",
   "uio-desktop-help-new-claim": "https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=en-US/Public/NewClaim/UIOnlineNewClaimLandingPage.htm",
+  "uio-desktop-help-new-claim-es": "https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=es-MX/Public/NewClaim/UIOnlineNewClaimLandingPage.htm",
   "uio-desktop-home": "https://uio.edd.ca.gov/UIO/Pages/ExternalUser/ClaimantAccountManagement/UIOnlineHome.aspx",
   "uio-mobile-home": "https://uiom.edd.ca.gov/UIOM/Pages/Public/ExternalUser/UIOMobileLandingPage.aspx",
   "uio-desktop-landing-page": "https://uio.edd.ca.gov/UIO/Pages/Public/ExternalUser/UIOnlineLandingPage.aspx",

--- a/utils/browser/getUrl.ts
+++ b/utils/browser/getUrl.ts
@@ -23,10 +23,15 @@ export function stripTrailingSlashes(url: string | undefined): string | undefine
  * Get url from urls.json
  * urlPrefixes: environment-specific links to UIO, UIO Mobile, and BPO, used by EDD testing
  */
-export default function getUrl(linkKey: string, urlPrefixes?: UrlPrefixes): string | undefined {
+export default function getUrl(linkKey: string, urlPrefixes?: UrlPrefixes, language?: string): string | undefined {
   // Explicitly cast to one of the allowed keys in urls.json.
   // If the key does not exist in urls.json, this function will return undefined.
-  const key = linkKey as UrlType
+  let key
+  if (language === 'es') {
+    key = (linkKey + '-es') as UrlType
+  } else {
+    key = linkKey as UrlType
+  }
 
   // urlPrefixes must be passed in if getUrl is called client-side (e.g. from TimeoutModal.tsx),
   // since env vars aren't accessible client-side; otherwise, prefixes can be loaded from env vars below


### PR DESCRIPTION
Updates help link to be different for English and Spanish

From: https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=en-US/Public/NewClaim/UIOnlineNewClaimLandingPage.htm 
To: https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=es-MX/Public/NewClaim/UIOnlineNewClaimLandingPage.htm

Resolves #584