### PR TITLE
Removes duplicate install of ansi-html-community

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "chromatic": "npx chromatic --project-token $CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
-    "ansi-html-community": "0.0.8",
     "applicationinsights": "^2.1.8",
     "bootstrap": "^4.6.0",
     "luxon": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3855,8 +3855,7 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-html-community@0.0.8, ansi-html@0.0.7, ansi-html@^0.0.7, "ansi-html@https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41":
-  name ansi-html
+ansi-html@0.0.7, ansi-html@^0.0.7, "ansi-html@https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
   integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==


### PR DESCRIPTION
<!-- Write a description below of the changes in this pull request. 

Include images/GIFs if relevant for reviewers. Try Firefox (right-click -> Take Screenshot) for full-page screenshots and LICEcap (macOS) or Peek (ubuntu) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items. -->

Turns out we _only_ need the resolution. Adding it as a direct dependency was causing the conflict.

Testing:
  - Delete `node_modules`
  - run `yarn install`
    - [ ] Confirm warning does not appear
    - [ ] Confirmed that we're still using the community version:
     ```
      $ cat node_modules/ansi-html/package.json
      {
        "name": "ansi-html-community",
        "version": "0.0.8",
        "description": "An elegant lib that converts the chalked (ANSI) text to HTML. (Community)",
        ...
      ```

===

Resolves #567 

- [ ] yarn install stops alerting on ansi-html 
- [ ] we are using the patched ansi-html-community version
