### PR TITLE
Updated BPO/SCP Logout URL

### DIFF
--- a/public/urls.json
+++ b/public/urls.json
@@ -10,7 +10,7 @@
   "edd-about-privacy-policy-es": "https://www.edd.ca.gov/About_EDD/Privacy_Policy_Espanol.htm",
   "edd-ca-gov": "https://edd.ca.gov",
   "bpo-login": "https://myedd.edd.ca.gov",
-  "bpo-logout": "https://uio.edd.ca.gov/claimstatus/icamLogout",
+  "bpo-logout": "/icamLogout",
   "uio-desktop-help-new-claim": "https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=en-US/Public/NewClaim/UIOnlineNewClaimLandingPage.htm",
   "uio-desktop-help-new-claim-es": "https://uio.edd.ca.gov/UIO/Pages/Public/help/index.htm#t=es-MX/Public/NewClaim/UIOnlineNewClaimLandingPage.htm",
   "uio-desktop-home": "https://uio.edd.ca.gov/UIO/Pages/ExternalUser/ClaimantAccountManagement/UIOnlineHome.aspx",

--- a/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/tests/pages/__snapshots__/index.test.tsx.snap
@@ -74,8 +74,8 @@ exports[`Full page snapshot renders homepage unchanged 1`] = `
           </a>
           <a
             className="nav-link"
-            data-rb-event-key="https://uio.edd.ca.gov/claimstatus/icamLogout"
-            href="https://uio.edd.ca.gov/claimstatus/icamLogout"
+            data-rb-event-key="/icamLogout"
+            href="/icamLogout"
             onClick={[Function]}
             onKeyDown={[Function]}
           >

--- a/tests/utils/browser/getUrl.test.ts
+++ b/tests/utils/browser/getUrl.test.ts
@@ -36,7 +36,6 @@ const cases = [
   ['URL_PREFIX_UIO_DESKTOP', 'urlPrefixUioDesktop', 'uio.edd.ca.gov/UIO', 'uio-desktop-home'],
   ['URL_PREFIX_UIO_MOBILE', 'urlPrefixUioMobile', 'uiom.edd.ca.gov/UIOM', 'uio-mobile-home'],
   ['URL_PREFIX_UIO_CLAIMSTATUS', 'urlPrefixUioClaimstatus', 'uio', 'uio-claimstatus'],
-  ['URL_PREFIX_UIO_CLAIMSTATUS', 'urlPrefixUioClaimstatus', 'uio', 'bpo-logout'],
   ['URL_PREFIX_BPO', 'urlPrefixBpo', 'myedd.edd.ca.gov', 'bpo-login'],
 ]
 describe.each(cases)(

--- a/utils/browser/getUrl.ts
+++ b/utils/browser/getUrl.ts
@@ -56,10 +56,6 @@ export default function getUrl(linkKey: string, urlPrefixes?: UrlPrefixes, langu
     return urls[key].replace('uio', urlPrefixUioClaimstatus)
   }
 
-  if (urlPrefixUioClaimstatus && key.startsWith('bpo-logout')) {
-    return urls[key].replace('uio', urlPrefixUioClaimstatus)
-  }
-
   if (urlPrefixBpo && key.startsWith('bpo-login')) {
     return urls[key].replace('myedd.edd.ca.gov', urlPrefixBpo)
   }


### PR DESCRIPTION
SCP Logout URL was updated. Because the URL is static for all environments, the logic for the logout URL was removed from getURL and the getURL tests.  
