### PR TITLE
Updated Language Selector links

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -93,7 +93,7 @@ export const Header: React.FC<HeaderProps> = ({ userArrivedFromUioMobile = false
           />
           <Nav>
             <Nav.Item>
-              <LanguageSelector />
+              <LanguageSelector assetPrefix={assetPrefix} />
             </Nav.Item>
             <Navbar.Collapse>
               <ExternalLink url={getUrl('edd-ca-gov')} text={t('header.edd-home')} />

--- a/components/LanguageSelector.tsx
+++ b/components/LanguageSelector.tsx
@@ -2,14 +2,12 @@ import { Dropdown } from 'react-bootstrap'
 import { useTranslation } from 'next-i18next'
 
 import languages from '../public/languages.json'
-import { UrlPrefixes } from '../types/common'
 
 export interface LanguageSelectorProps {
-  urlPrefixes?: UrlPrefixes
-  cstUrl: string | undefined
+  assetPrefix: string
 }
 
-export const LanguageSelector: React.FC = () => {
+export const LanguageSelector: React.FC<LanguageSelectorProps> = ({ assetPrefix = '' }) => {
   const { i18n } = useTranslation()
   const curLanguage = languages.languagelist.find(function (item) {
     return item['language-code'] === i18n.language
@@ -27,7 +25,7 @@ export const LanguageSelector: React.FC = () => {
           languages.languagelist.length > 0 &&
           languages.languagelist.map((language) => (
             <a
-              href={`./${language['language-code']}`}
+              href={`.` + assetPrefix + `/${language['language-code']}`}
               className={
                 language['language-code'] === curLanguage?.['language-code']
                   ? 'selected-language languageSelectorTextColor'

--- a/stories/LanguageSelector.stories.tsx
+++ b/stories/LanguageSelector.stories.tsx
@@ -1,13 +1,13 @@
 import { Story, Meta } from '@storybook/react'
 
-import { LanguageSelector as LanguageSelectorComponent } from '../components/LanguageSelector'
+import { LanguageSelector as LanguageSelectorComponent, LanguageSelectorProps } from '../components/LanguageSelector'
 
 export default {
   title: 'Component/Atoms/External Link',
   component: LanguageSelectorComponent,
 } as Meta
 
-const Template: Story = (args) => <LanguageSelectorComponent {...args} />
+const Template: Story<LanguageSelectorProps> = (args) => <LanguageSelectorComponent {...args} />
 
 export const LanguageSelector = Template.bind({})
 LanguageSelector.args = {}


### PR DESCRIPTION
Changed the link for selecting a new language to use the asset prefix to address an issue in testing
